### PR TITLE
Enable parallel evaluation by default in EngineConfig

### DIFF
--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -445,7 +445,7 @@ class EngineConfig:
 
     Most users only need to set ``max_metric_calls`` (evaluation budget).
     Parallel evaluation is enabled by default with ``max_workers`` set to
-    the number of available CPUs (``os.cpu_count()``).
+    ``os.cpu_count() or 32`` (CPU count when available, otherwise 32).
 
     Set ``capture_stdio=True`` to automatically route any ``print()`` output
     inside your evaluator into ASI (under ``"stdout"``/``"stderr"`` keys),
@@ -471,7 +471,7 @@ class EngineConfig:
 
     # Parallelization settings for evaluation
     parallel: bool = True
-    max_workers: int | None = field(default_factory=lambda: os.cpu_count())
+    max_workers: int | None = field(default_factory=lambda: os.cpu_count() or 32)
 
     # Evaluation caching
     cache_evaluation: bool = False


### PR DESCRIPTION
## Summary
- Sets `parallel=True` and `max_workers=os.cpu_count()` as defaults in `EngineConfig`, so evaluation runs concurrently out of the box using all available CPUs.
- Updates docstrings and example config to reflect the new defaults.

## Test plan
- [ ] Verify `EngineConfig()` defaults: `parallel` is `True`, `max_workers` equals `os.cpu_count()`
- [ ] Run existing test suite (`uv run pytest`) to confirm no regressions
- [ ] Confirm users can still override with `parallel=False` or a custom `max_workers`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default execution to run evaluations in parallel using all available CPUs, which can alter performance/resource usage and surface thread/process-safety issues in user evaluators. Behavior remains configurable via `parallel` and `max_workers` overrides.
> 
> **Overview**
> **Enables parallel evaluation by default** in `EngineConfig` by setting `parallel=True` and defaulting `max_workers` to `os.cpu_count()`.
> 
> Updates the `EngineConfig` docstring and `GEPAConfig` example to reflect that users typically only need to set `max_metric_calls`, with parallelism now on out of the box.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff7e795ecec372eea8939b1b09690c6f2eccc730. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->