### PR TITLE
Mock wandb and mlflow instead of testing storage

### DIFF
--- a/tests/test_experiment_tracking.py
+++ b/tests/test_experiment_tracking.py
@@ -473,22 +473,17 @@ class TestExperimentTrackerIntegration:
             use_mlflow=False,
         )
 
-        from unittest.mock import MagicMock
-        mock_wandb = MagicMock()
-        mock_wandb.log = MagicMock()
-        
-        with patch.dict('sys.modules', {'wandb': mock_wandb}):
-            with tracker:
-                # Test different metric types
-                tracker.log_metrics({"loss": 0.5}, step=1)
-                tracker.log_metrics({"accuracy": 0.9, "f1": 0.85}, step=2)
-                tracker.log_metrics({"learning_rate": 0.001}, step=3)
+        with tracker:
+            # Test different metric types
+            tracker.log_metrics({"loss": 0.5}, step=1)
+            tracker.log_metrics({"accuracy": 0.9, "f1": 0.85}, step=2)
+            tracker.log_metrics({"learning_rate": 0.001}, step=3)
 
-                # Test without step
-                tracker.log_metrics({"final_loss": 0.1})
+            # Test without step
+            tracker.log_metrics({"final_loss": 0.1})
 
-                # Test with None step
-                tracker.log_metrics({"test_metric": 42}, step=None)
+            # Test with None step
+            tracker.log_metrics({"test_metric": 42}, step=None)
 
         # Verify all metrics were logged to wandb
         assert mock_wandb.log.call_count == 5

--- a/tests/test_experiment_tracking.py
+++ b/tests/test_experiment_tracking.py
@@ -172,16 +172,15 @@ class TestExperimentTrackerIntegration:
         tracker.start_run()
 
         # Should be able to log metrics
-        mock_log = mock_wandb.log
         tracker.log_metrics({"loss": 0.5, "accuracy": 0.9}, step=1)
         tracker.log_metrics({"loss": 0.4, "accuracy": 0.95}, step=2)
         
         # Verify wandb.log was called correctly
-        assert mock_log.call_count == 2
-        assert mock_log.call_args_list[0][0][0] == {"loss": 0.5, "accuracy": 0.9}
-        assert mock_log.call_args_list[0][1]["step"] == 1
-        assert mock_log.call_args_list[1][0][0] == {"loss": 0.4, "accuracy": 0.95}
-        assert mock_log.call_args_list[1][1]["step"] == 2
+        assert mock_wandb.log.call_count == 2
+        assert mock_wandb.log.call_args_list[0][0][0] == {"loss": 0.5, "accuracy": 0.9}
+        assert mock_wandb.log.call_args_list[0][1]["step"] == 1
+        assert mock_wandb.log.call_args_list[1][0][0] == {"loss": 0.4, "accuracy": 0.95}
+        assert mock_wandb.log.call_args_list[1][1]["step"] == 2
 
         # Should be active
         assert tracker.is_active()


### PR DESCRIPTION
Wandb offline mode is flaky ([failure](https://github.com/gepa-ai/gepa/actions/runs/17974503472/job/51158303766?pr=86#step:8:218)) so mock wandb and just confirm wandb APIs are called correctly.