### PR TITLE
Bug Fix: copy base valset eval output as pareto front

### DIFF
--- a/src/gepa/core/state.py
+++ b/src/gepa/core/state.py
@@ -42,7 +42,7 @@ class GEPAState(Generic[RolloutOutput]):
         track_best_outputs: bool = False,
     ):
         valset_base_score = sum(base_valset_eval_output[1]) / len(base_valset_eval_output[1])
-        base_valset_pareto_front = base_valset_eval_output[1]
+        base_valset_pareto_front = list(base_valset_eval_output[1])
 
         self.program_candidates = [seed_candidate]
         self.program_full_scores_val_set = [valset_base_score]


### PR DESCRIPTION
There is a bug that the 1st `val_state` (baseline) of `prog_candidate_val_subscores` in `GEPAState` will be modified once `pareto_front` is updated.

This is coz `base_valset_eval_output[1]` is directly referenced in both `pareto_front_valset` https://github.com/gepa-ai/gepa/blob/main/src/gepa/core/state.py#L45-L52 and `prog_candidate_val_subscores` https://github.com/gepa-ai/gepa/blob/main/src/gepa/core/state.py#L60 

And later `pareto_front_valset`  will be directly modified with new scores in place https://github.com/gepa-ai/gepa/blob/main/src/gepa/core/state.py#L131

so just make a copy

