### PR TITLE
fix: DspyAdapter outputs=None crash and reflection_lm type mismatch

### DIFF
--- a/src/gepa/adapters/dspy_full_program_adapter/full_program_adapter.py
+++ b/src/gepa/adapters/dspy_full_program_adapter/full_program_adapter.py
@@ -8,6 +8,7 @@ from dspy.primitives import Example, Prediction
 from dspy.teleprompt.bootstrap_trace import TraceData
 
 from gepa import EvaluationBatch, GEPAAdapter
+from gepa.proposer.reflective_mutation.base import LanguageModel
 
 
 class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
@@ -15,7 +16,7 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
         self,
         task_lm: dspy.LM,
         metric_fn: Callable,
-        reflection_lm: dspy.LM,
+        reflection_lm: LanguageModel,
         failure_score=0.0,
         num_threads: int | None = None,
         add_format_failure_as_feedback: bool = False,
@@ -83,7 +84,9 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
         program, feedback = self.build_program(candidate)
 
         if program is None:
-            return EvaluationBatch(outputs=None, scores=[self.failure_score for _ in batch], trajectories=feedback)
+            return EvaluationBatch(
+                outputs=[None for _ in batch], scores=[self.failure_score for _ in batch], trajectories=feedback
+            )
 
         if capture_traces:
             # bootstrap_trace_data-like flow with trace capture

--- a/tests/test_dspy_full_program_adapter.py
+++ b/tests/test_dspy_full_program_adapter.py
@@ -9,6 +9,10 @@ Covers two bugs:
 
 from __future__ import annotations
 
+import pytest
+
+pytest.importorskip("dspy", reason="dspy is not installed — skipping DspyAdapter tests")
+
 from unittest.mock import MagicMock, patch
 
 import dspy

--- a/tests/test_dspy_full_program_adapter.py
+++ b/tests/test_dspy_full_program_adapter.py
@@ -1,0 +1,159 @@
+"""Tests for DspyAdapter (full-program evolution adapter).
+
+Covers two bugs:
+1. evaluate() returned EvaluationBatch(outputs=None, ...) on build failure,
+   crashing downstream zip() in cached_evaluate_full.
+2. reflection_lm was typed as dspy.LM but must conform to the LanguageModel
+   protocol (callable returning str, not list[str]).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import dspy
+from dspy.primitives import Example
+
+from gepa.adapters.dspy_full_program_adapter.full_program_adapter import DspyAdapter
+from gepa.core.adapter import EvaluationBatch
+from gepa.proposer.reflective_mutation.base import LanguageModel
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter(reflection_lm=None):
+    """Build a DspyAdapter with mocked dependencies."""
+    task_lm = MagicMock(spec=dspy.LM)
+    metric_fn = MagicMock(return_value=1.0)
+    if reflection_lm is None:
+        reflection_lm = MagicMock(spec=LanguageModel)
+    return DspyAdapter(
+        task_lm=task_lm,
+        metric_fn=metric_fn,
+        reflection_lm=reflection_lm,
+        failure_score=0.0,
+        num_threads=1,
+    )
+
+
+def _make_batch(n=3):
+    """Create a minimal batch of DSPy Examples."""
+    return [Example(question=f"q{i}").with_inputs("question") for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: outputs must be a list, even on build failure
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateOutputsOnBuildFailure:
+    """When the candidate program fails to build, evaluate() must still
+    return an EvaluationBatch with a list of outputs (not None)."""
+
+    def test_outputs_is_list_on_syntax_error(self):
+        adapter = _make_adapter()
+        candidate = {"program": "def foo(  # syntax error"}
+        batch = _make_batch(4)
+
+        result = adapter.evaluate(batch, candidate, capture_traces=False)
+
+        assert isinstance(result, EvaluationBatch)
+        assert isinstance(result.outputs, list), f"outputs should be a list, got {type(result.outputs)}"
+        assert len(result.outputs) == len(batch)
+        assert len(result.scores) == len(batch)
+        assert all(s == 0.0 for s in result.scores)
+
+    def test_outputs_is_list_on_missing_program_object(self):
+        adapter = _make_adapter()
+        # Valid Python but doesn't define `program`
+        candidate = {"program": "x = 42"}
+        batch = _make_batch(2)
+
+        result = adapter.evaluate(batch, candidate, capture_traces=False)
+
+        assert isinstance(result.outputs, list)
+        assert len(result.outputs) == len(batch)
+
+    def test_outputs_is_list_on_runtime_error(self):
+        adapter = _make_adapter()
+        candidate = {"program": "raise RuntimeError('boom')"}
+        batch = _make_batch(5)
+
+        result = adapter.evaluate(batch, candidate, capture_traces=False)
+
+        assert isinstance(result.outputs, list)
+        assert len(result.outputs) == len(batch)
+
+    def test_outputs_zippable_with_example_ids(self):
+        """Reproduce the exact crash from cached_evaluate_full:
+        dict(zip(example_ids, outputs)) must not raise."""
+        adapter = _make_adapter()
+        candidate = {"program": "def foo(  # syntax error"}
+        batch = _make_batch(3)
+
+        result = adapter.evaluate(batch, candidate, capture_traces=False)
+        example_ids = list(range(len(batch)))
+
+        # This is the exact operation that crashed before the fix
+        outputs_by_id = dict(zip(example_ids, result.outputs, strict=False))
+        scores_by_id = dict(zip(example_ids, result.scores, strict=False))
+
+        assert len(outputs_by_id) == len(batch)
+        assert len(scores_by_id) == len(batch)
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: reflection_lm must conform to LanguageModel protocol
+# ---------------------------------------------------------------------------
+
+
+class TestReflectionLmProtocol:
+    """The reflection_lm parameter should accept any callable that returns str,
+    not require a dspy.LM specifically."""
+
+    def test_lambda_wrapper_accepted(self):
+        """A lambda wrapping dspy.LM (as shown in GEPA's example notebook)
+        should be accepted as reflection_lm."""
+        mock_dspy_lm = MagicMock(spec=dspy.LM)
+        mock_dspy_lm.return_value = ["response text"]
+        wrapped = lambda x: mock_dspy_lm(x)[0]
+
+        # Should not raise
+        adapter = _make_adapter(reflection_lm=wrapped)
+        assert adapter.reflection_lm is wrapped
+
+    def test_plain_callable_accepted(self):
+        """Any callable (str) -> str should work as reflection_lm."""
+
+        def my_lm(prompt):
+            return "generated response"
+
+        adapter = _make_adapter(reflection_lm=my_lm)
+        assert adapter.reflection_lm is my_lm
+
+    def test_propose_new_texts_calls_lm_correctly(self):
+        """propose_new_texts should pass the prompt to reflection_lm and use
+        the str return value (not a list)."""
+        mock_lm = MagicMock(return_value="<new_program>\nimport dspy\nprogram = dspy.Predict('q -> a')\n</new_program>")
+        adapter = _make_adapter(reflection_lm=mock_lm)
+
+        candidate = {"program": "import dspy\nprogram = dspy.Predict('q -> a')"}
+        reflective_dataset = {"program": [{"input": "q1", "output": "a1", "score": 0.5}]}
+
+        # The proposal signature will call lm(prompt) and expect a str back.
+        # We mock the signature's run method to verify the LM is called.
+        with patch(
+            "gepa.adapters.dspy_full_program_adapter.dspy_program_proposal_signature.DSPyProgramProposalSignature.run",
+            return_value={"new_program": "import dspy\nprogram = dspy.Predict('q -> a')"},
+        ) as mock_run:
+            result = adapter.propose_new_texts(candidate, reflective_dataset, ["program"])
+            mock_run.assert_called_once_with(
+                lm=mock_lm,
+                input_dict={
+                    "curr_program": candidate["program"],
+                    "dataset_with_feedback": reflective_dataset["program"],
+                },
+            )
+            assert "program" in result


### PR DESCRIPTION
## Problem

Two bugs in `DspyAdapter` (full-program evolution adapter) cause runtime crashes during optimization.

### Bug 1: `outputs=None` causes `TypeError` in `cached_evaluate_full`

When a candidate program fails to build (syntax error, runtime error, or missing `program` object), `evaluate()` returns `EvaluationBatch(outputs=None, ...)`. But `EvaluationBatch.outputs` is typed as `list[RolloutOutput]`, not `Optional`. Downstream in `state.py`, `cached_evaluate_full` does `dict(zip(example_ids, outputs))` which crashes because `None` is not iterable.

This happens frequently during full-program evolution — GEPA proposes new program code that may contain syntax errors, runtime errors, or simply not define a `program` variable. Every such failure triggers this crash.

The other adapters (`DspyAdapter` for prompt-only optimization, `MCPAdapter`) don't have this bug — they always return a proper list of outputs, even on failure.

**Reproduction:**

```python
from gepa.core.adapter import EvaluationBatch

batch = ['example1', 'example2', 'example3']
example_ids = [0, 1, 2]

# What the original code returns on build failure:
result = EvaluationBatch(
    outputs=None,  # <-- the bug
    scores=[0.0 for _ in batch],
    trajectories='Syntax Error in code...'
)

# What cached_evaluate_full does (state.py:622):
dict(zip(example_ids, result.outputs))
# TypeError: 'NoneType' object is not iterable
```

**Full traceback users see:**

```
File "gepa/proposer/reflective_mutation/reflective_mutation.py", line 165, in propose
    new_scores, actual_evals_count = state.cached_evaluate(...)
File "gepa/core/state.py", line 538, in cached_evaluate
    _, scores_by_id, _, num_actual_evals = self.cached_evaluate_full(...)
File "gepa/core/state.py", line 553, in cached_evaluate_full
    outputs_by_id = dict(zip(example_ids, outputs, strict=False))
TypeError: 'NoneType' object is not iterable
```

### Bug 2: `reflection_lm` type annotation causes `AttributeError`

`DspyAdapter.__init__` types `reflection_lm` as `dspy.LM`, but GEPA's `LanguageModel` protocol expects `(str) -> str`. `dspy.LM.__call__` actually returns `list[dict | str]`, not `str`:

```python
>>> import inspect, dspy
>>> inspect.signature(dspy.LM.__call__).return_annotation
list[dict[str, typing.Any] | str]
```

So when `Signature.run()` calls `.strip()` on the return value, it crashes:

```python
# base.py:48-49
lm_out = lm(full_prompt).strip()
# AttributeError: 'list' object has no attribute 'strip'
```

**Reproduction:**

```python
# dspy.LM returns a list, not a string:
fake_lm_output = ['This is the generated response']  # what dspy.LM actually returns

fake_lm_output.strip()
# AttributeError: 'list' object has no attribute 'strip'

# The example notebook correctly wraps it:
# reflection_lm=lambda x: reflection_lm(x)[0]
# But the type annotation dspy.LM misleads users into passing it raw.
```

**Full traceback users see:**

```
File "gepa/proposer/reflective_mutation/reflective_mutation.py", line 142, in propose
    new_texts = self.propose_new_texts(curr_prog, reflective_dataset, predictor_names_to_update)
File "gepa/proposer/reflective_mutation/reflective_mutation.py", line 67, in propose_new_texts
    return self.adapter.propose_new_texts(candidate, reflective_dataset, components_to_update)
File "gepa/adapters/dspy_full_program_adapter/full_program_adapter.py", line 262, in propose_new_texts
    new_texts[name] = DSPyProgramProposalSignature.run(lm=self.reflection_lm, ...)
File "gepa/proposer/reflective_mutation/base.py", line 48, in run
    lm_out = lm(full_prompt).strip()
AttributeError: 'list' object has no attribute 'strip'
```

## Changes

### Bug 1 fix (`full_program_adapter.py:86`)

Return a list of `None` values matching the batch size, instead of bare `None`:

```python
# Before (crashes downstream):
EvaluationBatch(outputs=None, scores=[...], trajectories=feedback)

# After (consistent with DspyAdapter and MCPAdapter):
EvaluationBatch(outputs=[None for _ in batch], scores=[...], trajectories=feedback)
```

### Bug 2 fix (`full_program_adapter.py:18`)

Update the type annotation to match the `LanguageModel` protocol that GEPA actually expects:

```python
# Before (misleading — dspy.LM returns list[str], not str):
reflection_lm: dspy.LM

# After (matches the LanguageModel protocol: (str) -> str):
from gepa.proposer.reflective_mutation.base import LanguageModel
reflection_lm: LanguageModel
```

## Tests

Added `tests/test_dspy_full_program_adapter.py` with 7 tests:

**Bug 1 coverage:**
- `test_outputs_is_list_on_syntax_error` — program with syntax error returns list outputs
- `test_outputs_is_list_on_missing_program_object` — valid Python without `program` variable
- `test_outputs_is_list_on_runtime_error` — program that raises at exec time
- `test_outputs_zippable_with_example_ids` — reproduces the exact `zip()` crash from `cached_evaluate_full`

**Bug 2 coverage:**
- `test_lambda_wrapper_accepted` — lambda `(str) -> str` works as `reflection_lm`
- `test_plain_callable_accepted` — plain function works as `reflection_lm`
- `test_propose_new_texts_calls_lm_correctly` — LM is correctly passed through to proposal signature

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to error-path return shape and a type annotation update, plus new unit tests to prevent regressions.
> 
> **Overview**
> Prevents `DspyAdapter.evaluate()` from crashing downstream caching when candidate program construction fails by returning an `EvaluationBatch` with `outputs` as a batch-sized list of `None` (instead of `None`).
> 
> Aligns `reflection_lm`’s type from `dspy.LM` to GEPA’s `LanguageModel` protocol to support `(str) -> str` callables, and adds targeted tests covering build failures and `reflection_lm` callability/usage in `propose_new_texts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e1c465eb3867fff9f3c025c790e793ff593029f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->