### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -4,6 +4,8 @@
 # - PyPI: Always uses exact tag version (e.g., v1.0.0 -> 1.0.0), fails if version exists
 # - Git operations: Use original tag version for branch names and merge messages
 name: Publish Python 🐍 distributions 📦 to PyPI
+permissions:
+  contents: read
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/gepa-ai/gepa/security/code-scanning/1](https://github.com/gepa-ai/gepa/security/code-scanning/1)

To fix the problem, add the `permissions` key at the top level of the workflow file, `.github/workflows/build_and_release.yml`. This ensures that all jobs will inherit these restrictive permissions unless they define their own, thus limiting the scope of the default `GITHUB_TOKEN`. The best default for most workflows is `contents: read`, only allowing read access to repository contents. For jobs that require greater privileges, such as publishing or pushing branches, a per-job `permissions` block can override the global default (as is already done in `build-and-publish-test-pypi`). Therefore, insert:

```yaml
permissions:
  contents: read
```

below the `name:` key and above the `on:` key at the top of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
