### PR TITLE
docs: add Self-Optimizing Multi-Agent Deep Research paper (ECIR 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ Finally:
     - [OpenAI Cookbook showing how to build self-evolving agents using GEPA](https://cookbook.openai.com/examples/partners/self_evolving_agents/autonomous_agent_retraining)
     - [What Do Prompts Reveal About Model Capabilities in Low-Resource Languages? (AfricaNLP 2026)](https://openreview.net/attachment?id=7JZmTp85Yf&name=pdf)
     - [Beyond the Answer: Decoding the Behavior of LLMs as Scientific Reasoners (ICLR 2026 Workshop)](https://arxiv.org/abs/2603.28038)
+    - [Self-Optimizing Multi-Agent Systems for Deep Research (ECIR 2026 Workshop) — GEPA outperforms TextGrad and expert-crafted prompts](https://arxiv.org/abs/2604.02988)
 
 ---
 

--- a/docs/docs/guides/use-cases.md
+++ b/docs/docs/guides/use-cases.md
@@ -502,6 +502,20 @@ Discover how organizations and researchers are using GEPA to optimize AI systems
 
     [:material-arrow-right: Read the paper](https://arxiv.org/abs/2603.28038)
 
+-   **Self-Optimizing Multi-Agent Systems for Deep Research (ECIR 2026 Workshop)**
+
+    ---
+
+    Camara, Slot & Zavrel (Zeta Alpha, ECIR 2026) evaluate GEPA and TextGrad for optimizing multi-agent Deep Research systems. **GEPA outperforms TextGrad, OpenAI's prompt optimizer, and expert-crafted prompts**, with GEPA + custom meta-prompt achieving the best overall score (0.705) on the ScholarQA-CS benchmark.
+
+    **Key Results:**
+
+    - GEPA's Pareto-based exploration converges faster than TextGrad's greedy search
+    - Domain-tailored meta-prompts yield the best performance
+    - Optimized agents match or outperform expert-crafted prompts
+
+    [:material-arrow-right: Read the paper](https://arxiv.org/abs/2604.02988)
+
 </div>
 
 ---


### PR DESCRIPTION
## Summary

Add [Camara, Slot & Zavrel — "Self-Optimizing Multi-Agent Systems for Deep Research"](https://arxiv.org/abs/2604.02988) (ECIR 2026 Workshop) to Showcase and README.

GEPA outperforms TextGrad, OpenAI's prompt optimizer, and expert-crafted prompts on the ScholarQA-CS benchmark for multi-agent Deep Research systems. GEPA + custom meta-prompt achieved the best overall score (0.705).

## Files changed

- `docs/docs/guides/use-cases.md` — Research & Academic section (new card)
- `README.md` — GEPA uses section

## Test plan

- [ ] Verify link resolves
- [ ] Verify card renders with `mkdocs serve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)