### PR TITLE
feat: updated the README.md for anymaths; fixed AnyMathsAdapter code; provided example training and dataset preparation

### DIFF
--- a/src/gepa/adapters/anymaths_adapter/README.md
+++ b/src/gepa/adapters/anymaths_adapter/README.md
@@ -1,7 +1,92 @@
 # GEPA for Math Problem Solving
-AnyMaths Adapter is a GEPAAdapter for any dataset that contains mathematical word problems of varying complexity and structure. It is designed to handle a wide range of mathematical tasks, including arithmetic, algebra, and more.
+**`AnyMaths`** Adapter is a GEPAAdapter for any dataset that contains mathematical word problems of varying complexity and structure. It is designed to handle a wide range of mathematical tasks, including arithmetic, algebra, and more.
 
-Note: Ollama must be installed and configured to use this adapter.
+Note: `Ollama` must be installed and configured to use this adapter. Instructions to download Ollama can be found in [this link](https://ollama.com/download). I recommend the Linux installation.
+
+### Preparing the maths & reasoning dataset
+In `src/gepa/examples/anymaths-bench/train_anymaths.py`, a sample function to prepare any maths dataset is provided via `init_dataset`. This function demonstrates how to load and preprocess the dataset for training and evaluation. Notably, it includes steps for data augmentation and splitting the dataset into training, validation, and test sets. Right now, it is more convenient to find datasets from Hugging Face dataset hub.
+
+#### Best format for a custom dataset
+If you have a custom dataset, it is best to follow the following schema:
+```
+{
+    "question": ...,
+    "solution": ...,
+    "answer": ...
+}
+```
+- `question` must be a string/text.
+- `solution` must be a string/text.
+- `answer` must be a purely numerical, no other text or units associated.
+
+It is best to upload your custom dataset to the Hugging Face dataset hub to fully utilize `datasets.load_dataset`.
+
+### Ollama-only
+This is an Ollama-only adapter, meaning it is specifically designed to work with the Ollama platform via LiteLLM. This design choice is based on the fact that not everyone has access to other provider APIs requiring paid subscriptions.
+
+### Preparing the seed prompt
+The seed prompt is the initial instruction you provide to the model. It sets the context for the task at hand and this prompt evolves or changes over time toward maximizing the model's performance. Default failure score (i.e., score if the model outputs incorrectly) is zero.
+
+Set the seed prompt in a separate directory under `prompt-templates`. Inside this directory is a file `instruction_prompt.txt` which contains the seed prompt.
+
+### Specifying the reflection LM
+The reflection LM is a language model used to generate reflections on the task at hand. You can specify the reflection LM by setting the `reflection_lm` argument when calling the `optimize` function.
+
+### Running a sample `AnyMaths` training
+To run a sample training session using the `AnyMaths` adapter, you can use the following command:
+
+```bash
+python src/gepa/examples/anymaths-bench/train_anymaths.py --model_name ... --api_base ... --max_litellm_workers ... --anymaths_dset_name ... --reflection_minibatch_size ... --budget ...
+```
+- `--model_name`: The model checkpoint to use for training (e.g., `"ollama/qwen3:4b"`).
+- `--api_base`: The base URL for the Ollama API (e.g., `http://localhost:11434`).
+- `--max_litellm_workers`: The maximum number of LiteLLM workers to use.
+- `--anymaths_dset_name`: The name of the AnyMaths dataset to use for training.
+- `--reflection_lm`: The name of the reflection language model to use (e.g., `"ollama/qwen3:8b"`).
+- `--reflection_minibatch_size`: The size of the minibatch for the reflection LM (default is 3).
+- `--budget`: The budget for the optimization process (default is 50).
+- `--seed`: The seed for the random number generator for reproducibility (default is 0).
+
+
+Example of a run:
+```bash
+python src/gepa/examples/anymaths-bench/train_anymaths.py --model_name "ollama/qwen3:4b" --api_base "http://localhost:11434" --max_litellm_workers 4 --anymaths_dset_name "openai/gsm8k" --reflection_lm "ollama/qwen3:8b" --reflection_minibatch_size 3 --budget 10 --seed 0
+```
+
+#### Sample output
+- Initial prompt
+```
+You are an AI assistant that solves mathematical word problems. You will be given a question and you need to provide a step-by-step solution to the problem. Finally, you will provide the answer to the question.
+
+When outputting the final answer, make sure there are no other text or explanations included, just the answer itself.
+
+The following fields are what you need to include in your response:
+- final_answer: The final answer to the question.
+- solution_pad: The step-by-step solution to the problem.
+```
+- Final prompt (after 4 iterations):
+```
+You are an AI assistant that solves mathematical word problems. You will be given a question and you need to provide a step-by-step solution to the problem. Finally, you will provide the answer to the question.
+
+When outputting the final answer, make sure there are no other text or explanations included, just the answer itself.
+
+The following fields are what you need to include in your response:
+- final_answer: The final answer to the question.
+- solution_pad: The step-by-step solution to the problem.
+
+Key guidelines:
+1. **Break down the problem into clear steps** and calculate each part sequentially.
+2. **Verify all arithmetic operations** (addition, subtraction, multiplication, division, percentages) for accuracy.
+3. **Use proper notation** for intermediate steps (e.g., <<calculation>>).
+4. **Avoid common errors**:
+    - Correctly compute percentages (e.g., 10% of 90 = 9, not 9.5).
+    - Ensure averages are calculated by summing all values and dividing by the count.
+    - Match the final answer exactly to the correct sequence of operations.
+5. **Double-check** that the final answer is derived directly from the problem's logic, not from intermediate miscalculations.
+
+Example: If the problem involves multiple steps (e.g., percentages, averages, comparisons), ensure each step is logically connected and mathematically accurate.
+```
+
 
 ### Contributor
-This adapter was contributed by [egmaminta](https://github.com/egmaminta).
+This adapter was contributed by *Emmanuel G. Maminta* ([egmaminta](https://github.com/egmaminta)).

--- a/src/gepa/adapters/anymaths_adapter/__init__.py
+++ b/src/gepa/adapters/anymaths_adapter/__init__.py
@@ -1,0 +1,1 @@
+from .anymaths_adapter import AnyMathsAdapter

--- a/src/gepa/adapters/anymaths_adapter/anymaths_adapter.py
+++ b/src/gepa/adapters/anymaths_adapter/anymaths_adapter.py
@@ -118,8 +118,8 @@ class AnyMathsAdapter(GEPAAdapter[AnyMathsDataInst, AnyMathsTrajectory, AnyMaths
                         "full_assistant_response": output["full_assistant_response"]
                     }
                 )
-
-            return EvaluationBatch(outputs=outputs, scores=scores, trajectories=trajectories)
+        # Return results for the entire batch (not just the first item)
+        return EvaluationBatch(outputs=outputs, scores=scores, trajectories=trajectories)
 
     def make_reflective_dataset(
         self,

--- a/src/gepa/examples/anymaths-bench/prompt-templates/instruction_prompt.txt
+++ b/src/gepa/examples/anymaths-bench/prompt-templates/instruction_prompt.txt
@@ -1,0 +1,7 @@
+You are an AI assistant that solves mathematical word problems. You will be given a question and you need to provide a step-by-step solution to the problem. Finally, you will provide the answer to the question.
+
+When outputting the final answer, make sure there are no other text or explanations included, just the answer itself.
+
+The following fields are what you need to include in your response:
+- final_answer: The final answer to the question.
+- solution_pad: The step-by-step solution to the problem.

--- a/src/gepa/examples/anymaths-bench/train_anymaths.py
+++ b/src/gepa/examples/anymaths-bench/train_anymaths.py
@@ -1,0 +1,134 @@
+def init_dataset(anymaths_dset_name: str = "openai/gsm8k"):
+    import random
+    from datasets import load_dataset
+
+    train_split = []
+    test_split = []
+    match anymaths_dset_name:
+        case "openai/gsm8k":
+            train_load_dataset = load_dataset(anymaths_dset_name, 'main', split='train')
+            for item in train_load_dataset:
+                answer = item["answer"].split("####")[-1].strip()
+                solution = item["answer"].split("####")[0].strip()
+                question = item["question"]
+
+                train_split.append({
+                    "input": question,
+                    "additional_context": {"solution": solution},
+                    "answer": answer
+                })
+
+            random.Random(0).shuffle(train_split)
+
+            test_load_dataset = load_dataset(anymaths_dset_name, 'main', split='test')
+            for item in test_load_dataset:
+                answer = item["answer"].split("####")[-1].strip()
+                solution = item["answer"].split("####")[0].strip()
+                question = item["question"]
+
+                test_split.append({
+                    "input": question,
+                    "answer": answer
+                })
+
+        case "MathArena/aime_2025":
+            train_load_dataset = load_dataset("AI-MO/aimo-validation-aime", 'default', split="train")
+            for item in train_load_dataset:
+                question = item["problem"]
+                solution = item["solution"]
+                answer = item["answer"]
+
+                train_split.append({
+                    "input": question,
+                    "additional_context": {"solution": solution},
+                    "answer": answer
+                })
+
+            random.Random(0).shuffle(train_split)
+
+            test_load_dataset = load_dataset("MathArena/aime_2025", 'default', split="train")
+            for item in test_load_dataset:
+                question = item["problem"]
+                answer = item["answer"]
+
+                test_split.append({
+                    "input": question,
+                    "answer": answer
+                })
+
+    trainset = train_split[:len(train_split)//2]
+    valset = train_split[len(train_split)//2:]
+    testset = test_split * 5
+
+    return trainset, valset, testset
+
+if __name__ == "__main__":
+    from gepa import optimize
+    from gepa.adapters.anymaths_adapter import AnyMathsAdapter
+    
+    from pathlib import Path
+    
+    import argparse
+    import litellm
+    
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_name", type=str, default="ollama/qwen3:4b")    # only Ollama models are supported
+    parser.add_argument("--api_base", type=str, default="http://localhost:11434")
+    parser.add_argument("--max_litellm_workers", type=int, default=10)
+    parser.add_argument("--anymaths_dset_name", type=str, default="openai/gsm8k")
+    parser.add_argument("--budget", type=int, default=50, help="The budget for the optimization process.")
+    parser.add_argument("--reflection_lm", type=str, default="ollama/qwen3:8b", help="The name of the reflection LM to use.")
+    parser.add_argument("--reflection_minibatch_size", type=int, default=3, help="The size of the minibatch for the reflection LM.")
+    parser.add_argument("--seed", type=int, default=0, help="The seed for the random number generator for reproducibility.")
+    args = parser.parse_args()
+
+    INSTRUCTION_PROMPT_PATH = (
+        Path(__file__).parent / "prompt-templates/instruction_prompt.txt"
+    )
+
+    seed_instruction = INSTRUCTION_PROMPT_PATH.read_text()
+
+    trainset, valset, testset = init_dataset(args.anymaths_dset_name)
+    
+    trainset = trainset[:10]  # Limit to 10 samples for demo purposes
+    valset = valset[:10]      # Limit to 10 samples for demo purposes
+    testset = testset[:10]    # Limit to 10 samples for demo purposes
+    
+    print(f"Train set size: {len(trainset)}")
+    print(f"Validation set size: {len(valset)}")
+    print(f"Test set size: {len(testset)}")
+
+    reflection_lm_name = args.reflection_lm
+    reflection_lm = (
+        lambda prompt: litellm.completion(
+            model=reflection_lm_name,
+            messages=[
+                {"role": "user", "content": prompt}
+            ]
+        )
+        .choices[0]
+        .message.content
+    )
+
+    adapter_model = args.model_name
+    api_base = args.api_base
+    max_litellm_workers = args.max_litellm_workers
+    budget = args.budget
+    reflection_minibatch_size = args.reflection_minibatch_size
+    seed = args.seed
+
+    optimized_results = optimize(
+        seed_candidate={"instruction_prompt": seed_instruction},
+        trainset=trainset,
+        valset=valset,
+        adapter=AnyMathsAdapter(model=adapter_model, api_base=api_base, max_litellm_workers=max_litellm_workers),
+        reflection_lm=reflection_lm,
+        reflection_minibatch_size=reflection_minibatch_size,
+        perfect_score=1,
+        skip_perfect_score=False,
+        use_wandb=False,
+        num_iters=budget,
+        seed=seed
+    )
+
+    print(optimized_results.to_dict())


### PR DESCRIPTION
### AnyMaths: adapter fix, dataset prep, sample training, and docs

#### Summary
This PR improves the `AnyMaths` example end-to-end by fixing the adapter code (I found a bug that only outputs 1 Pareto val set), adding dataset preparation utilities, providing a runnable sample training script, and updating the `AnyMaths` README with clear usage guidance.

#### Changes
- Docs
    - Updated `README.md` with setup, configuration, and run instructions.
- Adapter
    - Fixed `AnyMaths` adapter to correctly handle multi-item evaluation (no more assertion error when valset > 1).
    - Ensured batched/iterative evaluation returns consistent metrics and aggregates correctly.
- Dataset preparation
    - Added dataset loading and splitting logic supporting:
        - `"openai/gsm8k"` (train/test) with deterministic shuffling and derived solutions.
        - `"MathArena/aime_2025"` with aligned train/test preprocessing.
    - Provides train/val split from train; expands a small test set for demo runs.
- Sample training
    - Added `train_anymaths.py`:
        - CLI args for model, API base, budget, reflection LM, minibatch size, and seed.
        - Uses `gepa.optimize` with `AnyMathsAdapter`.
        - LiteLLM-based reflection LM hook.
        - Small default subset sizes for quick demos.

#### Why
- The adapter previously triggered an assertion when `valset > 1`. This is non-ideal for real validation and made experiments brittle.
- Providing dataset prep and a runnable script lowers the barrier to trying AnyMaths with GEPA.

#### How to use
- Start an Ollama server (or compatible endpoint) and ensure the requested models are available.
- Run the training script (example):
    - Module: `python -m gepa.examples.anymaths-bench.train_anymaths --model_name ollama/qwen3:4b --api_base http://localhost:11434 --anymaths_dset_name openai/gsm8k --budget 50`
- Adjust `--reflection_lm`, `--reflection_minibatch_size`, and `--seed` as needed.


#### Notes
- Defaults limit train/val/test to 10 items for fast demos; expand as desired.
- No breaking API changes expected outside the AnyMaths example path.

Checklist

- [x] Docs updated
- [x] Adapter supports multi-item validation
- [x] Dataset prep utilities included
- [x] Sample training script added and runnable