### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,4 +1,6 @@
 name: Lint, Test, and Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gepa-ai/gepa/security/code-scanning/3](https://github.com/gepa-ai/gepa/security/code-scanning/3)

The recommended fix is to explicitly specify a `permissions` block in the workflow YAML file to limit the GITHUB_TOKEN permissions according to the principle of least privilege. The minimal safe default for most workflows is likely `permissions: { contents: read }`, which grants read-only access to repository contents. This can be set either at the workflow root (to apply to all jobs) or per job; since CodeQL flags the `build_package` job, either approach would resolve the error, but setting at the workflow root ensures all jobs are protected and avoids having to duplicate the block.

- **How to fix (general):** Add a `permissions:` block at the top level of `.github/workflows/run_tests.yml` (just after `name:` or directly below `on:`).
- **Single best way:** Place `permissions: { contents: read }` after the `name:` in the workflow root, so all jobs that do not need write access will operate under read-only permissions.
- **Lines to change:** Insert the `permissions:` block after the `name:` (line 1), before the `on:` block (line 3), to apply universally.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
