### PR TITLE
feat: thread-safe EvaluationCache, enable caching by default

### DIFF
--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -80,7 +80,7 @@ def optimize(
     display_progress_bar: bool = False,
     use_cloudpickle: bool = False,
     # Evaluation caching
-    cache_evaluation: bool = False,
+    cache_evaluation: bool = True,
     # Reproducibility
     seed: int = 0,
     raise_on_exception: bool = True,
@@ -168,7 +168,7 @@ def optimize(
     - use_cloudpickle: Use cloudpickle instead of pickle. This can be helpful when the serialized state contains dynamically generated DSPy signatures.
 
     # Evaluation caching
-    - cache_evaluation: Whether to cache the (score, output, objective_scores) of (candidate, example) pairs. If True and a cache entry exists, GEPA will skip the fitness evaluation and use the cached results. This helps avoid redundant evaluations and saves metric calls. Defaults to False.
+    - cache_evaluation: Whether to cache the (score, output, objective_scores) of (candidate, example) pairs. If True and a cache entry exists, GEPA will skip the fitness evaluation and use the cached results. This helps avoid redundant evaluations and saves metric calls. The cache is thread-safe. Defaults to True.
 
     # Reproducibility
     - seed: The seed to use for the random number generator.

--- a/src/gepa/core/state.py
+++ b/src/gepa/core/state.py
@@ -4,6 +4,7 @@
 import hashlib
 import json
 import os
+import threading
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
@@ -44,13 +45,30 @@ class CachedEvaluation(Generic[RolloutOutput]):
 
 @dataclass
 class EvaluationCache(Generic[RolloutOutput, DataId]):
-    """Cache for storing evaluation results of (candidate, example) pairs."""
+    """Thread-safe cache for storing evaluation results of (candidate, example) pairs.
+
+    All public methods are safe to call from multiple threads concurrently.
+    The lock is held only for dict reads/writes, never during evaluator calls,
+    so long-running evaluations do not block cache lookups.
+    """
 
     _cache: dict[CacheKey, CachedEvaluation[RolloutOutput]] = field(default_factory=dict)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False, compare=False)
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Exclude the non-picklable lock when serializing."""
+        return {"_cache": self._cache}
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Restore the lock when deserializing."""
+        self._cache = state["_cache"]
+        self._lock = threading.Lock()
 
     def get(self, candidate: dict[str, str], example_id: DataId) -> CachedEvaluation[RolloutOutput] | None:
         """Retrieve cached evaluation result if it exists."""
-        return self._cache.get((_candidate_hash(candidate), example_id))
+        key = (_candidate_hash(candidate), example_id)
+        with self._lock:
+            return self._cache.get(key)
 
     def put(
         self,
@@ -61,19 +79,24 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         objective_scores: ObjectiveScores | None = None,
     ) -> None:
         """Store an evaluation result in the cache."""
-        self._cache[(_candidate_hash(candidate), example_id)] = CachedEvaluation(output, score, objective_scores)
+        key = (_candidate_hash(candidate), example_id)
+        entry = CachedEvaluation(output, score, objective_scores)
+        with self._lock:
+            self._cache[key] = entry
 
     def get_batch(
         self, candidate: dict[str, str], example_ids: list[DataId]
     ) -> tuple[dict[DataId, CachedEvaluation[RolloutOutput]], list[DataId]]:
         """Look up cached results for a batch. Returns (cached_results, uncached_ids)."""
         h = _candidate_hash(candidate)
-        cached, uncached = {}, []
-        for eid in example_ids:
-            if entry := self._cache.get((h, eid)):
-                cached[eid] = entry
-            else:
-                uncached.append(eid)
+        cached: dict[DataId, CachedEvaluation[RolloutOutput]] = {}
+        uncached: list[DataId] = []
+        with self._lock:
+            for eid in example_ids:
+                if entry := self._cache.get((h, eid)):
+                    cached[eid] = entry
+                else:
+                    uncached.append(eid)
         return cached, uncached
 
     def put_batch(
@@ -86,10 +109,18 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
     ) -> None:
         """Store evaluation results for a batch of examples."""
         h = _candidate_hash(candidate)
-        for i, eid in enumerate(example_ids):
-            self._cache[(h, eid)] = CachedEvaluation(
-                outputs[i], scores[i], objective_scores_list[i] if objective_scores_list else None
+        entries = [
+            (
+                (h, eid),
+                CachedEvaluation(
+                    outputs[i], scores[i], objective_scores_list[i] if objective_scores_list else None
+                ),
             )
+            for i, eid in enumerate(example_ids)
+        ]
+        with self._lock:
+            for key, entry in entries:
+                self._cache[key] = entry
 
     def evaluate_with_cache_full(
         self,
@@ -98,8 +129,10 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         fetcher: Callable[[list[DataId]], Any],
         evaluator: Callable[[Any, dict[str, str]], tuple[Any, list[float], Sequence[ObjectiveScores] | None]],
     ) -> tuple[dict[DataId, RolloutOutput], dict[DataId, float], dict[DataId, ObjectiveScores] | None, int]:
-        """
-        Evaluate using cache, returning full results.
+        """Evaluate using cache, returning full results.
+
+        Only uncached examples are passed through the evaluator; cached results
+        are returned directly.  The lock is NOT held during the evaluator call.
 
         Returns (outputs_by_id, scores_by_id, objective_scores_by_id, num_actual_evals).
         """
@@ -115,7 +148,7 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
                 objective_by_id = objective_by_id or {}
                 objective_by_id[eid] = c.objective_scores
 
-        # Evaluate uncached examples
+        # Evaluate uncached examples (lock NOT held here)
         if uncached_ids:
             batch = fetcher(uncached_ids)
             outputs, scores, obj_scores = evaluator(batch, candidate)

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -477,7 +477,7 @@ class EngineConfig:
     max_workers: int | None = field(default_factory=lambda: os.cpu_count() or 32)
 
     # Evaluation caching
-    cache_evaluation: bool = False
+    cache_evaluation: bool = True
     cache_evaluation_storage: CacheEvaluationStorage = "auto"
 
     # Track top-K best evaluations per example, passed to evaluator via OptimizationState

--- a/tests/test_aime_prompt_optimization/test_aime_prompt_optimize.py
+++ b/tests/test_aime_prompt_optimization/test_aime_prompt_optimize.py
@@ -47,6 +47,7 @@ def test_aime_prompt_optimize(mocked_lms, recorder_dir):
         max_metric_calls=30,  # Can be reduced to 17
         reflection_lm=reflection_lm,
         display_progress_bar=True,
+        cache_evaluation=False,
     )
 
     # 3. Assertion: Verify the result against the golden file

--- a/tests/test_callbacks_integration/test_callbacks_with_optimization.py
+++ b/tests/test_callbacks_integration/test_callbacks_with_optimization.py
@@ -147,6 +147,7 @@ def test_callbacks_during_optimization(mocked_lms, recorder_dir):
         reflection_lm=reflection_lm,
         display_progress_bar=True,
         callbacks=[callback],
+        cache_evaluation=False,
     )
 
     # 3. Assertions: Verify callbacks were invoked correctly
@@ -301,6 +302,7 @@ def test_multiple_callbacks_all_receive_events(mocked_lms, recorder_dir):
         max_metric_calls=30,
         reflection_lm=reflection_lm,
         callbacks=[callback1, callback2],
+        cache_evaluation=False,
     )
 
     # Both callbacks should have received the same events
@@ -359,6 +361,7 @@ def test_partial_callback_implementation(mocked_lms, recorder_dir):
         max_metric_calls=30,
         reflection_lm=reflection_lm,
         callbacks=[callback],
+        cache_evaluation=False,
     )
 
     assert len(callback.iterations) >= 1, "partial callback should receive iteration events"

--- a/tests/test_evaluation_cache.py
+++ b/tests/test_evaluation_cache.py
@@ -69,6 +69,117 @@ class TestEvaluationCache:
         assert cache.get(candidate, "ex2").objective_scores == {"acc": 0.8}
 
 
+class TestEvaluationCacheThreadSafety:
+    """Tests for thread safety of EvaluationCache."""
+
+    def test_concurrent_put_and_get(self):
+        """Concurrent puts from multiple threads should not lose data."""
+        import threading
+
+        cache: EvaluationCache = EvaluationCache()
+        candidate = {"prompt": "test"}
+        num_threads = 8
+        items_per_thread = 100
+        barrier = threading.Barrier(num_threads)
+
+        def writer(thread_id: int):
+            barrier.wait()
+            for j in range(items_per_thread):
+                eid = f"t{thread_id}_ex{j}"
+                cache.put(candidate, eid, f"out_{thread_id}_{j}", float(j))
+
+        threads = [threading.Thread(target=writer, args=(t,)) for t in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Every entry should be present
+        for t in range(num_threads):
+            for j in range(items_per_thread):
+                result = cache.get(candidate, f"t{t}_ex{j}")
+                assert result is not None, f"Missing entry t{t}_ex{j}"
+                assert result.score == float(j)
+
+    def test_concurrent_put_batch_and_get_batch(self):
+        """Concurrent put_batch and get_batch should not corrupt data."""
+        import threading
+
+        cache: EvaluationCache = EvaluationCache()
+        num_threads = 4
+        batch_size = 50
+        barrier = threading.Barrier(num_threads)
+
+        def writer(thread_id: int):
+            candidate = {"prompt": f"candidate_{thread_id}"}
+            eids = [f"ex_{j}" for j in range(batch_size)]
+            outputs = [f"out_{thread_id}_{j}" for j in range(batch_size)]
+            scores = [float(j) for j in range(batch_size)]
+            barrier.wait()
+            cache.put_batch(candidate, eids, outputs, scores)
+
+        threads = [threading.Thread(target=writer, args=(t,)) for t in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Verify all batches are retrievable
+        for t in range(num_threads):
+            candidate = {"prompt": f"candidate_{t}"}
+            cached, uncached = cache.get_batch(candidate, [f"ex_{j}" for j in range(batch_size)])
+            assert len(cached) == batch_size
+            assert len(uncached) == 0
+
+    def test_concurrent_evaluate_with_cache_full(self):
+        """evaluate_with_cache_full should work correctly under concurrent access."""
+        import threading
+
+        cache: EvaluationCache = EvaluationCache()
+        candidate = {"prompt": "shared"}
+        call_count = 0
+        count_lock = threading.Lock()
+
+        def fetcher(ids):
+            return [{"id": eid} for eid in ids]
+
+        def evaluator(batch, cand):
+            nonlocal call_count
+            with count_lock:
+                call_count += len(batch)
+            outputs = [f"out_{b['id']}" for b in batch]
+            scores = [1.0] * len(batch)
+            return outputs, scores, None
+
+        # Pre-populate half the cache
+        cache.put_batch(candidate, ["ex_0", "ex_1"], ["out_ex_0", "out_ex_1"], [1.0, 1.0])
+
+        barrier = threading.Barrier(4)
+        results = [None] * 4
+
+        def worker(idx):
+            barrier.wait()
+            results[idx] = cache.evaluate_with_cache_full(
+                candidate, ["ex_0", "ex_1", "ex_2", "ex_3"], fetcher, evaluator
+            )
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # All workers should return all 4 results
+        for r in results:
+            outputs_by_id, scores_by_id, _, _ = r
+            assert len(outputs_by_id) == 4
+            assert len(scores_by_id) == 4
+
+        # ex_0 and ex_1 were pre-cached, so evaluator should only be called for ex_2 and ex_3
+        # (possibly multiple times since threads race on the uncached portion)
+        assert call_count >= 2  # At least one thread evaluated the uncached ones
+
+
 class TestEvaluationCacheIntegration:
     """Integration tests for evaluation cache with optimize function."""
 

--- a/tests/test_incremental_eval_policy.py
+++ b/tests/test_incremental_eval_policy.py
@@ -126,6 +126,7 @@ def test_incremental_eval_policy_handles_dynamic_valset(tmp_path):
         max_metric_calls=12,
         run_dir=str(tmp_path / "run"),
         val_evaluation_policy=RoundRobinSampleEvaluationPolicy(batch_size=2),
+        cache_evaluation=False,
     )
 
     assert val_loader.expansions == 1

--- a/tests/test_pareto_frontier_types/test_pareto_frontier_types.py
+++ b/tests/test_pareto_frontier_types/test_pareto_frontier_types.py
@@ -107,6 +107,7 @@ def test_pareto_frontier_type(mocked_lms, recorder_dir, frontier_type):
         max_metric_calls=32,
         reflection_minibatch_size=3,
         display_progress_bar=False,
+        cache_evaluation=False,
     )
     assert gepa_result.total_metric_calls in [36, 48]
 

--- a/tests/test_rag_adapter/test_rag_end_to_end.py
+++ b/tests/test_rag_adapter/test_rag_end_to_end.py
@@ -314,6 +314,7 @@ def test_rag_end_to_end_optimization(sample_ai_ml_dataset, mock_chromadb_store):
         max_metric_calls=5,  # Small number for fast testing
         reflection_lm=simple_reflection_lm,
         display_progress_bar=True,
+        cache_evaluation=False,
     )
 
     # 3. Assertions: Verify the optimization completed successfully
@@ -409,6 +410,7 @@ def test_rag_end_to_end_optimization(sample_ai_ml_dataset, mock_chromadb_store):
         max_metric_calls=5,
         reflection_lm=simple_reflection_lm,
         display_progress_bar=False,  # Disable progress bar for cleaner test output
+        cache_evaluation=False,
     )
 
     # Results should be identical due to deterministic mocks
@@ -506,6 +508,7 @@ def test_rag_dynamic_valset_round_robin_sample(sample_ai_ml_dataset, mock_chroma
         max_metric_calls=15,
         val_evaluation_policy=RoundRobinSampleEvaluationPolicy(batch_size=1),
         run_dir=str(tmp_path / "dynamic_val_run"),
+        cache_evaluation=False,
     )
 
     assert val_loader.num_unlocked_stages >= 2
@@ -532,6 +535,7 @@ def test_rag_dynamic_valset_round_robin_sample(sample_ai_ml_dataset, mock_chroma
         max_metric_calls=12,
         val_evaluation_policy=RoundRobinSampleEvaluationPolicy(batch_size=1),
         run_dir=str(tmp_path / "dynamic_val_run_stage2"),
+        cache_evaluation=False,
     )
 
     assert val_loader.num_unlocked_stages == 3

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -306,6 +306,7 @@ def test_e2e_resume_run(mocked_lms, run_dir):
         reflection_lm=reflection_lm,
         display_progress_bar=True,
         run_dir=run_dir,
+        cache_evaluation=False,
     )
 
     # Resume from the same run_dir. Even if called with `max_metric_calls=0`,
@@ -319,5 +320,6 @@ def test_e2e_resume_run(mocked_lms, run_dir):
         reflection_lm=reflection_lm,
         display_progress_bar=True,
         run_dir=run_dir,
+        cache_evaluation=False,
     )
     assert second_run.total_metric_calls == first_run.total_metric_calls


### PR DESCRIPTION
## Summary

- Makes `EvaluationCache` thread-safe by adding a `threading.Lock` — the lock is held only during dict reads/writes, never during evaluator calls, so long-running evaluations don't block cache lookups
- Adds `__getstate__`/`__setstate__` for pickle compatibility (Lock excluded from serialization, recreated on deserialization)
- Changes `cache_evaluation` default from `False` to `True` in both `optimize()` and `optimize_anything()` — caching avoids redundant `(candidate, example)` evaluations and saves metric calls
- Adds 3 thread-safety tests covering concurrent `put`/`get`, concurrent `put_batch`/`get_batch`, and concurrent `evaluate_with_cache_full`

Closes #4

## Test plan
- [x] All 347 tests pass (3 new thread-safety tests added)
- [x] pyright: 0 errors
- [x] ruff: clean
- [x] Replay-based tests pinned to `cache_evaluation=False` to preserve recorded LM call sequences

🤖 Generated with [Claude Code](https://claude.com/claude-code)