### PR TITLE
Skip components that are not present in reflective dataset instead of raising KeyError failure

### DIFF
--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -63,6 +63,13 @@ class ReflectiveMutationProposer(ProposeNewCandidate):
 
         new_texts: dict[str, str] = {}
         for name in components_to_update:
+            # Gracefully handle cases where a selected component has no data in reflective_dataset
+            if name not in reflective_dataset or not reflective_dataset.get(name):
+                self.logger.log(
+                    f"Component '{name}' is not in reflective dataset. Skipping."
+                )
+                continue
+
             base_instruction = candidate[name]
             dataset_with_feedback = reflective_dataset[name]
             new_texts[name] = InstructionProposalSignature.run(


### PR DESCRIPTION
My module architecture has a number of registered submodules that are conditionally routed to.

When ReflectiveMutationProposer tries to retrieve the reflective dataset for one of these submodules, it crashes since there is no trace.

This update handles this case by logging and continuing.

Error details below:
```
2025-09-17 17:33:48,913 - INFO - [MainThread] dspy.teleprompt.gepa.gepa: Iteration 1: Exception during reflection/proposal: 'describe_image_module.predict.predict'
2025-09-17 17:33:48,914 - INFO - [MainThread] dspy.teleprompt.gepa.gepa: Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/gepa/proposer/reflective_mutation/reflective_mutation.py", line 116, in propose
    new_texts = self.propose_new_texts(curr_prog, reflective_dataset, predictor_names_to_update)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/gepa/proposer/reflective_mutation/reflective_mutation.py", line 67, in propose_new_texts
    dataset_with_feedback = reflective_dataset[name]
                            ~~~~~~~~~~~~~~~~~~^^^^^^
KeyError: 'describe_image_module.predict.predict'

2025-09-17 17:33:48,915 - INFO - [MainThread] dspy.teleprompt.gepa.gepa: Iteration 1: Reflective mutation did not propose a new candidate
```