### PR TITLE
Add `reflection_prompt_template` parameter to `optimize` function

### DIFF
--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -35,6 +35,7 @@ def optimize(
     skip_perfect_score=True,
     reflection_minibatch_size=3,
     perfect_score=1,
+    reflection_prompt_template: str | None = None,
     # Component selection configuration
     module_selector: "ReflectionComponentSelector | str" = "round_robin",
     # Merge-based configuration
@@ -106,6 +107,7 @@ def optimize(
     - skip_perfect_score: Whether to skip updating the candidate if it achieves a perfect score on the minibatch.
     - reflection_minibatch_size: The number of examples to use for reflection in each proposal step.
     - perfect_score: The perfect score to achieve.
+    - reflection_prompt_template: The prompt template to use for reflection. If not provided, GEPA will use the default prompt template (see InstructionProposalSignature). It should contain the following placeholders, which will be replaced with actual values: <curr_instructions> (the instructions to evolve), <inputs_outputs_feedback> (the inputs, outputs, and feedback to reflect on).
 
     # Component selection configuration
     - module_selector: Component selection strategy. Can be a ReflectionComponentSelector instance or a string ('round_robin', 'all'). Defaults to 'round_robin'. The 'round_robin' strategy cycles through components in order. The 'all' strategy selects all components for modification in every GEPA iteration.
@@ -240,6 +242,7 @@ def optimize(
         skip_perfect_score=skip_perfect_score,
         experiment_tracker=experiment_tracker,
         reflection_lm=reflection_lm,
+        reflection_prompt_template=reflection_prompt_template,
     )
 
     def evaluator(inputs, prog):

--- a/src/gepa/strategies/instruction_proposal.py
+++ b/src/gepa/strategies/instruction_proposal.py
@@ -5,7 +5,7 @@ from gepa.proposer.reflective_mutation.base import Signature
 
 
 class InstructionProposalSignature(Signature):
-    prompt_template = """I provided an assistant with the following instructions to perform a task for me:
+    default_prompt_template = """I provided an assistant with the following instructions to perform a task for me:
 ```
 <curr_instructions>
 ```
@@ -23,8 +23,20 @@ Read all the assistant responses and the corresponding feedback. Identify all ni
 
 Provide the new instructions within ``` blocks."""
 
-    input_keys = ["current_instruction_doc", "dataset_with_feedback"]
+    input_keys = ["current_instruction_doc", "dataset_with_feedback", "prompt_template"]
     output_keys = ["new_instruction"]
+
+    @classmethod
+    def validate_prompt_template(cls, prompt_template: str | None):
+        if prompt_template is None:
+            return
+        missing_placeholders = [
+            p for p in ["<curr_instructions>", "<inputs_outputs_feedback>"] if p not in prompt_template
+        ]
+        if missing_placeholders:
+            raise ValueError(
+                f"Missing placeholder(s) in prompt template: {', '.join(missing_placeholders)}"
+            )
 
     @classmethod
     def prompt_renderer(cls, input_dict: dict[str, str]) -> str:
@@ -59,8 +71,9 @@ Provide the new instructions within ``` blocks."""
 
             return "\n\n".join(convert_sample_to_markdown(sample, i + 1) for i, sample in enumerate(samples))
 
-        prompt = cls.prompt_template
-        prompt = prompt.replace("<curr_instructions>", input_dict["current_instruction_doc"])
+        prompt_template = input_dict.get("prompt_template", None) or cls.default_prompt_template
+        cls.validate_prompt_template(prompt_template)
+        prompt = prompt_template.replace("<curr_instructions>", input_dict["current_instruction_doc"])
         prompt = prompt.replace("<inputs_outputs_feedback>", format_samples(input_dict["dataset_with_feedback"]))
         return prompt
 

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,0 +1,83 @@
+from unittest.mock import Mock
+import re
+from gepa.core.adapter import EvaluationBatch
+from gepa import optimize
+import pytest
+
+
+def test_reflection_prompt_template():
+    """Test that reflection_prompt_template works with optimize()."""
+    mock_data = [
+        {
+            "input": "my_input",
+            "answer": "my_answer",
+            "additional_context": {"context": "my_context"},
+        }
+    ]
+
+    # Mock the reflection LM to return improved instructions and track calls
+    reflection_calls = []
+
+    task_lm = Mock()
+    task_lm.return_value = "test response"
+
+    def mock_reflection_lm(prompt):
+        reflection_calls.append(prompt)
+        return "```\nimproved instructions\n```"
+
+    custom_template = """Current instructions:
+<curr_instructions>
+Inputs, outputs, and feedback:
+<inputs_outputs_feedback>
+Please improve the instructions."""
+
+    result = optimize(
+        seed_candidate={"instructions": "initial instructions"},
+        trainset=mock_data,
+        task_lm=task_lm,
+        reflection_lm=mock_reflection_lm,
+        reflection_prompt_template=custom_template,
+        max_metric_calls=2,
+        reflection_minibatch_size=1,
+    )
+
+    # Check that the reflection_lm was called with our custom template
+    assert len(reflection_calls) > 0
+    reflection_prompt = reflection_calls[0]
+    assert "initial instructions" in reflection_prompt
+    assert "my_input" in reflection_prompt
+    assert "Please improve the instructions." in reflection_prompt
+
+
+def test_reflection_prompt_template_missing_placeholders():
+    """Test that reflection_prompt_template fails when placeholders are missing."""
+    mock_data = [
+        {
+            "input": "my_input",
+            "answer": "my_answer",
+            "additional_context": {"context": "my_context"},
+        }
+    ]
+
+    # Mock the reflection LM to return improved instructions and track calls
+    reflection_calls = []
+
+    task_lm = Mock()
+    task_lm.return_value = "test response"
+
+    def mock_reflection_lm(prompt):
+        reflection_calls.append(prompt)
+        return "```\nimproved instructions\n```"
+
+    custom_template = "Missing both placeholders."
+
+    with pytest.raises(ValueError, match=re.escape("Missing placeholder(s) in prompt template: <curr_instructions>, <inputs_outputs_feedback>")):
+        result = optimize(
+            seed_candidate={"instructions": "initial instructions"},
+            trainset=mock_data,
+            task_lm=task_lm,
+            reflection_lm=mock_reflection_lm,
+            reflection_prompt_template=custom_template,
+            max_metric_calls=2,
+            reflection_minibatch_size=1,
+        )


### PR DESCRIPTION
This adds a new parameter, `reflection_prompt_template`. Previously, the prompt template was hardcoded in strategies/instruction_proposal.py. This allows for improved customization of the reflection LM's behavior.

For example, if the prompts found by GEPA are too long and specific for your use case, you can replace the part of the default prompt template that says "Identify all niche and domain specific factual information about the task and include it in the instruction" with something else.

The provided prompt template must include the placeholders "<curr_instructions>" and "<inputs_outputs_feedback>". Otherwise, `optimize` will fail.

The new parameter can be used like this:
```
reflection_prompt_template = """
Instructions:
<curr_instructions>

Inputs, outputs, and feedback:
<inputs_outputs_feedback>

Write new instructions given the feedback. Make the instructions as short as possible while still mentioning everything important. Provide the new instructions within ``` blocks.
"""
result = optimize(
    trainset=data,
    task_lm=task_lm,
    reflection_lm=reflection_lm,
    reflection_prompt_template=reflection_prompt_template,
)
```