### PR TITLE
feat: GEPAAdapter for any maths, reasoning dataset in HuggingFace; Ollama-friendly

### DIFF
--- a/src/gepa/adapters/anymaths_adapter.py
+++ b/src/gepa/adapters/anymaths_adapter.py
@@ -1,0 +1,173 @@
+from typing import Any, TypedDict
+
+from pydantic import BaseModel, Field
+
+from gepa.core.adapter import EvaluationBatch, GEPAAdapter
+
+
+class AnyMathsDataInst(TypedDict):
+    input: str
+    additional_context: dict[str, str]
+    answer: str
+
+class AnyMathsTrajectory(TypedDict):
+    data: AnyMathsDataInst
+    full_assistant_response: str
+
+class AnyMathsRolloutOutput(TypedDict):
+    full_assistant_response: str
+
+
+class AnyMathsStructuredOutput(BaseModel):
+    final_answer: str = Field(..., description="The final answer to the mathematical problem (i.e., no units, no other text)")
+    solution_pad: str = Field(..., description="The solution pad containing the step-by-step solution to the problem.")
+
+
+class AnyMathsAdapter(GEPAAdapter[AnyMathsDataInst, AnyMathsTrajectory, AnyMathsRolloutOutput]):
+    """AnyMaths Adapter is a GEPAAdapter for any dataset that contains mathematical word problems
+    of varying complexity and structure. It is designed to handle a wide range of mathematical
+    tasks, including arithmetic, algebra, and more.
+
+    Note: Ollama must be installed and configured to use this adapter.
+    """
+    def __init__(
+        self,
+        model: str,
+        failure_score: float = 0.0,
+        api_base: str = "http://localhost:11434",
+        max_litellm_workers: int =  10
+    ) -> None:
+        
+        import litellm
+
+        self.model = model
+        self.failure_score = failure_score
+        self.litellm = litellm
+        self.max_litellm_workers = max_litellm_workers
+        self.api_base = api_base
+
+        assert self.api_base is not None, "API base URL must be provided."
+        assert self.model.startswith("ollama"), "Model name must start with 'ollama'. Only ollama models are supported"
+
+
+    def evaluate(
+        self,
+        batch: list[AnyMathsDataInst],
+        candidate: dict[str, str],
+        capture_traces: bool = False,
+    ) -> EvaluationBatch[AnyMathsTrajectory, AnyMathsRolloutOutput]:
+
+        import ast
+
+        outputs: list[AnyMathsRolloutOutput] = []
+        scores: list[float] = []
+        trajectories: list[AnyMathsTrajectory] | None = [] if capture_traces else None
+
+        if not candidate:
+            raise ValueError("Candidate must contain at least one component text.")
+
+        system_content = list(candidate.values())[0]
+
+        litellm_requests = []
+
+        for data in batch:
+            user_content = f"{data['input']}"
+
+            messages = [
+                {"role": "system", "content": system_content},
+                {"role": "user", "content": user_content},
+            ]
+
+            litellm_requests.append(messages)
+
+        try:
+            responses = self.litellm.batch_completion(
+                model=self.model,
+                messages=litellm_requests,
+                api_base=self.api_base,
+                max_workers=self.max_litellm_workers,
+                format=AnyMathsStructuredOutput.model_json_schema()
+            )
+        except Exception as e:
+            raise e
+
+        for data, response in zip(batch, responses, strict=False):
+            correct_output_format = True
+            try:
+                assistant_response = ast.literal_eval(response.choices[0].message.content.strip())
+            except Exception as e:
+                assistant_response = "Assistant failed to respond with the correct answer or format."
+                correct_output_format = False
+
+            if correct_output_format:
+                structured_assistant_response = f"Assistant's Solution: {assistant_response['solution_pad']}\n"
+                structured_assistant_response += f"Final Answer: {assistant_response['final_answer']}"
+                output = {"full_assistant_response": structured_assistant_response}
+                score = 1.0 if data["answer"] in assistant_response['final_answer'] else self.failure_score
+            else:
+                output = {"full_assistant_response": assistant_response}
+                score = self.failure_score
+            
+            outputs.append(output)
+            scores.append(score)
+
+            if capture_traces:
+                trajectories.append(
+                    {
+                        "data": data,
+                        "full_assistant_response": output["full_assistant_response"]
+                    }
+                )
+
+            return EvaluationBatch(outputs=outputs, scores=scores, trajectories=trajectories)
+
+    def make_reflective_dataset(
+        self,
+        candidate: dict[str, str],
+        eval_batch: EvaluationBatch[AnyMathsTrajectory, AnyMathsRolloutOutput],
+        components_to_update: list[str]
+    ) -> dict[str, list[dict[str, Any]]]:
+        
+        ret_d: dict[str, list[dict[str, Any]]] = {}
+
+        assert len(components_to_update) == 1
+        comp = components_to_update[0]
+
+        items: list[dict[str, Any]] = []
+        trace_instances = list(zip(eval_batch.trajectories, eval_batch.scores, eval_batch.outputs, strict=False))
+
+        for trace_instance in trace_instances:
+            traj, score, _ = trace_instance
+            data = traj["data"]
+            generated_outputs = traj["full_assistant_response"]
+
+            if score > 0.0:
+                feedback = f"The generated response is correct. The final answer is: {data['answer']}."
+            else:
+                additional_context_str = "\n".join(f"{k}: {v}" for k, v in data["additional_context"].items())
+                if additional_context_str:
+                    feedback = (
+                        f"The generated response is incorrect. The correct answer is: {data['answer']}. "
+                        "Ensure that the correct answer is included in the response exactly as it is. "
+                        f"Here is some additional context that might be helpful:\n{additional_context_str}"
+                    )
+                else:
+                    feedback = (
+                        f"The generated response is incorrect. The correct answer is: {data['answer']}. "
+                        "Ensure that the correct answer is included in the response exactly as it is."
+                    )
+
+            d = {
+                "Inputs": data["input"],
+                "Generated Outputs": generated_outputs,
+                "Feedback": feedback
+            }
+            
+            items.append(d)
+
+        ret_d[comp] = items
+
+        if len(items) == 0:
+            raise Exception("No valid predictions found for any module.")
+
+        return ret_d


### PR DESCRIPTION
## Add `AnyMaths` Adapter: structured-output math word problem adapter

### Summary
This PR introduces `AnyMathsAdapter`, a GEPA adapter tailored for math word problems across diverse datasets. It standardizes inputs and enforces a strict, schema-driven structured output with a final numeric/text answer and a solution "pad" trace, enabling reliable scoring and reflection.

File added: `src/gepa/adapters/anymaths_adapter.py`

### Why
- Math datasets vary in format; consistent IO makes evaluation and iteration easier.
- Structured outputs reduce parsing fragility and enable deterministic scoring and feedback generation.
- Batching and concurrency via LiteLLM improves throughput on local Ollama models.

### What’s included
- Pydantic schema `AnyMathsStructuredOutput` with:
    - `final_answer`: final, clean answer string (no units/extras)
    - `solution_pad`: step-by-step reasoning trace
- Adapter `AnyMathsAdapter` implementing:
    - `evaluate(...)` with LiteLLM `batch_completion` and JSON-schema enforced output (`format=AnyMathsStructuredOutput.model_json_schema()`).
    - Robust handling when models don’t comply with the schema (fallback failure score and raw text).
    - Per-item scoring based on presence of ground-truth answer in `final_answer`.
    - Optional trajectory capture for analysis/training signals.
    - `make_reflective_dataset(...)` that generates feedback examples (uses `additional_context` when available).

### Scope and constraints
- Ollama-only: model must start with ollama and requires a running Ollama server.
- Configurable:
    - `api_base` (default `http://localhost:11434`)
    - `max_litellm_workers` for concurrent requests
    - `failure_score` for malformed/incorrect responses

### Data contract
Input item (`TypeDict AnyMathsDataInst`):
- `input: str` - the math problem
- `additional_context: dict[str, str]` - optional, used in feedback
- `answer: str` - ground-truth answer for scoring

Candidate (GEPA component): A dict of component texts; first value is used as the system prompt.

Output
- Rollout: `{"full_assistant_response": str}` combining solution pad + final answer
- Scores: 1.0 if `final_answer` contains ground truth; else `failure_score`
- Optional trajectories when `capture_traces=True`