### PR TITLE
feat: default track_best_outputs to True

### DIFF
--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -76,7 +76,7 @@ def optimize(
     use_mlflow: bool = False,
     mlflow_tracking_uri: str | None = None,
     mlflow_experiment_name: str | None = None,
-    track_best_outputs: bool = False,
+    track_best_outputs: bool = True,
     display_progress_bar: bool = False,
     use_cloudpickle: bool = False,
     # Evaluation caching

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -459,7 +459,7 @@ class EngineConfig:
     display_progress_bar: bool = False
     raise_on_exception: bool = True
     use_cloudpickle: bool = True
-    track_best_outputs: bool = False
+    track_best_outputs: bool = True
 
     # Simple stopping conditions
     max_metric_calls: int | None = None


### PR DESCRIPTION
Changes the default for `track_best_outputs` from `False` to `True` in both `EngineConfig` and `gepa.optimize()`.

Users now get `result.best_outputs_valset` populated by default — the best outputs obtained for each validation example across all candidates. Previously this required explicitly passing `track_best_outputs=True`.

No behavioral change for users who already set it explicitly.

## Files changed
- `src/gepa/optimize_anything.py` — `EngineConfig.track_best_outputs` default
- `src/gepa/api.py` — `optimize()` parameter default

🤖 Generated with [Claude Code](https://claude.com/claude-code)