### PR TITLE
Fix reflective proposer stalling by consuming metric budget on trace failures

### DIFF
--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -92,12 +92,12 @@ class ReflectiveMutationProposer(ProposeNewCandidate):
 
         # 1) Evaluate current program with traces
         eval_curr = self.adapter.evaluate(minibatch, curr_prog, capture_traces=True)
+        state.total_num_evals += len(subsample_ids)
+        state.full_program_trace[-1]["subsample_scores"] = eval_curr.scores
+
         if not eval_curr.trajectories or len(eval_curr.trajectories) == 0:
             self.logger.log(f"Iteration {i}: No trajectories captured. Skipping.")
             return None
-
-        state.total_num_evals += len(subsample_ids)
-        state.full_program_trace[-1]["subsample_scores"] = eval_curr.scores
 
         if self.skip_perfect_score and all(s >= self.perfect_score for s in eval_curr.scores):
             self.logger.log(f"Iteration {i}: All subsample scores perfect. Skipping.")


### PR DESCRIPTION
Increment `state.total_num_evals` immediately after the minibatch evaluation, even when no trajectories are captured. Without this, the proposer returned early before updating the counter, so MaxMetricCallsStopper (which checks
  `total_num_evals >= max_metric_calls`) never triggered and the optimization loop could run indefinitely. 

This change restores the budget accounting and prevents the infinite loop.

Fixes #46 