### PR TITLE
Add 'all' component selector for selecting all components

### DIFF
--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -16,8 +16,8 @@ from gepa.proposer.reflective_mutation.reflective_mutation import ReflectiveMuta
 from gepa.strategies.batch_sampler import EpochShuffledBatchSampler
 from gepa.strategies.candidate_selector import CurrentBestCandidateSelector, ParetoCandidateSelector
 from gepa.strategies.component_selector import (
-    all_reflection_component_selector,
-    round_robin_reflection_component_selector,
+    AllReflectionComponentSelector,
+    RoundRobinReflectionComponentSelector,
 )
 
 
@@ -169,16 +169,16 @@ def optimize(
     )
 
     if isinstance(module_selector, str):
-        module_selector_fn = {
-            "round_robin": round_robin_reflection_component_selector,
-            "all": all_reflection_component_selector,
+        module_selector_cls = {
+            "round_robin": RoundRobinReflectionComponentSelector,
+            "all": AllReflectionComponentSelector,
         }.get(module_selector)
 
-        assert module_selector_fn is not None, (
+        assert module_selector_cls is not None, (
             f"Unknown module_selector strategy: {module_selector}. Supported strategies: 'round_robin', 'all'"
         )
 
-        module_selector = module_selector_fn
+        module_selector = module_selector_cls()
 
     batch_sampler = EpochShuffledBatchSampler(minibatch_size=reflection_minibatch_size, rng=rng)
 

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -15,7 +15,10 @@ from gepa.proposer.reflective_mutation.base import LanguageModel, ReflectionComp
 from gepa.proposer.reflective_mutation.reflective_mutation import ReflectiveMutationProposer
 from gepa.strategies.batch_sampler import EpochShuffledBatchSampler
 from gepa.strategies.candidate_selector import CurrentBestCandidateSelector, ParetoCandidateSelector
-from gepa.strategies.component_selector import AllReflectionComponentSelector, RoundRobinReflectionComponentSelector
+from gepa.strategies.component_selector import (
+    all_reflection_component_selector,
+    round_robin_reflection_component_selector,
+)
 
 
 def optimize(
@@ -166,16 +169,16 @@ def optimize(
     )
 
     if isinstance(module_selector, str):
-        module_selector_cls = {
-            "round_robin": RoundRobinReflectionComponentSelector,
-            "all": AllReflectionComponentSelector,
+        module_selector_fn = {
+            "round_robin": round_robin_reflection_component_selector,
+            "all": all_reflection_component_selector,
         }.get(module_selector)
 
-        assert module_selector_cls is not None, (
+        assert module_selector_fn is not None, (
             f"Unknown module_selector strategy: {module_selector}. Supported strategies: 'round_robin', 'all'"
         )
 
-        module_selector = module_selector_cls()
+        module_selector = module_selector_fn
 
     batch_sampler = EpochShuffledBatchSampler(minibatch_size=reflection_minibatch_size, rng=rng)
 

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -15,7 +15,7 @@ from gepa.proposer.reflective_mutation.base import LanguageModel, ReflectionComp
 from gepa.proposer.reflective_mutation.reflective_mutation import ReflectiveMutationProposer
 from gepa.strategies.batch_sampler import EpochShuffledBatchSampler
 from gepa.strategies.candidate_selector import CurrentBestCandidateSelector, ParetoCandidateSelector
-from gepa.strategies.component_selector import RoundRobinReflectionComponentSelector
+from gepa.strategies.component_selector import AllReflectionComponentSelector, RoundRobinReflectionComponentSelector
 
 
 def optimize(
@@ -102,7 +102,7 @@ def optimize(
     - perfect_score: The perfect score to achieve.
 
     # Component selection configuration
-    - module_selector: Component selection strategy. Can be a ReflectionComponentSelector instance, a string ('round_robin'), or None. If None, defaults to 'round_robin'. The 'round_robin' strategy cycles through components in order.
+    - module_selector: Component selection strategy. Can be a ReflectionComponentSelector instance, a string ('round_robin', 'all'), or None. If None, defaults to 'round_robin'. The 'round_robin' strategy cycles through components in order. The 'all' strategy selects all components for modification.
 
     # Merge-based configuration
     - use_merge: Whether to use the merge strategy.
@@ -170,10 +170,11 @@ def optimize(
     if isinstance(module_selector, str):
         module_selector_cls = {
             "round_robin": RoundRobinReflectionComponentSelector,
+            "all": AllReflectionComponentSelector,
         }.get(module_selector)
 
         assert module_selector_cls is not None, (
-            f"Unknown module_selector strategy: {module_selector}. Supported strategies: 'round_robin'"
+            f"Unknown module_selector strategy: {module_selector}. Supported strategies: 'round_robin', 'all'"
         )
 
         module_selector = module_selector_cls()

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -31,7 +31,7 @@ def optimize(
     reflection_minibatch_size=3,
     perfect_score=1,
     # Component selection configuration
-    module_selector: "ReflectionComponentSelector | str | None" = None,
+    module_selector: "ReflectionComponentSelector | str" = "round_robin",
     # Merge-based configuration
     use_merge=False,
     max_merge_invocations=5,
@@ -102,7 +102,7 @@ def optimize(
     - perfect_score: The perfect score to achieve.
 
     # Component selection configuration
-    - module_selector: Component selection strategy. Can be a ReflectionComponentSelector instance, a string ('round_robin', 'all'), or None. If None, defaults to 'round_robin'. The 'round_robin' strategy cycles through components in order. The 'all' strategy selects all components for modification.
+    - module_selector: Component selection strategy. Can be a ReflectionComponentSelector instance or a string ('round_robin', 'all'). Defaults to 'round_robin'. The 'round_robin' strategy cycles through components in order. The 'all' strategy selects all components for modification in every GEPA iteration.
 
     # Merge-based configuration
     - use_merge: Whether to use the merge strategy.
@@ -164,8 +164,6 @@ def optimize(
     candidate_selector = (
         ParetoCandidateSelector(rng=rng) if candidate_selection_strategy == "pareto" else CurrentBestCandidateSelector()
     )
-
-    module_selector = module_selector or "round_robin"
 
     if isinstance(module_selector, str):
         module_selector_cls = {

--- a/src/gepa/proposer/reflective_mutation/base.py
+++ b/src/gepa/proposer/reflective_mutation/base.py
@@ -9,27 +9,27 @@ from gepa.core.state import GEPAState
 
 
 class CandidateSelector(Protocol):
-    def select_candidate_idx(self, state: GEPAState) -> int:
-        ...
+    def select_candidate_idx(self, state: GEPAState) -> int: ...
+
 
 class ReflectionComponentSelector(Protocol):
-    def select_modules(
+    def __call__(
         self,
         state: GEPAState,
         trajectories: list[Trajectory],
         subsample_scores: list[float],
         candidate_idx: int,
         candidate: dict[str, str],
-    ) -> list[str]:
-        ...
+    ) -> list[str]: ...
+
 
 class BatchSampler(Protocol):
-    def next_minibatch_indices(self, trainset_size: int, iteration: int) -> list[int]:
-        ...
+    def next_minibatch_indices(self, trainset_size: int, iteration: int) -> list[int]: ...
+
 
 class LanguageModel(Protocol):
-    def __call__(self, prompt: str) -> str:
-        ...
+    def __call__(self, prompt: str) -> str: ...
+
 
 @dataclass
 class Signature:

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -106,7 +106,7 @@ class ReflectiveMutationProposer(ProposeNewCandidate):
         self.experiment_tracker.log_metrics({"subsample_score": sum(eval_curr.scores)}, step=i)
 
         # 2) Decide which predictors to update
-        predictor_names_to_update = self.module_selector.select_modules(
+        predictor_names_to_update = self.module_selector(
             state, eval_curr.trajectories, eval_curr.scores, curr_prog_id, curr_prog
         )
 
@@ -116,7 +116,9 @@ class ReflectiveMutationProposer(ProposeNewCandidate):
             new_texts = self.propose_new_texts(curr_prog, reflective_dataset, predictor_names_to_update)
             for pname, text in new_texts.items():
                 self.logger.log(f"Iteration {i}: Proposed new text for {pname}: {text}")
-            self.experiment_tracker.log_metrics({f"new_instruction_{pname}": text for pname, text in new_texts.items()}, step=i)
+            self.experiment_tracker.log_metrics(
+                {f"new_instruction_{pname}": text for pname, text in new_texts.items()}, step=i
+            )
         except Exception as e:
             self.logger.log(f"Iteration {i}: Exception during reflection/proposal: {e}")
             import traceback

--- a/src/gepa/strategies/component_selector.py
+++ b/src/gepa/strategies/component_selector.py
@@ -8,7 +8,7 @@ from gepa.proposer.reflective_mutation.base import ReflectionComponentSelector
 
 
 class RoundRobinReflectionComponentSelector(ReflectionComponentSelector):
-    def select_modules(
+    def __call__(
         self,
         state: GEPAState,
         trajectories: list[Trajectory],
@@ -25,7 +25,7 @@ class RoundRobinReflectionComponentSelector(ReflectionComponentSelector):
 
 
 class AllReflectionComponentSelector(ReflectionComponentSelector):
-    def select_modules(
+    def __call__(
         self,
         state: GEPAState,
         trajectories: list[Trajectory],

--- a/src/gepa/strategies/component_selector.py
+++ b/src/gepa/strategies/component_selector.py
@@ -7,30 +7,33 @@ from gepa.core.state import GEPAState
 from gepa.proposer.reflective_mutation.base import ReflectionComponentSelector
 
 
-class RoundRobinReflectionComponentSelector(ReflectionComponentSelector):
-    def __call__(
-        self,
-        state: GEPAState,
-        trajectories: list[Trajectory],
-        subsample_scores: list[float],
-        candidate_idx: int,
-        candidate: dict[str, str],
-    ) -> list[str]:
-        pid = state.named_predictor_id_to_update_next_for_program_candidate[candidate_idx]
-        state.named_predictor_id_to_update_next_for_program_candidate[candidate_idx] = (pid + 1) % len(
-            state.list_of_named_predictors
-        )
-        name = state.list_of_named_predictors[pid]
-        return [name]
+def round_robin_reflection_component_selector(
+    state: GEPAState,
+    trajectories: list[Trajectory],
+    subsample_scores: list[float],
+    candidate_idx: int,
+    candidate: dict[str, str],
+) -> list[str]:
+    """Select components in round-robin fashion."""
+    pid = state.named_predictor_id_to_update_next_for_program_candidate[candidate_idx]
+    state.named_predictor_id_to_update_next_for_program_candidate[candidate_idx] = (pid + 1) % len(
+        state.list_of_named_predictors
+    )
+    name = state.list_of_named_predictors[pid]
+    return [name]
 
 
-class AllReflectionComponentSelector(ReflectionComponentSelector):
-    def __call__(
-        self,
-        state: GEPAState,
-        trajectories: list[Trajectory],
-        subsample_scores: list[float],
-        candidate_idx: int,
-        candidate: dict[str, str],
-    ) -> list[str]:
-        return list(candidate.keys())
+def all_reflection_component_selector(
+    state: GEPAState,
+    trajectories: list[Trajectory],
+    subsample_scores: list[float],
+    candidate_idx: int,
+    candidate: dict[str, str],
+) -> list[str]:
+    """Select all components for modification."""
+    return list(candidate.keys())
+
+
+# Explicit declarations that the functions implement the ReflectionComponentSelector protocol
+round_robin_reflection_component_selector: ReflectionComponentSelector = round_robin_reflection_component_selector
+all_reflection_component_selector: ReflectionComponentSelector = all_reflection_component_selector

--- a/src/gepa/strategies/component_selector.py
+++ b/src/gepa/strategies/component_selector.py
@@ -7,33 +7,30 @@ from gepa.core.state import GEPAState
 from gepa.proposer.reflective_mutation.base import ReflectionComponentSelector
 
 
-def round_robin_reflection_component_selector(
-    state: GEPAState,
-    trajectories: list[Trajectory],
-    subsample_scores: list[float],
-    candidate_idx: int,
-    candidate: dict[str, str],
-) -> list[str]:
-    """Select components in round-robin fashion."""
-    pid = state.named_predictor_id_to_update_next_for_program_candidate[candidate_idx]
-    state.named_predictor_id_to_update_next_for_program_candidate[candidate_idx] = (pid + 1) % len(
-        state.list_of_named_predictors
-    )
-    name = state.list_of_named_predictors[pid]
-    return [name]
+class RoundRobinReflectionComponentSelector(ReflectionComponentSelector):
+    def __call__(
+        self,
+        state: GEPAState,
+        trajectories: list[Trajectory],
+        subsample_scores: list[float],
+        candidate_idx: int,
+        candidate: dict[str, str],
+    ) -> list[str]:
+        pid = state.named_predictor_id_to_update_next_for_program_candidate[candidate_idx]
+        state.named_predictor_id_to_update_next_for_program_candidate[candidate_idx] = (pid + 1) % len(
+            state.list_of_named_predictors
+        )
+        name = state.list_of_named_predictors[pid]
+        return [name]
 
 
-def all_reflection_component_selector(
-    state: GEPAState,
-    trajectories: list[Trajectory],
-    subsample_scores: list[float],
-    candidate_idx: int,
-    candidate: dict[str, str],
-) -> list[str]:
-    """Select all components for modification."""
-    return list(candidate.keys())
-
-
-# Explicit declarations that the functions implement the ReflectionComponentSelector protocol
-round_robin_reflection_component_selector: ReflectionComponentSelector = round_robin_reflection_component_selector
-all_reflection_component_selector: ReflectionComponentSelector = all_reflection_component_selector
+class AllReflectionComponentSelector(ReflectionComponentSelector):
+    def __call__(
+        self,
+        state: GEPAState,
+        trajectories: list[Trajectory],
+        subsample_scores: list[float],
+        candidate_idx: int,
+        candidate: dict[str, str],
+    ) -> list[str]:
+        return list(candidate.keys())

--- a/src/gepa/strategies/component_selector.py
+++ b/src/gepa/strategies/component_selector.py
@@ -33,4 +33,4 @@ class AllReflectionComponentSelector(ReflectionComponentSelector):
         candidate_idx: int,
         candidate: dict[str, str],
     ) -> list[str]:
-        return list(state.list_of_named_predictors)
+        return list(candidate.keys())

--- a/src/gepa/strategies/component_selector.py
+++ b/src/gepa/strategies/component_selector.py
@@ -17,8 +17,20 @@ class RoundRobinReflectionComponentSelector(ReflectionComponentSelector):
         candidate: dict[str, str],
     ) -> list[str]:
         pid = state.named_predictor_id_to_update_next_for_program_candidate[candidate_idx]
-        state.named_predictor_id_to_update_next_for_program_candidate[candidate_idx] = (
-            pid + 1
-        ) % len(state.list_of_named_predictors)
+        state.named_predictor_id_to_update_next_for_program_candidate[candidate_idx] = (pid + 1) % len(
+            state.list_of_named_predictors
+        )
         name = state.list_of_named_predictors[pid]
         return [name]
+
+
+class AllReflectionComponentSelector(ReflectionComponentSelector):
+    def select_modules(
+        self,
+        state: GEPAState,
+        trajectories: list[Trajectory],
+        subsample_scores: list[float],
+        candidate_idx: int,
+        candidate: dict[str, str],
+    ) -> list[str]:
+        return list(state.list_of_named_predictors)

--- a/tests/test_module_selector.py
+++ b/tests/test_module_selector.py
@@ -4,8 +4,8 @@ import pytest
 
 from gepa import optimize
 from gepa.strategies.component_selector import (
-    all_reflection_component_selector,
-    round_robin_reflection_component_selector,
+    AllReflectionComponentSelector,
+    RoundRobinReflectionComponentSelector,
 )
 
 
@@ -46,11 +46,11 @@ def test_module_selector_default_round_robin(mock_proposer, mock_run, common_moc
         max_metric_calls=1,
     )
 
-    # Verify that ReflectiveMutationProposer was called with round_robin_reflection_component_selector
+    # Verify that ReflectiveMutationProposer was called with RoundRobinReflectionComponentSelector
     mock_proposer.assert_called_once()
     call_args = mock_proposer.call_args
     module_selector = call_args.kwargs["module_selector"]
-    assert module_selector is round_robin_reflection_component_selector
+    assert isinstance(module_selector, RoundRobinReflectionComponentSelector)
     assert result is not None
 
 
@@ -73,11 +73,11 @@ def test_module_selector_string_round_robin(mock_proposer, mock_run, common_mock
         max_metric_calls=1,
     )
 
-    # Verify that ReflectiveMutationProposer was called with round_robin_reflection_component_selector
+    # Verify that ReflectiveMutationProposer was called with RoundRobinReflectionComponentSelector
     mock_proposer.assert_called_once()
     call_args = mock_proposer.call_args
     module_selector = call_args.kwargs["module_selector"]
-    assert module_selector is round_robin_reflection_component_selector
+    assert isinstance(module_selector, RoundRobinReflectionComponentSelector)
     assert result is not None
 
 
@@ -100,11 +100,11 @@ def test_module_selector_string_all(mock_proposer, mock_run, common_mocks):
         max_metric_calls=1,
     )
 
-    # Verify that ReflectiveMutationProposer was called with all_reflection_component_selector
+    # Verify that ReflectiveMutationProposer was called with AllReflectionComponentSelector
     mock_proposer.assert_called_once()
     call_args = mock_proposer.call_args
     module_selector = call_args.kwargs["module_selector"]
-    assert module_selector is all_reflection_component_selector
+    assert isinstance(module_selector, AllReflectionComponentSelector)
     assert result is not None
 
 
@@ -141,14 +141,15 @@ def test_module_selector_custom_instance(mock_proposer, mock_run, common_mocks):
 
 
 def test_all_reflection_component_selector_behavior():
-    """Test that all_reflection_component_selector returns all component names from candidate."""
+    """Test that AllReflectionComponentSelector returns all component names from candidate."""
 
     # Create a mock state (not used in the new implementation)
     mock_state = Mock()
 
-    # Call selector function directly - should return all components from candidate
+    # Call selector class instance directly - should return all components from candidate
+    selector = AllReflectionComponentSelector()
     candidate = {"component1": "value1", "component2": "value2", "component3": "value3"}
-    result = all_reflection_component_selector(
+    result = selector(
         state=mock_state,
         trajectories=[],
         subsample_scores=[],

--- a/tests/test_module_selector.py
+++ b/tests/test_module_selector.py
@@ -3,8 +3,10 @@ from unittest.mock import Mock, patch
 import pytest
 
 from gepa import optimize
-from gepa.proposer.reflective_mutation.base import ReflectionComponentSelector
-from gepa.strategies.component_selector import AllReflectionComponentSelector, RoundRobinReflectionComponentSelector
+from gepa.strategies.component_selector import (
+    all_reflection_component_selector,
+    round_robin_reflection_component_selector,
+)
 
 
 @pytest.fixture
@@ -44,11 +46,11 @@ def test_module_selector_default_round_robin(mock_proposer, mock_run, common_moc
         max_metric_calls=1,
     )
 
-    # Verify that ReflectiveMutationProposer was called with a RoundRobinReflectionComponentSelector
+    # Verify that ReflectiveMutationProposer was called with round_robin_reflection_component_selector
     mock_proposer.assert_called_once()
     call_args = mock_proposer.call_args
     module_selector = call_args.kwargs["module_selector"]
-    assert isinstance(module_selector, RoundRobinReflectionComponentSelector)
+    assert module_selector is round_robin_reflection_component_selector
     assert result is not None
 
 
@@ -71,11 +73,11 @@ def test_module_selector_string_round_robin(mock_proposer, mock_run, common_mock
         max_metric_calls=1,
     )
 
-    # Verify that ReflectiveMutationProposer was called with a RoundRobinReflectionComponentSelector
+    # Verify that ReflectiveMutationProposer was called with round_robin_reflection_component_selector
     mock_proposer.assert_called_once()
     call_args = mock_proposer.call_args
     module_selector = call_args.kwargs["module_selector"]
-    assert isinstance(module_selector, RoundRobinReflectionComponentSelector)
+    assert module_selector is round_robin_reflection_component_selector
     assert result is not None
 
 
@@ -98,11 +100,11 @@ def test_module_selector_string_all(mock_proposer, mock_run, common_mocks):
         max_metric_calls=1,
     )
 
-    # Verify that ReflectiveMutationProposer was called with an AllReflectionComponentSelector
+    # Verify that ReflectiveMutationProposer was called with all_reflection_component_selector
     mock_proposer.assert_called_once()
     call_args = mock_proposer.call_args
     module_selector = call_args.kwargs["module_selector"]
-    assert isinstance(module_selector, AllReflectionComponentSelector)
+    assert module_selector is all_reflection_component_selector
     assert result is not None
 
 
@@ -113,11 +115,10 @@ def test_module_selector_custom_instance(mock_proposer, mock_run, common_mocks):
     mock_run_return, mock_adapter = common_mocks
     mock_run.return_value = mock_run_return
 
-    class CustomComponentSelector(ReflectionComponentSelector):
-        def __call__(self, state, trajectories, subsample_scores, candidate_idx, candidate):
-            return ["test_component"]
+    def custom_component_selector(state, trajectories, subsample_scores, candidate_idx, candidate):
+        return ["test_component"]
 
-    custom_selector = CustomComponentSelector()
+    custom_selector = custom_component_selector
 
     # Create mock data instances
     mock_data = [Mock() for _ in range(3)]
@@ -140,16 +141,14 @@ def test_module_selector_custom_instance(mock_proposer, mock_run, common_mocks):
 
 
 def test_all_reflection_component_selector_behavior():
-    """Test that AllReflectionComponentSelector returns all component names from candidate."""
+    """Test that all_reflection_component_selector returns all component names from candidate."""
 
     # Create a mock state (not used in the new implementation)
     mock_state = Mock()
 
-    selector = AllReflectionComponentSelector()
-
-    # Call selector - should return all components from candidate
+    # Call selector function directly - should return all components from candidate
     candidate = {"component1": "value1", "component2": "value2", "component3": "value3"}
-    result = selector(
+    result = all_reflection_component_selector(
         state=mock_state,
         trajectories=[],
         subsample_scores=[],

--- a/tests/test_module_selector.py
+++ b/tests/test_module_selector.py
@@ -27,17 +27,20 @@ def common_mocks():
 
 @patch("gepa.api.GEPAEngine.run")
 @patch("gepa.api.ReflectiveMutationProposer")
-def test_module_selector_none_defaults_to_round_robin(mock_proposer, mock_run, common_mocks):
-    """Test that module_selector=None defaults to round robin."""
+def test_module_selector_default_round_robin(mock_proposer, mock_run, common_mocks):
+    """Test that module_selector defaults to round robin."""
     mock_run_return, mock_adapter = common_mocks
     mock_run.return_value = mock_run_return
 
+    # Create mock data instances
+    mock_data = [Mock() for _ in range(3)]
+
     result = optimize(
         seed_candidate={"test": "value"},
-        trainset=[],
+        trainset=mock_data,
         adapter=mock_adapter,
         reflection_lm=lambda x: "test response",
-        module_selector=None,  # Explicitly test None
+        # Use default module_selector
         max_metric_calls=1,
     )
 
@@ -56,9 +59,12 @@ def test_module_selector_string_round_robin(mock_proposer, mock_run, common_mock
     mock_run_return, mock_adapter = common_mocks
     mock_run.return_value = mock_run_return
 
+    # Create mock data instances
+    mock_data = [Mock() for _ in range(3)]
+
     result = optimize(
         seed_candidate={"test": "value"},
-        trainset=[],
+        trainset=mock_data,
         adapter=mock_adapter,
         reflection_lm=lambda x: "test response",
         module_selector="round_robin",
@@ -80,9 +86,12 @@ def test_module_selector_string_all(mock_proposer, mock_run, common_mocks):
     mock_run_return, mock_adapter = common_mocks
     mock_run.return_value = mock_run_return
 
+    # Create mock data instances to avoid empty trainset concern
+    mock_data = [Mock() for _ in range(3)]
+
     result = optimize(
         seed_candidate={"test": "value"},
-        trainset=[],
+        trainset=mock_data,
         adapter=mock_adapter,
         reflection_lm=lambda x: "test response",
         module_selector="all",
@@ -110,9 +119,12 @@ def test_module_selector_custom_instance(mock_proposer, mock_run, common_mocks):
 
     custom_selector = CustomComponentSelector()
 
+    # Create mock data instances
+    mock_data = [Mock() for _ in range(3)]
+
     result = optimize(
         seed_candidate={"test": "value"},
-        trainset=[],
+        trainset=mock_data,
         adapter=mock_adapter,
         reflection_lm=lambda x: "test response",
         module_selector=custom_selector,
@@ -128,21 +140,21 @@ def test_module_selector_custom_instance(mock_proposer, mock_run, common_mocks):
 
 
 def test_all_reflection_component_selector_behavior():
-    """Test that AllReflectionComponentSelector returns all component names."""
+    """Test that AllReflectionComponentSelector returns all component names from candidate."""
 
-    # Create a mock state with multiple components
+    # Create a mock state (not used in the new implementation)
     mock_state = Mock()
-    mock_state.list_of_named_predictors = ["component1", "component2", "component3"]
 
     selector = AllReflectionComponentSelector()
 
-    # Call select_modules - should return all components
+    # Call select_modules - should return all components from candidate
+    candidate = {"component1": "value1", "component2": "value2", "component3": "value3"}
     result = selector.select_modules(
         state=mock_state,
         trajectories=[],
         subsample_scores=[],
         candidate_idx=0,
-        candidate={"component1": "value1", "component2": "value2", "component3": "value3"},
+        candidate=candidate,
     )
 
     assert result == ["component1", "component2", "component3"]
@@ -153,10 +165,13 @@ def test_module_selector_invalid_string_raises_error(common_mocks):
     """Test that invalid module_selector string raises AssertionError."""
     _, mock_adapter = common_mocks
 
+    # Create mock data instances
+    mock_data = [Mock() for _ in range(3)]
+
     with pytest.raises(AssertionError, match="Unknown module_selector strategy"):
         optimize(
             seed_candidate={"test": "value"},
-            trainset=[],
+            trainset=mock_data,
             adapter=mock_adapter,
             reflection_lm=lambda x: "test response",
             module_selector="invalid_strategy",

--- a/tests/test_module_selector.py
+++ b/tests/test_module_selector.py
@@ -147,3 +147,18 @@ def test_all_reflection_component_selector_behavior():
 
     assert result == ["component1", "component2", "component3"]
     assert len(result) == 3
+
+
+def test_module_selector_invalid_string_raises_error(common_mocks):
+    """Test that invalid module_selector string raises AssertionError."""
+    _, mock_adapter = common_mocks
+
+    with pytest.raises(AssertionError, match="Unknown module_selector strategy"):
+        optimize(
+            seed_candidate={"test": "value"},
+            trainset=[],
+            adapter=mock_adapter,
+            reflection_lm=lambda x: "test response",
+            module_selector="invalid_strategy",
+            max_metric_calls=1,
+        )

--- a/tests/test_module_selector.py
+++ b/tests/test_module_selector.py
@@ -114,7 +114,7 @@ def test_module_selector_custom_instance(mock_proposer, mock_run, common_mocks):
     mock_run.return_value = mock_run_return
 
     class CustomComponentSelector(ReflectionComponentSelector):
-        def select_modules(self, state, trajectories, subsample_scores, candidate_idx, candidate):
+        def __call__(self, state, trajectories, subsample_scores, candidate_idx, candidate):
             return ["test_component"]
 
     custom_selector = CustomComponentSelector()
@@ -147,9 +147,9 @@ def test_all_reflection_component_selector_behavior():
 
     selector = AllReflectionComponentSelector()
 
-    # Call select_modules - should return all components from candidate
+    # Call selector - should return all components from candidate
     candidate = {"component1": "value1", "component2": "value2", "component3": "value3"}
-    result = selector.select_modules(
+    result = selector(
         state=mock_state,
         trajectories=[],
         subsample_scores=[],


### PR DESCRIPTION
Implement `all_reflection_component_selector` that returns all components for modification instead of cycling through them individually like the existing round_robin selector.

Changes:
- Add all_reflection_component_selector function in component_selector.py
- Register 'all' selector in api.py module_selector mapping
- Update docstring to document new 'all' option
- Add tests

## Related
Fixes https://github.com/gepa-ai/gepa/issues/66