### PR TITLE
Remove 'stubPath' from pyrightconfig.json

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -11,6 +11,5 @@
     "src/gepa/adapters/anymaths_adapter",
     "src/gepa/adapters/terminal_bench_adapter",
     "tests"
-  ],
-  "stubPath": "typings"
+  ]
 }


### PR DESCRIPTION
Removed the 'stubPath' property from the configuration.