### PR TITLE
docs: rewrite callbacks guide with full event reference and cookbook

### DIFF
--- a/docs/docs/guides/callbacks.md
+++ b/docs/docs/guides/callbacks.md
@@ -2,8 +2,13 @@
 
 GEPA provides a callback system for observing and instrumenting optimization runs.  Callbacks receive events at every stage of the loop — you can log custom metrics, stream results to external systems, add dynamic training data, inspect every LM call, or implement domain-specific monitoring.
 
-!!! note "Observational only"
-    Callbacks are **read-only observers**.  They receive a snapshot of the current state but cannot modify it.  Exceptions in callbacks are caught, logged as warnings, and never crash the optimization.
+!!! note "Mostly observational, with sanctioned mutation points"
+    Callbacks receive the **live** optimization state, not a copy.  Most events are intended for observation only, but a few fields are explicitly designed to support mutation:
+
+    - `event["trainset_loader"]` in `on_iteration_start` — call `.add_items()` to grow the training set mid-run (see [Dynamic training data](#5-dynamic-training-data-add-examples-mid-run) below).
+
+    Mutating `event["state"]` or other fields directly outside these sanctioned patterns is unsupported and may cause undefined behaviour.
+    Exceptions in callbacks are caught, logged as warnings, and never crash the optimization.
 
 ---
 


### PR DESCRIPTION
## Summary

Rewrites the callbacks guide from a brief overview into a comprehensive reference and cookbook.

### What's new

**Complete event reference** — all 21 event types with key fields, organized by category (lifecycle, candidate, evaluation, reflection, merge, state/budget).

**9 cookbook recipes:**
1. Live progress display
2. Inspect every LM call — prompt + raw response via `on_proposal_end`
3. Link accepted `candidate_idx` to the LM call that produced it
4. Stream every accepted prompt to a JSONL file
5. Dynamic training data — add hard examples mid-run via `trainset_loader`
6. Budget-aware early stopping
7. Slack / webhook notifications
8. Per-example output collection
9. Error monitoring

**Other additions:**
- `CompositeCallback` usage + runtime `add()`
- `GEPAState` field reference for `on_iteration_*` handlers
- Tips section (fast callbacks, exception handling, `on_proposal_end` as the observability window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)