### PR TITLE
Fix parsing for ``` blocks with language in InstructionProposalSignature

### DIFF
--- a/tests/test_instruction_proposal.py
+++ b/tests/test_instruction_proposal.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+import pytest
+from gepa.strategies.instruction_proposal import InstructionProposalSignature
+
+
+class TestInstructionProposalSignature:
+    """Test InstructionProposalSignature functions."""
+
+    @pytest.mark.parametrize(
+        "lm_output,expected_instruction",
+        [
+            # Test with language specifier
+            (
+                """Here's the improved instruction:
+```markdown
+This is the actual instruction content.
+It should not include the word 'markdown'.
+```
+""",
+                "This is the actual instruction content.\nIt should not include the word 'markdown'.",
+            ),
+            # Test without language specifier (original behavior)
+            (
+                """Here's the instruction:
+```
+This is the instruction without language specifier.
+```
+Done.""",
+                "This is the instruction without language specifier.",
+            ),
+            (
+                """```markdown
+Don't get confused by these backticks: ```
+```""",
+                "Don't get confused by these backticks: ```",
+            ),
+            # Test stripping the output string
+            (
+                """```
+
+Here are the instructions.
+
+```""",
+                "Here are the instructions.",
+            ),
+            # Test multiple sets of backticks (should take the "outermost" block)
+            (
+                """Begin text
+```plaintext
+Begin instructions
+
+```
+Internal block 1
+```
+
+```python
+Internal block 2
+```
+
+End instructions
+```
+End text
+""",
+                "Begin instructions\n\n```\nInternal block 1\n```\n\n```python\nInternal block 2\n```\n\nEnd instructions",
+            ),
+            # Test when the output starts with ``` but doesn't end with it
+            (
+                """```text
+Here are the instructions.""",
+                "Here are the instructions.",
+            ),
+            # Test when the output ends with ``` but doesn't start with it
+            (
+                """Here are the instructions.
+```""",
+                "Here are the instructions.",
+            ),
+            # Test only backticks in the middle
+            (
+                """
+Here are some backticks:
+```
+I hope you didn't get confused.
+                """,
+                "Here are some backticks:\n```\nI hope you didn't get confused.",
+            ),
+            # Test when there are no backticks at all, also strip whitespace
+            (
+                """
+                Here are the instructions.
+                """,
+                "Here are the instructions.",
+            ),
+        ],
+    )
+    def test_extract_code_blocks(self, lm_output, expected_instruction):
+        """Test extraction of instructions from various code block formats."""
+        result = InstructionProposalSignature.output_extractor(lm_output)
+        assert result["new_instruction"] == expected_instruction


### PR DESCRIPTION
This allows us to properly parse code blocks written by the reflection LM when they include a language specifier.

For example, this "plaintext" block:
```plaintext
These are the instructions.
```
would previously parse to "plaintext\nThese are the instructions." After this change, it will parse to "These are the instructions."