### PR TITLE
docs: replace patience with max_iterations_without_improvement

### DIFF
--- a/docs/docs/guides/faq.md
+++ b/docs/docs/guides/faq.md
@@ -85,7 +85,7 @@ config = GEPAConfig(
     engine=EngineConfig(max_metric_calls=200),
     stop_callbacks=[
         TimeoutStopCondition(seconds=3600),
-        NoImprovementStopper(patience=10),
+        NoImprovementStopper(max_iterations_without_improvement=10),
     ],
 )
 ```

--- a/docs/docs/guides/quickstart.md
+++ b/docs/docs/guides/quickstart.md
@@ -188,7 +188,7 @@ result = gepa.optimize(
     max_metric_calls=100,                          # Stop after 100 evaluations
     stop_callbacks=[
         TimeoutStopCondition(seconds=3600),        # Or after 1 hour
-        NoImprovementStopper(patience=10),         # Or after 10 iterations without improvement
+        NoImprovementStopper(max_iterations_without_improvement=10),         # Or after 10 iterations without improvement
     ],
 )
 ```


### PR DESCRIPTION
This PR corrects a terminology inconsistency in the documentation. The term `patience` was being used to describe the early stopping criteria, but the actual parameter implemented in the codebase is `max_iterations_without_improvement`.

Changes:
- Documentation Updates: Replaced all instances of `patience` with `max_iterations_without_improvement` in the API references and usage guides.

- Clarity: Ensures the documentation aligns perfectly with the function signatures to prevent user confusion.