### PR TITLE
Add MLflow prompt optimization using GEPA on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ We encourage the community and users to help us develop adapters to allow GEPA t
 - **GEPA Integrations:**  
   Want to use GEPA in other frameworks?  
   - [DSPy Adapter Code](https://github.com/stanfordnlp/dspy/tree/main/dspy/teleprompt/gepa/gepa_utils.py) (integrates GEPA with [DSPy](https://dspy.ai/)),  
+  - [MLflow Prompt Optimization](https://mlflow.org/docs/latest/genai/prompt-registry/optimize-prompts/) - GEPA is integrated into MLflow's `mlflow.genai.optimize_prompts()` API for automatic prompt improvement using evaluation metrics and training data. Works with any agent framework and supports multi-prompt optimization.
   - [Contributed Adapters](src/gepa/adapters/) – see our adapter templates and issue tracker to request new integrations.
     - [DefaultAdapter](src/gepa/adapters/default_adapter/) - System Prompt Optimization for a single-turn task.
     - [DSPy Full Program Adapter](src/gepa/adapters/dspy_full_program_adapter/) - Evolves entire DSPy programs including signatures, modules, and control flow. Achieves **93% accuracy** on MATH benchmark (vs 67% with basic DSPy ChainOfThought).


### PR DESCRIPTION
In MLflow 3.5.0, we released a new API `mlflow.genai.optimize_prompts` that enable MLflow users to optimize their prompts using the GEPA algorithm ([doc](https://mlflow.org/docs/latest/genai/prompt-registry/optimize-prompts/)). This PR adds the link and explanation in the "GEPA Integrations" section.