### PR TITLE
feat: add mutation_rate parameter to control mutation magnitude

### DIFF
--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -187,6 +187,10 @@ def optimize(
     if seed_candidate is None or not seed_candidate:
         raise ValueError("seed_candidate must contain at least one component text.")
 
+    # Validate mutation_rate
+    if not 0.0 <= mutation_rate <= 1.0:
+        raise ValueError(f"mutation_rate must be between 0.0 and 1.0, got {mutation_rate}")
+
     active_adapter: GEPAAdapter[DataInst, Trajectory, RolloutOutput] | None = None
     if adapter is None:
         assert task_lm is not None, (
@@ -350,10 +354,6 @@ def optimize(
     evaluation_cache: EvaluationCache[RolloutOutput, DataId] | None = None
     if cache_evaluation:
         evaluation_cache = EvaluationCache[RolloutOutput, DataId]()
-
-    # Validate mutation_rate
-    if not 0.0 <= mutation_rate <= 1.0:
-        raise ValueError(f"mutation_rate must be between 0.0 and 1.0, got {mutation_rate}")
 
     reflective_proposer = ReflectiveMutationProposer(
         logger=logger,

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -468,9 +468,9 @@ class EngineConfig:
 
     # Strategy selection for the engine
     val_evaluation_policy: EvaluationPolicy | Literal["full_eval"] = "full_eval"
-    candidate_selection_strategy: (
-        CandidateSelector | Literal["pareto", "current_best", "epsilon_greedy", "top_k_pareto"]
-    ) = "pareto"
+    candidate_selection_strategy: CandidateSelector | Literal[
+        "pareto", "current_best", "epsilon_greedy", "top_k_pareto"
+    ] = "pareto"
     frontier_type: FrontierType = "hybrid"
 
     # Parallelization settings for evaluation
@@ -623,7 +623,9 @@ def _build_seed_generation_prompt(
         examples = dataset[:3]
         example_lines = [f"- Example {i}: {ex}" for i, ex in enumerate(examples, 1)]
         sections.append(
-            "\n## Sample Inputs\n\nThe candidate will be evaluated on inputs like these:\n\n" + "\n".join(example_lines)
+            "\n## Sample Inputs\n\n"
+            "The candidate will be evaluated on inputs like these:\n\n"
+            + "\n".join(example_lines)
         )
 
     sections.append(

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -125,6 +125,8 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
             # Short-circuit: mutation_rate=0 means no change, skip LM call entirely
             if self.mutation_rate == 0.0:
                 new_texts[name] = base_instruction
+                prompts[name] = "(frozen: mutation_rate=0.0)"
+                raw_lm_outputs[name] = base_instruction
                 continue
 
             dataset_with_feedback = reflective_dataset[name]

--- a/tests/test_mutation_rate.py
+++ b/tests/test_mutation_rate.py
@@ -76,7 +76,7 @@ class TestMutationRateConstraintText:
         assert "70%" in prompt
 
     def test_freeze_at_0_skips_lm(self) -> None:
-        """mutation_rate=0.0 returns original text without calling LM."""
+        """mutation_rate=0.0 returns original text without calling LM, with metadata."""
         proposer = _make_proposer(mutation_rate=0.0)
         new_texts, prompts, raw_outputs = proposer.propose_new_texts(
             {"component": "original text"},
@@ -85,6 +85,8 @@ class TestMutationRateConstraintText:
         )
         assert new_texts["component"] == "original text"
         proposer.reflection_lm.assert_not_called()
+        assert "frozen" in prompts["component"]
+        assert raw_outputs["component"] == "original text"
 
     def test_constraint_uses_generic_language(self) -> None:
         """Constraint text says 'parameter value', not 'prompt'."""

--- a/tests/test_mutation_rate_integration.py
+++ b/tests/test_mutation_rate_integration.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from gepa.optimize_anything import ReflectionConfig
 
 
@@ -18,3 +20,29 @@ class TestMutationRateValidation:
         """Default mutation_rate is 1.0 (full rewrite allowed)."""
         config = ReflectionConfig()
         assert config.mutation_rate == 1.0
+
+    def test_optimize_rejects_mutation_rate_above_1(self) -> None:
+        """gepa.optimize() raises ValueError for mutation_rate > 1.0."""
+        import gepa
+
+        with pytest.raises(ValueError, match="mutation_rate must be between"):
+            gepa.optimize(
+                seed_candidate={"instructions": "test"},
+                trainset=[{"input": "x", "answer": "y", "additional_context": {}}],
+                reflection_lm=lambda p: "ok",
+                mutation_rate=1.5,
+                max_metric_calls=1,
+            )
+
+    def test_optimize_rejects_negative_mutation_rate(self) -> None:
+        """gepa.optimize() raises ValueError for negative mutation_rate."""
+        import gepa
+
+        with pytest.raises(ValueError, match="mutation_rate must be between"):
+            gepa.optimize(
+                seed_candidate={"instructions": "test"},
+                trainset=[{"input": "x", "answer": "y", "additional_context": {}}],
+                reflection_lm=lambda p: "ok",
+                mutation_rate=-0.1,
+                max_metric_calls=1,
+            )


### PR DESCRIPTION
Implements `mutation_rate` (#277). Controls how much of the candidate the reflection LM can change per iteration — the "learning rate" analogy for text optimization.

## Summary

`mutation_rate` is a float (0.0–1.0) on `ReflectionConfig` and `gepa.optimize()` that appends a `## Mutation Constraint` section to the reflection prompt when < 1.0:

- **`1.0` (default)** — current behavior, LM can rewrite entirely
- **`0.3`** — conservative, constraint instructs LM to retain at least 70% of current content
- **`0.1`** — very conservative, small targeted edits only
- **`0.0`** — freezes the candidate, LM must return it as-is

When `mutation_rate` is not set, behavior is identical to before — no constraint is appended.

## Changed files

- `src/gepa/proposer/reflective_mutation/reflective_mutation.py` — accept `mutation_rate`, append constraint section to reflection prompt in `propose_new_texts()`
- `src/gepa/optimize_anything.py` — add `mutation_rate` field to `ReflectionConfig`, validate and wire to proposer
- `src/gepa/api.py` — add `mutation_rate` parameter to `optimize()`, validate and wire to proposer
- `tests/test_mutation_rate.py` — 6 unit tests for constraint text generation
- `tests/test_mutation_rate_integration.py` — 2 integration tests for ReflectionConfig wiring

## Test plan

- [x] 8 tests covering default behavior, retention percentages, freeze mode, generic language, prompt ordering
- [x] Full suite passes (74 tests, no regressions)
- [x] `ruff check` + `pyright` clean