### PR TITLE
Add LLM-based crossover proposal mode

### DIFF
--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -55,6 +55,7 @@ def optimize(
     perfect_score: float = 1.0,
     reflection_prompt_template: str | dict[str, str] | None = None,
     custom_candidate_proposer: ProposalFn | None = None,
+    proposal_mode: Literal["rewrite", "edit", "crossover"] = "rewrite",
     # Component selection configuration
     module_selector: ReflectionComponentSelector | str = "round_robin",
     # Merge-based configuration
@@ -250,7 +251,6 @@ def optimize(
             + "GEPA will use the default proposer, which requires a reflection_lm to be specified."
         )
 
-
     reflection_lm_callable: LanguageModel | None = None
     if isinstance(reflection_lm, str):
         import litellm
@@ -359,6 +359,7 @@ def optimize(
         reflection_prompt_template=reflection_prompt_template,
         custom_candidate_proposer=custom_candidate_proposer,
         callbacks=callbacks,
+        proposal_mode=proposal_mode,
     )
 
     def evaluator_fn(

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -715,6 +715,7 @@ class ReflectionConfig:
     reflection_lm: LanguageModel | str | None = "openai/gpt-5.1"
     reflection_prompt_template: str | dict[str, str] | None = optimize_anything_reflection_prompt_template
     custom_candidate_proposer: ProposalFn | None = None
+    proposal_mode: Literal["rewrite", "edit", "crossover"] = "rewrite"
 
 
 @dataclass
@@ -1417,6 +1418,7 @@ def optimize_anything(
         reflection_lm=config.reflection.reflection_lm,
         reflection_prompt_template=config.reflection.reflection_prompt_template,
         custom_candidate_proposer=config.reflection.custom_candidate_proposer,
+        proposal_mode=config.reflection.proposal_mode,
     )
 
     # Define evaluator function for merge proposer

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
 # https://github.com/gepa-ai/gepa
 
+import random
 from collections.abc import Mapping, Sequence
 from typing import Any
 
@@ -26,7 +27,7 @@ from gepa.proposer.reflective_mutation.base import (
     ReflectionComponentSelector,
 )
 from gepa.strategies.batch_sampler import BatchSampler
-from gepa.strategies.instruction_proposal import InstructionProposalSignature
+from gepa.strategies.instruction_proposal import InstructionCrossoverSignature, InstructionProposalSignature
 
 
 class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
@@ -56,6 +57,7 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
         reflection_prompt_template: str | dict[str, str] | None = None,
         custom_candidate_proposer: ProposalFn | None = None,
         callbacks: list[GEPACallback] | None = None,
+        proposal_mode: str = "rewrite",
     ):
         self.logger = logger
         self.trainset = ensure_loader(trainset)
@@ -69,6 +71,7 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
         self.reflection_lm = reflection_lm
         self.custom_candidate_proposer = custom_candidate_proposer
         self.callbacks = callbacks
+        self.proposal_mode = proposal_mode
 
         self.reflection_prompt_template = reflection_prompt_template
         # Track parameters for which we've already logged missing template warnings
@@ -91,6 +94,7 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
         candidate: dict[str, str],
         reflective_dataset: Mapping[str, Sequence[Mapping[str, Any]]],
         components_to_update: list[str],
+        donor_candidate: dict[str, str] | None = None,
     ) -> dict[str, str]:
         if self.adapter.propose_new_texts is not None:
             return self.adapter.propose_new_texts(candidate, reflective_dataset, components_to_update)
@@ -125,14 +129,26 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
                 # Use the single template for all parameters
                 prompt_template = self.reflection_prompt_template
 
-            new_texts[name] = InstructionProposalSignature.run(
-                lm=self.reflection_lm,
-                input_dict={
+            if self.proposal_mode == "crossover" and donor_candidate is not None:
+                input_dict: dict[str, Any] = {
                     "current_instruction_doc": base_instruction,
+                    "donor_instruction_doc": donor_candidate.get(name, ""),
                     "dataset_with_feedback": dataset_with_feedback,
                     "prompt_template": prompt_template,
-                },
-            )["new_instruction"]
+                }
+                new_texts[name] = InstructionCrossoverSignature.run(
+                    lm=self.reflection_lm,
+                    input_dict=input_dict,
+                )["new_instruction"]
+            else:
+                new_texts[name] = InstructionProposalSignature.run(
+                    lm=self.reflection_lm,
+                    input_dict={
+                        "current_instruction_doc": base_instruction,
+                        "dataset_with_feedback": dataset_with_feedback,
+                        "prompt_template": prompt_template,
+                    },
+                )["new_instruction"]
         return new_texts
 
     def propose(self, state: GEPAState) -> CandidateProposal | None:
@@ -296,7 +312,17 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
                 ),
             )
 
-            new_texts = self.propose_new_texts(curr_prog, reflective_dataset, predictor_names_to_update)
+            # For crossover, select a donor candidate different from the current one
+            donor_candidate: dict[str, str] | None = None
+            if self.proposal_mode == "crossover" and len(state.program_candidates) > 1:
+                other_ids = [j for j in range(len(state.program_candidates)) if j != curr_prog_id]
+                donor_id = random.choice(other_ids)
+                donor_candidate = state.program_candidates[donor_id]
+                self.logger.log(f"Iteration {i}: Crossover donor candidate: {donor_id}")
+
+            new_texts = self.propose_new_texts(
+                curr_prog, reflective_dataset, predictor_names_to_update, donor_candidate=donor_candidate
+            )
 
             # Notify proposal end
             notify_callbacks(
@@ -307,7 +333,6 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
                     new_instructions=new_texts,
                 ),
             )
-
 
             for pname, text in new_texts.items():
                 self.logger.log(f"Iteration {i}: Proposed new text for {pname}: {text}")

--- a/src/gepa/strategies/instruction_proposal.py
+++ b/src/gepa/strategies/instruction_proposal.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any, ClassVar
 
 from gepa.image import Image
-from gepa.proposer.reflective_mutation.base import Signature
+from gepa.proposer.reflective_mutation.base import LanguageModel, Signature
 
 
 class InstructionProposalSignature(Signature):
@@ -151,3 +151,86 @@ Provide the new instructions within ``` blocks."""
             return content.strip()
 
         return {"new_instruction": extract_instruction_text()}
+
+
+class InstructionCrossoverSignature(InstructionProposalSignature):
+    """Combines two parent candidates into a new one by asking the LLM to
+    take the best parts of both.
+
+    Requires an additional ``donor_instruction_doc`` key in the input dict
+    containing the text of the second parent candidate.  Uses the same
+    ``<curr_param>`` / ``<side_info>`` placeholders as the base class, plus
+    ``<donor_param>`` for the second parent.
+    """
+
+    default_prompt_template = """I provided an assistant with the following instructions to perform a task for me:
+
+## Candidate A (primary)
+```
+<curr_param>
+```
+
+## Candidate B (donor)
+```
+<donor_param>
+```
+
+The following are examples of different task inputs provided to the assistant along with the assistant's response for each of them, and some feedback on how the assistant's response could be better:
+```
+<side_info>
+```
+
+Your task is to combine the best parts of Candidate A and Candidate B into a single, improved instruction for the assistant.
+
+Identify what each candidate does well and where each falls short based on the feedback. Merge the strengths of both candidates while avoiding their weaknesses. Preserve any domain-specific factual information or effective strategies from either candidate.
+
+Provide the new combined instruction within ``` blocks."""
+
+    input_keys: ClassVar[list[str]] = [
+        "current_instruction_doc",
+        "donor_instruction_doc",
+        "dataset_with_feedback",
+        "prompt_template",
+    ]
+
+    @classmethod
+    def validate_prompt_template(cls, prompt_template: str | None) -> None:
+        if prompt_template is None:
+            return
+        missing_placeholders = [
+            placeholder
+            for placeholder in ("<curr_param>", "<donor_param>", "<side_info>")
+            if placeholder not in prompt_template
+        ]
+        if missing_placeholders:
+            raise ValueError(f"Missing placeholder(s) in prompt template: {', '.join(missing_placeholders)}")
+
+    @classmethod
+    def prompt_renderer(cls, input_dict: Mapping[str, Any]) -> str | list[dict[str, Any]]:
+        donor_instruction = input_dict.get("donor_instruction_doc")
+        if not isinstance(donor_instruction, str):
+            raise TypeError("donor_instruction_doc must be a string")
+
+        # Build the base prompt (handles curr_param, side_info, images)
+        base_result = super().prompt_renderer(input_dict)
+
+        # Substitute the donor placeholder
+        if isinstance(base_result, str):
+            return base_result.replace("<donor_param>", donor_instruction)
+        else:
+            # Multimodal messages list — replace in the text content part
+            for msg in base_result:
+                if isinstance(msg.get("content"), list):
+                    for part in msg["content"]:
+                        if part.get("type") == "text":
+                            part["text"] = part["text"].replace("<donor_param>", donor_instruction)
+                elif isinstance(msg.get("content"), str):
+                    msg["content"] = msg["content"].replace("<donor_param>", donor_instruction)
+            return base_result
+
+    @classmethod
+    def run(cls, lm: LanguageModel, input_dict: Mapping[str, Any]) -> dict[str, str]:
+        full_prompt = cls.prompt_renderer(input_dict)
+        lm_res = lm(full_prompt)
+        lm_out = lm_res.strip()
+        return cls.output_extractor(lm_out)

--- a/tests/test_instruction_proposal.py
+++ b/tests/test_instruction_proposal.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from gepa.strategies.instruction_proposal import InstructionProposalSignature
+from gepa.strategies.instruction_proposal import InstructionCrossoverSignature, InstructionProposalSignature
 
 
 class TestInstructionProposalSignature:
@@ -100,3 +100,53 @@ I hope you didn't get confused.
         """Test extraction of instructions from various code block formats."""
         result = InstructionProposalSignature.output_extractor(lm_output)
         assert result["new_instruction"] == expected_instruction
+
+
+class TestInstructionCrossoverSignature:
+    """Test InstructionCrossoverSignature."""
+
+    def test_prompt_includes_both_candidates(self):
+        """Test that the prompt renderer includes both primary and donor candidates."""
+        input_dict = {
+            "current_instruction_doc": "Primary instruction text",
+            "donor_instruction_doc": "Donor instruction text",
+            "dataset_with_feedback": [{"input": "test", "output": "result", "feedback": "good"}],
+            "prompt_template": None,
+        }
+        prompt = InstructionCrossoverSignature.prompt_renderer(input_dict)
+        assert isinstance(prompt, str)
+        assert "Primary instruction text" in prompt
+        assert "Donor instruction text" in prompt
+
+    def test_run_produces_merged_output(self):
+        """Test full run() with a mock LM."""
+        calls = []
+
+        def mock_lm(prompt):
+            calls.append(prompt)
+            return "```\nMerged instruction combining the best of both.\n```"
+
+        result = InstructionCrossoverSignature.run(
+            lm=mock_lm,
+            input_dict={
+                "current_instruction_doc": "Candidate A text",
+                "donor_instruction_doc": "Candidate B text",
+                "dataset_with_feedback": [{"input": "x", "output": "y", "feedback": "combine"}],
+                "prompt_template": None,
+            },
+        )
+        assert result["new_instruction"] == "Merged instruction combining the best of both."
+        assert len(calls) == 1
+        assert "Candidate A" in calls[0]
+        assert "Candidate B" in calls[0]
+
+    def test_validate_prompt_template_requires_donor(self):
+        """Test that custom templates must include <donor_param>."""
+        with pytest.raises(ValueError, match="donor_param"):
+            InstructionCrossoverSignature.validate_prompt_template(
+                "Only has <curr_param> and <side_info>"
+            )
+
+    def test_validate_prompt_template_none_is_ok(self):
+        """Test that None template (use default) passes validation."""
+        InstructionCrossoverSignature.validate_prompt_template(None)


### PR DESCRIPTION
## Summary

- Adds `InstructionCrossoverSignature` that combines two parent candidates by asking the LLM to merge the best parts of both
- New `proposal_mode="crossover"` option alongside existing `"rewrite"` and `"edit"`
- In crossover mode, the proposer randomly selects a donor candidate from the population and passes both to the LLM
- Falls back to standard rewrite when only one candidate exists (e.g., first iteration)
- Wired through `api.py` and `optimize_anything.py`

Inspired by ShinkaEvolve's crossover operator (10% of their mutations), adapted for GEPA's architecture where candidates are text components rather than code files.

Closes #238 (partial — crossover mode)

## Test plan

- [x] New tests for `InstructionCrossoverSignature` (prompt rendering, full run, template validation)
- [x] Existing `InstructionProposalSignature` tests still pass
- [x] `ruff check` and `ruff format` pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)