### PR TITLE
Use cloudpickle if available.

### DIFF
--- a/src/gepa/core/state.py
+++ b/src/gepa/core/state.py
@@ -86,14 +86,20 @@ class GEPAState(Generic[RolloutOutput]):
         if run_dir is None:
             return
         with open(os.path.join(run_dir, "gepa_state.bin"), "wb") as f:
-            import pickle
+            try:
+                import cloudpickle as pickle
+            except ImportError:
+                import pickle
             d = dict(self.__dict__.items())
             pickle.dump(d, f)
 
     @staticmethod
     def load(run_dir: str) -> "GEPAState":
         with open(os.path.join(run_dir, "gepa_state.bin"), "rb") as f:
-            import pickle
+            try:
+                import cloudpickle as pickle
+            except ImportError:
+                import pickle
             d = pickle.load(f)
         state = GEPAState.__new__(GEPAState)
         state.__dict__.update(d)


### PR DESCRIPTION
I'd like to use `dspy.GEPA` with the `log_dir` parameter for checkpointing, but [DSPy Issue 1221](https://github.com/stanfordnlp/dspy/issues/1221) stops me. As I understand it the pickle is unable to serialize the [dynamically created class created by SignatureMeta](https://github.com/stanfordnlp/dspy/blob/965da1db9cec611710534d42b9049fdbc13d88d7/dspy/signatures/signature.py#L49).   To get around issue, this MR replaces pickle with `cloudpickle` when the it can be imported and otherwise falls back to `pickle` in `src/gepa/core/state.py` so the dynamic class can be serialized. No dependency was added.