### PR TITLE
Improve logging for subsample scores in GEPA engine

### DIFF
--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -232,7 +232,7 @@ class GEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
                 old_sum = sum(proposal.subsample_scores_before or [])
                 new_sum = sum(proposal.subsample_scores_after or [])
                 if new_sum <= old_sum:
-                    self.logger.log(f"Iteration {state.i + 1}: New subsample score is not better, skipping")
+                    self.logger.log(f"Iteration {state.i + 1}: New subsample score {old_sum} is not better than old score {old_sum}, skipping")
                     continue
 
                 # Accept: full eval + add

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -232,8 +232,10 @@ class GEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
                 old_sum = sum(proposal.subsample_scores_before or [])
                 new_sum = sum(proposal.subsample_scores_after or [])
                 if new_sum <= old_sum:
-                    self.logger.log(f"Iteration {state.i + 1}: New subsample score {old_sum} is not better than old score {old_sum}, skipping")
+                    self.logger.log(f"Iteration {state.i + 1}: New subsample score {new_sum} is not better than old score {old_sum}, skipping")
                     continue
+                else:
+                    self.logger.log(f"Iteration {state.i + 1}: New subsample score {new_sum} is better than old score {old_sum}. Continue to full eval and add to candidate pool.")
 
                 # Accept: full eval + add
                 self._run_full_eval_and_add(


### PR DESCRIPTION
This change improves debugging - for example, when I made this change locally, I realized that every new program except the initial one was getting a score of 0.0, which made things a lot clearer.