### PR TITLE
docs: add Google ADK official docs, AfricaNLP paper, and ICLR workshop paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ GEPA is integrated into several major frameworks:
 - **[Pydantic](https://pydantic.dev/articles/prompt-optimization-with-gepa)** — Prompt optimization for Pydantic AI.
 - **[OpenAI Cookbook](https://cookbook.openai.com/examples/partners/self_evolving_agents/autonomous_agent_retraining)** — Self-evolving agents with GEPA.
 - **[HuggingFace Cookbook](https://huggingface.co/learn/cookbook/en/dspy_gepa)** — Prompt optimization guide.
-- **[Google ADK](https://raphaelmansuy.github.io/adk_training/blog/gepa-optimization-tutorial/)** — Optimizing Google Agent Development Kit agents.
+- **[Google ADK](https://adk.dev/optimize/)** — Built-in agent optimization in Google's Agent Development Kit. [Community tutorial](https://raphaelmansuy.github.io/adk_training/blog/gepa-optimization-tutorial/).
 
 ---
 
@@ -388,7 +388,7 @@ Finally:
   - [Comet ML Opik](https://www.comet.com/docs/opik/agent_optimization/algorithms/gepa_optimizer) - Core optimization algorithm in Opik Agent Optimizer.
   - [OpenAI Cookbook](https://cookbook.openai.com/examples/partners/self_evolving_agents/autonomous_agent_retraining) - Self-evolving agents with GEPA.
   - [HuggingFace Cookbook](https://huggingface.co/learn/cookbook/en/dspy_gepa) - Prompt optimization guide.
-  - [Google ADK](https://raphaelmansuy.github.io/adk_training/blog/gepa-optimization-tutorial/) - Optimizing Google Agent Development Kit agents.
+  - [Google ADK](https://adk.dev/optimize/) - Built-in agent optimization in Google's Agent Development Kit. [Community tutorial](https://raphaelmansuy.github.io/adk_training/blog/gepa-optimization-tutorial/).
   - [Contributed Adapters](src/gepa/adapters/) – see our adapter templates and issue tracker to request new integrations.
     - [DefaultAdapter](src/gepa/adapters/default_adapter/) - System Prompt Optimization for a single-turn task.
     - [DSPy Full Program Adapter](src/gepa/adapters/dspy_full_program_adapter/) - Evolves entire DSPy programs including signatures, modules, and control flow. Achieves **93% accuracy** on MATH benchmark (vs 67% with basic DSPy ChainOfThought).
@@ -415,9 +415,11 @@ Finally:
     - [DeepResearch Agent Optimized with GEPA](https://www.rajapatnaik.com/blog/2025/10/23/langgraph-dspy-gepa-researcher)
     - Boosting Sanskrit QA: Finetuning EmbeddingGemma with 50k GEPA generated synthetic data samples [(Tweet)](https://x.com/dhrtha/status/1984315872547385504), [(Code)](https://github.com/ganarajpr/rgfe)
     - [Simulating Realistic Market Research Focus Groups with GEPA-Optimized AI Personas](https://x.com/hammer_mt/status/1984269888979116061)
-    - [Optimizing Google ADK Agents' SOP using GEPA](https://raphaelmansuy.github.io/adk_training/blog/gepa-optimization-tutorial/)
+    - [Google ADK: Official agent optimization powered by GEPA](https://adk.dev/optimize/)
     - [HuggingFace Cookbook on prompt optimization for with DSPy and GEPA](https://huggingface.co/learn/cookbook/en/dspy_gepa)
     - [OpenAI Cookbook showing how to build self-evolving agents using GEPA](https://cookbook.openai.com/examples/partners/self_evolving_agents/autonomous_agent_retraining)
+    - [What Do Prompts Reveal About Model Capabilities in Low-Resource Languages? (AfricaNLP 2026)](https://openreview.net/attachment?id=7JZmTp85Yf&name=pdf)
+    - [Beyond the Answer: Decoding the Behavior of LLMs as Scientific Reasoners (ICLR 2026 Workshop)](https://arxiv.org/abs/2603.28038)
 
 ---
 

--- a/docs/docs/guides/use-cases.md
+++ b/docs/docs/guides/use-cases.md
@@ -91,21 +91,23 @@ Discover how organizations and researchers are using GEPA to optimize AI systems
 
     [:material-arrow-right: View cookbook](https://huggingface.co/learn/cookbook/en/dspy_gepa)
 
--   **Google ADK Agents Optimization**
+-   **Google ADK: Official Agent Optimization**
 
     ---
 
     ![Google ADK Training](../static/img/use-cases/google_adk.png){ .card-image }
 
-    Tutorial on optimizing **Google Agent Development Kit (ADK)** agents using GEPA for improved performance.
+    Google's Agent Development Kit (ADK) uses GEPA as its **built-in agent optimization engine**. The `adk optimize` CLI command runs a `GEPARootAgentPromptOptimizer` to automatically improve agent instructions based on evaluation results.
 
-    **Key Topics:**
+    **Key Features:**
 
-    - Optimizing agent SOPs (Standard Operating Procedures)
-    - Integrating GEPA with ADK workflows
-    - Production deployment patterns
+    - Official `adk optimize` CLI powered by GEPA
+    - `LocalEvalSampler` for running evaluations
+    - Automatic prompt rewriting via `GEPARootAgentPromptOptimizer`
 
-    [:material-arrow-right: View tutorial](https://raphaelmansuy.github.io/adk_training/blog/gepa-optimization-tutorial/)
+    [:material-arrow-right: Official ADK docs](https://adk.dev/optimize/)
+
+    [:material-arrow-right: Community tutorial](https://raphaelmansuy.github.io/adk_training/blog/gepa-optimization-tutorial/)
 
 -   **Comet-ml Opik Integration**
 
@@ -481,6 +483,24 @@ Discover how organizations and researchers are using GEPA to optimize AI systems
     - State-of-the-art on clinical error detection
 
     [:material-arrow-right: Read the paper](https://arxiv.org/abs/2602.22483)
+
+-   **What Do Prompts Reveal About Model Capabilities in Low-Resource Languages? (AfricaNLP 2026)**
+
+    ---
+
+    Ajayi & Ogundepo (AfricaNLP 2026) investigate what GEPA-optimized prompts reveal about LLM capabilities when applied to **low-resource African languages**, using prompt optimization as a lens into model behavior on underrepresented languages.
+
+    [:material-arrow-right: Read the paper](https://openreview.net/attachment?id=7JZmTp85Yf&name=pdf)
+
+    [:material-arrow-right: LinkedIn announcement](https://www.linkedin.com/feed/update/urn%3Ali%3Aactivity%3A7444797637414924289/?commentUrn=urn%3Ali%3Acomment%3A%28activity%3A7444797637414924289%2C7445145380280758273%29&dashCommentUrn=urn%3Ali%3Afsd%5Fcomment%3A%287445145380280758273%2Curn%3Ali%3Aactivity%3A7444797637414924289%29)
+
+-   **Beyond the Answer: Decoding the Behavior of LLMs as Scientific Reasoners (ICLR 2026 Workshop)**
+
+    ---
+
+    Pandey, Ye & Li (Post-AGI Science and Society Workshop, ICLR 2026) use a GEPA-based approach to systematically optimize prompts for scientific reasoning tasks, finding that reasoning gains correspond to **model-specific heuristics that fail to generalize** across systems — framing prompt optimization as a tool for model interpretability.
+
+    [:material-arrow-right: Read the paper](https://arxiv.org/abs/2603.28038)
 
 </div>
 

--- a/docs/docs/tutorials/index.md
+++ b/docs/docs/tutorials/index.md
@@ -50,7 +50,8 @@ For more tutorials, especially those focused on the DSPy integration, see:
 - [DeepResearch Agent](https://www.rajapatnaik.com/blog/2025/10/23/langgraph-dspy-gepa-researcher) - LangGraph + DSPy + GEPA research system by @RajaPatnaik
 - [Self-Improving AI Agents](https://medium.com/@bindupriya117/building-self-improving-ai-agents-gepa-for-orchestration-trm-for-reasoning-1602e96f3e2b) - GEPA for orchestration, TRM for reasoning
 - [Context Compression Experiments](https://github.com/Laurian/context-compression-experiments-2508) - GEPA for optimizing context compression prompts by @gridinoc
-- [Google ADK Training with GEPA](https://raphaelmansuy.github.io/adk_training/blog/gepa-optimization-tutorial/) - Optimizing Google Agent Development Kit agents
+- [Google ADK Agent Optimization (Official)](https://adk.dev/optimize/) - Built-in GEPA-powered optimization in Google's Agent Development Kit
+- [Google ADK Training with GEPA](https://raphaelmansuy.github.io/adk_training/blog/gepa-optimization-tutorial/) - Community tutorial on optimizing ADK agents
 - [Speeding Up a Sudoku Solver with GEPA optimize_anything](https://blog.mariusvach.com/posts/gepa-sudoku-solver) - Use `optimize_anything` to speed up a Python Sudoku solver `optimize_anything`
 
 ### International Tutorials


### PR DESCRIPTION
## Summary

- **Google ADK official docs**: Update ADK links across README, Showcase, and Tutorials to point to the official [`adk.dev/optimize/`](https://adk.dev/optimize/) page (GEPA is now a built-in optimizer via `adk optimize` CLI), while keeping the existing community tutorial link
- **AfricaNLP 2026 paper**: Add [Ajayi & Ogundepo — "What Do Prompts Reveal About Model Capabilities in Low-Resource Languages?"](https://openreview.net/attachment?id=7JZmTp85Yf&name=pdf) to Showcase and README
- **ICLR 2026 Workshop paper**: Add [Pandey, Ye & Li — "Beyond the Answer: Decoding the Behavior of LLMs as Scientific Reasoners"](https://arxiv.org/abs/2603.28038) to Showcase and README

## Files changed

- `README.md` — Integrations section, GEPA Integrations section, GEPA uses section
- `docs/docs/guides/use-cases.md` — Enterprise & Production (ADK card), Research & Academic (two new cards)
- `docs/docs/tutorials/index.md` — Added official ADK docs link

## Test plan

- [ ] Verify all links resolve correctly
- [ ] Verify Showcase page renders cards properly with `mkdocs serve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)