### PR TITLE
fix: filter non-numeric metrics from wandb/mlflow logging

### DIFF
--- a/src/gepa/logging/experiment_tracker.py
+++ b/src/gepa/logging/experiment_tracker.py
@@ -96,7 +96,10 @@ class ExperimentTracker:
             try:
                 import wandb  # type: ignore
 
-                wandb.log(metrics, step=step)
+                # Filter out non-numeric values to avoid creating noisy string charts
+                numeric_metrics = {k: v for k, v in metrics.items() if isinstance(v, int | float)}
+                if numeric_metrics:
+                    wandb.log(numeric_metrics, step=step)
             except Exception as e:
                 print(f"Warning: Failed to log to wandb: {e}")
 


### PR DESCRIPTION
## Summary
- Applies the same numeric-only filtering to `wandb.log()` that was already done for MLflow (line 108)
- Non-numeric values (strings, dicts, lists) were creating noisy charts in WandB dashboards

Closes #137

## Test plan
- [ ] `uv run ruff check src/` passes
- [ ] `uv run pytest` passes
- [ ] Verify WandB only receives numeric metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)