### PR TITLE
Reuse MLflow active run if exist

### DIFF
--- a/tests/test_experiment_tracking.py
+++ b/tests/test_experiment_tracking.py
@@ -1,11 +1,10 @@
-import os
 import shutil
-import tempfile
 import sys
+import tempfile
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
-from unittest.mock import MagicMock, patch
 
 from gepa.logging.experiment_tracker import ExperimentTracker, create_experiment_tracker
 
@@ -14,6 +13,7 @@ def has_wandb():
     """Check if wandb is available."""
     try:
         import wandb  # noqa: F401
+
         return True
     except ImportError:
         return False
@@ -23,6 +23,7 @@ def has_mlflow():
     """Check if mlflow is available."""
     try:
         import mlflow  # noqa: F401
+
         return True
     except ImportError:
         return False
@@ -129,11 +130,13 @@ class TestExperimentTrackerIntegration:
         """Mock wandb."""
         if not has_wandb():
             pytest.skip("wandb not available")
-        if 'wandb' in sys.modules:
-            del sys.modules['wandb']
+        if "wandb" in sys.modules:
+            del sys.modules["wandb"]
         wandb = MagicMock()
+
         def finish():
             wandb.run = None
+
         wandb.finish.side_effect = finish
         with patch.dict("sys.modules", {"wandb": wandb}):
             yield wandb
@@ -174,7 +177,7 @@ class TestExperimentTrackerIntegration:
         # Should be able to log metrics
         tracker.log_metrics({"loss": 0.5, "accuracy": 0.9}, step=1)
         tracker.log_metrics({"loss": 0.4, "accuracy": 0.95}, step=2)
-        
+
         # Verify wandb.log was called correctly
         assert mock_wandb.log.call_count == 2
         assert mock_wandb.log.call_args_list[0][0][0] == {"loss": 0.5, "accuracy": 0.9}
@@ -214,6 +217,7 @@ class TestExperimentTrackerIntegration:
 
         # Verify metrics were logged by checking mlflow run data
         import mlflow
+
         run = mlflow.active_run()
         assert run is not None
         assert run.info.run_id is not None
@@ -230,6 +234,7 @@ class TestExperimentTrackerIntegration:
 
         # Check that metrics were stored in the mlflow tracking store
         from mlflow.tracking import MlflowClient
+
         client = MlflowClient(tracking_uri=f"file://{temp_dir}/mlflow")
 
         # Get the experiment
@@ -273,7 +278,7 @@ class TestExperimentTrackerIntegration:
         # Should be able to log metrics to both backends
         with patch("wandb.log") as mock_wandb_log:
             tracker.log_metrics({"loss": 0.4, "accuracy": 0.95})
-            
+
             # Verify wandb was called
             mock_wandb_log.assert_called_once_with({"loss": 0.4, "accuracy": 0.95}, step=None)
 
@@ -282,11 +287,13 @@ class TestExperimentTrackerIntegration:
 
         # Check wandb
         import wandb
+
         wandb_run = wandb.run
         assert wandb_run is not None
 
         # Check mlflow
         import mlflow
+
         mlflow_run = mlflow.active_run()
         assert mlflow_run is not None
         assert mlflow_run.info.run_id is not None
@@ -299,6 +306,7 @@ class TestExperimentTrackerIntegration:
 
         # Verify mlflow metrics were stored
         from mlflow.tracking import MlflowClient
+
         client = MlflowClient(tracking_uri=f"file://{temp_dir}/mlflow")
         experiment = client.get_experiment_by_name("test-experiment")
         runs = client.search_runs(experiment_ids=[experiment.experiment_id])
@@ -328,7 +336,7 @@ class TestExperimentTrackerIntegration:
             assert tracker.is_active()
             tracker.log_metrics({"loss": 0.5}, step=1)
             tracker.log_metrics({"accuracy": 0.9}, step=2)
-            
+
             # Verify wandb.log was called correctly
             assert mock_wandb.log.call_count == 2
             assert mock_wandb.log.call_args_list[0][0][0] == {"loss": 0.5}
@@ -372,12 +380,11 @@ class TestExperimentTrackerIntegration:
             mlflow_experiment_name="test-experiment",
         )
 
-    
         with tracker:
             assert tracker.is_active()
             tracker.log_metrics({"loss": 0.5}, step=1)
             tracker.log_metrics({"accuracy": 0.9}, step=2)
-            
+
             # Verify wandb was called correctly
             assert mock_wandb.log.call_count == 2
             assert mock_wandb.log.call_args_list[0][0][0] == {"loss": 0.5}
@@ -390,6 +397,7 @@ class TestExperimentTrackerIntegration:
 
         # Verify mlflow metrics were stored
         from mlflow.tracking import MlflowClient
+
         client = MlflowClient(tracking_uri=f"file://{temp_dir}/mlflow")
         experiment = client.get_experiment_by_name("test-experiment")
         runs = client.search_runs(experiment_ids=[experiment.experiment_id])
@@ -418,7 +426,7 @@ class TestExperimentTrackerIntegration:
             with tracker:
                 tracker.log_metrics({"test": 1.0}, step=1)
                 raise ValueError("test exception")
-        
+
         # Verify wandb.log was called before the exception
         mock_wandb.log.assert_called_once_with({"test": 1.0}, step=1)
 
@@ -439,7 +447,6 @@ class TestExperimentTrackerIntegration:
             with tracker:
                 tracker.log_metrics({"test": 1.0}, step=1)
                 raise ValueError("test exception")
-
 
     @pytest.mark.skipif(not has_mlflow(), reason="mlflow not available")
     def test_mlflow_experiment_creation(self, temp_dir):
@@ -486,7 +493,7 @@ class TestExperimentTrackerIntegration:
 
         # Verify all metrics were logged to wandb
         assert mock_wandb.log.call_count == 5
-        
+
         # Check each call
         expected_calls = [
             ({"loss": 0.5}, {"step": 1}),
@@ -495,11 +502,57 @@ class TestExperimentTrackerIntegration:
             ({"final_loss": 0.1}, {"step": None}),
             ({"test_metric": 42}, {"step": None}),
         ]
-        
+
         for i, (expected_metrics, expected_kwargs) in enumerate(expected_calls):
             call_args, call_kwargs = mock_wandb.log.call_args_list[i]
             assert call_args[0] == expected_metrics
             assert call_kwargs == expected_kwargs
+
+    @pytest.mark.skipif(not has_mlflow(), reason="mlflow not available")
+    def test_mlflow_nested_run_handling(self, temp_dir):
+        import mlflow
+
+        # Start an outer mlflow run
+        mlflow.set_tracking_uri(f"file://{temp_dir}/mlflow")
+        mlflow.set_experiment("test-experiment")
+
+        with mlflow.start_run() as outer_run:
+            outer_run_id = outer_run.info.run_id
+
+            # Create tracker inside existing run
+            tracker = ExperimentTracker(
+                use_wandb=False,
+                use_mlflow=True,
+                mlflow_tracking_uri=f"file://{temp_dir}/mlflow",
+                mlflow_experiment_name="test-experiment",
+            )
+
+            tracker.initialize()
+            tracker.start_run()
+
+            # Log some metrics
+            tracker.log_metrics({"inner_metric": 1.0}, step=1)
+
+            # End the tracker
+            tracker.end_run()
+
+            # The outer run should still be active
+            assert mlflow.active_run() is not None
+            assert mlflow.active_run().info.run_id == outer_run_id
+
+            # Log more metrics to the outer run
+            mlflow.log_metric("outer_metric", 2.0)
+
+        # Now the outer run should be ended
+        assert mlflow.active_run() is None
+
+        # Verify both metrics were logged
+        from mlflow.tracking import MlflowClient
+
+        client = MlflowClient(tracking_uri=f"file://{temp_dir}/mlflow")
+        run_data = client.get_run(outer_run_id)
+        assert "inner_metric" in run_data.data.metrics
+        assert "outer_metric" in run_data.data.metrics
 
     @pytest.mark.skipif(not has_mlflow(), reason="mlflow not available")
     def test_metric_logging_variations_mlflow(self, temp_dir):
@@ -525,6 +578,7 @@ class TestExperimentTrackerIntegration:
 
         # Verify all metrics were logged to mlflow
         from mlflow.tracking import MlflowClient
+
         client = MlflowClient(tracking_uri=f"file://{temp_dir}/mlflow")
         experiment = client.get_experiment_by_name("test-experiment")
         runs = client.search_runs(experiment_ids=[experiment.experiment_id])


### PR DESCRIPTION
Currently, the experiment tracker always creates a new MLflow run, but it's more useful if users can log metrics to an existing active run to consolidate gepa metrics with other metrics.