### PR TITLE
feat: add Top-K Pareto candidate selector

### DIFF
--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -29,6 +29,7 @@ from gepa.strategies.candidate_selector import (
     CurrentBestCandidateSelector,
     EpsilonGreedyCandidateSelector,
     ParetoCandidateSelector,
+    TopKParetoCandidateSelector,
 )
 from gepa.strategies.component_selector import (
     AllReflectionComponentSelector,
@@ -47,7 +48,8 @@ def optimize(
     evaluator: Evaluator | None = None,
     # Reflection-based configuration
     reflection_lm: LanguageModel | str | None = None,
-    candidate_selection_strategy: CandidateSelector | Literal["pareto", "current_best", "epsilon_greedy"] = "pareto",
+    candidate_selection_strategy: CandidateSelector
+    | Literal["pareto", "current_best", "epsilon_greedy", "top_k_pareto"] = "pareto",
     frontier_type: FrontierType = "instance",
     skip_perfect_score: bool = True,
     batch_sampler: BatchSampler | Literal["epoch_shuffled"] = "epoch_shuffled",
@@ -250,7 +252,6 @@ def optimize(
             + "GEPA will use the default proposer, which requires a reflection_lm to be specified."
         )
 
-
     reflection_lm_callable: LanguageModel | None = None
     if isinstance(reflection_lm, str):
         import litellm
@@ -281,6 +282,7 @@ def optimize(
             "pareto": lambda: ParetoCandidateSelector(rng=rng),
             "current_best": lambda: CurrentBestCandidateSelector(),
             "epsilon_greedy": lambda: EpsilonGreedyCandidateSelector(epsilon=0.1, rng=rng),
+            "top_k_pareto": lambda: TopKParetoCandidateSelector(k=5, rng=rng),
         }
 
         try:
@@ -288,7 +290,7 @@ def optimize(
         except KeyError as exc:
             raise ValueError(
                 f"Unknown candidate_selector strategy: {candidate_selection_strategy}. "
-                "Supported strategies: 'pareto', 'current_best', 'epsilon_greedy'"
+                "Supported strategies: 'pareto', 'current_best', 'epsilon_greedy', 'top_k_pareto'"
             ) from exc
     elif isinstance(candidate_selection_strategy, CandidateSelector):
         candidate_selector = candidate_selection_strategy

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -138,6 +138,7 @@ from gepa.strategies.candidate_selector import (
     CurrentBestCandidateSelector,
     EpsilonGreedyCandidateSelector,
     ParetoCandidateSelector,
+    TopKParetoCandidateSelector,
 )
 from gepa.strategies.component_selector import (
     AllReflectionComponentSelector,
@@ -466,7 +467,9 @@ class EngineConfig:
 
     # Strategy selection for the engine
     val_evaluation_policy: EvaluationPolicy | Literal["full_eval"] = "full_eval"
-    candidate_selection_strategy: CandidateSelector | Literal["pareto", "current_best", "epsilon_greedy"] = "pareto"
+    candidate_selection_strategy: CandidateSelector | Literal[
+        "pareto", "current_best", "epsilon_greedy", "top_k_pareto"
+    ] = "pareto"
     frontier_type: FrontierType = "hybrid"
 
     # Parallelization settings for evaluation
@@ -1303,6 +1306,7 @@ def optimize_anything(
             "pareto": lambda: ParetoCandidateSelector(rng=rng),
             "current_best": lambda: CurrentBestCandidateSelector(),
             "epsilon_greedy": lambda: EpsilonGreedyCandidateSelector(epsilon=0.1, rng=rng),
+            "top_k_pareto": lambda: TopKParetoCandidateSelector(k=5, rng=rng),
         }
 
         try:
@@ -1310,7 +1314,7 @@ def optimize_anything(
         except KeyError as exc:
             raise ValueError(
                 f"Unknown candidate_selector strategy: {config.engine.candidate_selection_strategy}. "
-                "Supported strategies: 'pareto', 'current_best', 'epsilon_greedy'"
+                "Supported strategies: 'pareto', 'current_best', 'epsilon_greedy', 'top_k_pareto'"
             ) from exc
     elif isinstance(config.engine.candidate_selection_strategy, CandidateSelector):
         candidate_selector = config.engine.candidate_selection_strategy

--- a/src/gepa/strategies/candidate_selector.py
+++ b/src/gepa/strategies/candidate_selector.py
@@ -48,3 +48,35 @@ class EpsilonGreedyCandidateSelector(CandidateSelector):
             return self.rng.randint(0, len(state.program_candidates) - 1)
         else:
             return idxmax(state.program_full_scores_val_set)
+
+
+class TopKParetoCandidateSelector(CandidateSelector):
+    """Pareto selection restricted to the top K programs by aggregate score."""
+
+    def __init__(self, k: int, rng: random.Random | None):
+        assert k > 0
+        self.k = k
+        if rng is None:
+            self.rng = random.Random(0)
+        else:
+            self.rng = rng
+
+    def select_candidate_idx(self, state: GEPAState) -> int:
+        assert len(state.program_full_scores_val_set) == len(state.program_candidates)
+        # Get top K program indices by aggregate score
+        scores = state.per_program_tracked_scores
+        top_k_indices = set(sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)[: self.k])
+
+        # Filter pareto front mapping to only include top K programs
+        pareto_mapping = state.get_pareto_front_mapping()
+        filtered_mapping = {}
+        for key, prog_set in pareto_mapping.items():
+            filtered = prog_set & top_k_indices
+            if filtered:
+                filtered_mapping[key] = filtered
+
+        if not filtered_mapping:
+            # Fallback: pick the best program overall
+            return idxmax(scores)
+
+        return select_program_candidate_from_pareto_front(filtered_mapping, scores, self.rng)


### PR DESCRIPTION
## Summary
- Adds `TopKParetoCandidateSelector` that restricts Pareto selection to only the top K programs by aggregate score
- Prevents low-scoring programs from being selected as parents for mutation, focusing optimization effort on the most promising candidates
- Available via `candidate_selection_strategy="top_k_pareto"` (default K=5) or by passing `TopKParetoCandidateSelector(k=N, rng=rng)` directly
- Registered in both `api.py` and `optimize_anything.py` factory dicts

Closes #75

## Test plan
- [ ] `uv run ruff check src/` passes
- [ ] `uv run pytest` passes
- [ ] Verify `candidate_selection_strategy="top_k_pareto"` works in an optimization run

🤖 Generated with [Claude Code](https://claude.com/claude-code)