### PR TITLE
feat: expose trainset_loader in IterationStartEvent for dynamic datasets

### DIFF
--- a/src/gepa/core/callbacks.py
+++ b/src/gepa/core/callbacks.py
@@ -35,6 +35,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Protocol, TypedDict, runtime_checkable
 
 if TYPE_CHECKING:
+    from gepa.core.data_loader import DataLoader
     from gepa.core.state import GEPAState, ProgramIdx
 
 logger = logging.getLogger(__name__)
@@ -70,6 +71,7 @@ class IterationStartEvent(TypedDict):
 
     iteration: int
     state: GEPAState
+    trainset_loader: DataLoader
 
 
 class IterationEndEvent(TypedDict):

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -399,6 +399,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                     IterationStartEvent(
                         iteration=state.i + 1,
                         state=state,
+                        trainset_loader=self.reflective_proposer.trainset,
                     ),
                 )
                 iteration_started = True


### PR DESCRIPTION
## Summary
- Adds `trainset_loader` field to `IterationStartEvent` so users can access the `MutableDataLoader` in their `on_iteration_start` callback
- Enables dynamic training datasets: users call `event.trainset_loader.add_items(new_data)` to grow the training set mid-optimization
- The batch sampler already detects loader size changes automatically (via `len(loader)` check), so newly added items are included in subsequent minibatches

**Example usage:**
```python
class DynamicDataCallback:
    def on_iteration_start(self, event):
        if should_add_new_data(event.iteration):
            event.trainset_loader.add_items(new_training_examples)
```

Closes #79

## Test plan
- [ ] `uv run ruff check src/` passes
- [ ] `uv run pytest` passes
- [ ] Verify callback receives trainset_loader and `add_items()` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)