### PR TITLE
feat: add GEPACallback support to optimize_anything

### DIFF
--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -123,6 +123,7 @@ from typing import (
 
 from gepa.adapters.optimize_anything_adapter.optimize_anything_adapter import OptimizeAnythingAdapter
 from gepa.core.adapter import DataInst, GEPAAdapter, ProposalFn
+from gepa.core.callbacks import GEPACallback
 from gepa.core.data_loader import ensure_loader
 from gepa.core.engine import GEPAEngine
 from gepa.core.result import GEPAResult
@@ -818,6 +819,24 @@ class GEPAConfig:
 
     # Complex callbacks that aren't serializable
     stop_callbacks: StopperProtocol | Sequence[StopperProtocol] | None = None
+    callbacks: "list[GEPACallback] | None" = None
+    """Observation callbacks for monitoring optimization progress.
+
+    Receive events like ``on_optimization_start``, ``on_iteration_end``,
+    ``on_candidate_accepted``, ``on_proposal_end``, etc.  See
+    :class:`~gepa.core.callbacks.GEPACallback` for the full protocol.
+
+    Example::
+
+        class MyCallback:
+            def on_candidate_accepted(self, event):
+                print(f"New candidate {event['new_candidate_idx']} accepted")
+
+        config = GEPAConfig(
+            callbacks=[MyCallback()],
+            engine=EngineConfig(max_metric_calls=100),
+        )
+    """
 
     def __post_init__(self):
         """Handle dicts passed in (e.g., from a JSON/YAML file)."""
@@ -1421,6 +1440,7 @@ def optimize_anything(
         reflection_lm=config.reflection.reflection_lm,
         reflection_prompt_template=config.reflection.reflection_prompt_template,
         custom_candidate_proposer=config.reflection.custom_candidate_proposer,
+        callbacks=config.callbacks,
     )
 
     # Define evaluator function for merge proposer
@@ -1461,6 +1481,7 @@ def optimize_anything(
         frontier_type=config.engine.frontier_type,
         logger=config.tracking.logger,
         experiment_tracker=experiment_tracker,
+        callbacks=config.callbacks,
         track_best_outputs=config.engine.track_best_outputs,
         display_progress_bar=config.engine.display_progress_bar,
         raise_on_exception=config.engine.raise_on_exception,

--- a/tests/test_optimize_anything_callbacks.py
+++ b/tests/test_optimize_anything_callbacks.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""Tests for GEPACallback support in optimize_anything."""
+
+from unittest.mock import MagicMock
+
+from gepa.optimize_anything import (
+    GEPAConfig,
+    EngineConfig,
+    ReflectionConfig,
+    optimize_anything,
+)
+
+
+def _good_evaluator(candidate):
+    return 0.5, {}
+
+
+def _mock_lm(prompt):
+    return "```\ncandidate\n```"
+
+
+class TestOptimizeAnythingCallbacks:
+    def test_callbacks_receive_events(self):
+        """Callbacks passed via GEPAConfig receive optimization events."""
+        events_received: list[str] = []
+
+        class Recorder:
+            def on_optimization_start(self, event):
+                events_received.append("optimization_start")
+
+            def on_iteration_start(self, event):
+                events_received.append("iteration_start")
+
+            def on_iteration_end(self, event):
+                events_received.append("iteration_end")
+
+            def on_optimization_end(self, event):
+                events_received.append("optimization_end")
+
+        result = optimize_anything(
+            seed_candidate="x",
+            evaluator=_good_evaluator,
+            config=GEPAConfig(
+                callbacks=[Recorder()],
+                engine=EngineConfig(max_metric_calls=5),
+                reflection=ReflectionConfig(reflection_lm=_mock_lm),
+            ),
+        )
+
+        assert result is not None
+        assert "optimization_start" in events_received
+        assert "iteration_start" in events_received
+        assert "iteration_end" in events_received
+        assert "optimization_end" in events_received
+
+    def test_multiple_callbacks(self):
+        """Multiple callbacks all receive events."""
+        counts = [0, 0]
+
+        class Counter1:
+            def on_iteration_end(self, event):
+                counts[0] += 1
+
+        class Counter2:
+            def on_iteration_end(self, event):
+                counts[1] += 1
+
+        optimize_anything(
+            seed_candidate="x",
+            evaluator=_good_evaluator,
+            config=GEPAConfig(
+                callbacks=[Counter1(), Counter2()],
+                engine=EngineConfig(max_metric_calls=5),
+                reflection=ReflectionConfig(reflection_lm=_mock_lm),
+            ),
+        )
+
+        assert counts[0] > 0
+        assert counts[0] == counts[1]
+
+    def test_no_callbacks_default(self):
+        """Without callbacks, optimization still works."""
+        result = optimize_anything(
+            seed_candidate="x",
+            evaluator=_good_evaluator,
+            config=GEPAConfig(
+                engine=EngineConfig(max_metric_calls=3),
+                reflection=ReflectionConfig(reflection_lm=_mock_lm),
+            ),
+        )
+        assert result is not None
+
+    def test_proposal_events_received(self):
+        """Callbacks receive on_proposal_start and on_proposal_end events."""
+        events: list[str] = []
+
+        class ProposalRecorder:
+            def on_proposal_start(self, event):
+                events.append("proposal_start")
+
+            def on_proposal_end(self, event):
+                events.append("proposal_end")
+
+        optimize_anything(
+            seed_candidate="x",
+            evaluator=_good_evaluator,
+            config=GEPAConfig(
+                callbacks=[ProposalRecorder()],
+                engine=EngineConfig(max_metric_calls=5),
+                reflection=ReflectionConfig(reflection_lm=_mock_lm),
+            ),
+        )
+
+        assert "proposal_start" in events
+        assert "proposal_end" in events


### PR DESCRIPTION
## Problem

`optimize_anything()` had no way to pass observation callbacks. Only `gepa.optimize()` accepted the `callbacks` parameter. Users of `optimize_anything` couldn't observe events like `on_iteration_start`, `on_candidate_accepted`, `on_proposal_end`, etc.

## Fix

Add `callbacks` field to `GEPAConfig`, wire it to both the `ReflectiveMutationProposer` (proposal events) and `GEPAEngine` (lifecycle, iteration, candidate, evaluation events).

```python
class MyCallback:
    def on_candidate_accepted(self, event):
        print(f"Accepted candidate {event['new_candidate_idx']}")

result = optimize_anything(
    seed_candidate="...",
    evaluator=my_eval,
    config=GEPAConfig(
        callbacks=[MyCallback()],
        engine=EngineConfig(max_metric_calls=100),
    ),
)
```

## Test plan
- [x] 4 new tests: events received, multiple callbacks, no callbacks default, proposal events
- [x] 374 total tests pass
- [x] pyright: 0 errors, ruff: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)