### PR TITLE
fix(security): bump litellm, mlflow, requests to address Dependabot alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,14 +22,14 @@ dependencies = []
 [project.optional-dependencies]
 full = [
     # Original dependencies for Python < 3.14
-    "litellm>=1.64.0; python_version < '3.14'",
+    "litellm>=1.83.0; python_version < '3.14'",
     "datasets>=2.14.6; python_version < '3.14'",
-    "mlflow>=3.0.0; python_version < '3.14'",
+    "mlflow>=3.11.1; python_version < '3.14'",
     "wandb; python_version < '3.14'",
     # Updated dependencies for Python 3.14+
-    "litellm>=1.81.0; python_version >= '3.14'",
+    "litellm>=1.83.0; python_version >= '3.14'",
     "datasets>=4.5.0; python_version >= '3.14'",
-    "mlflow-skinny>=3.8.1; python_version >= '3.14'",
+    "mlflow-skinny>=3.11.1; python_version >= '3.14'",
     "wandb>=0.23.0; python_version >= '3.14'",
     "pyarrow>=22.0.0; python_version >= '3.14'",
     "pydantic>=2.12.0; python_version >= '3.14'",
@@ -51,7 +51,7 @@ build = [
     "twine",
     "semver",
     "packaging",
-    "requests"
+    "requests>=2.33.0"
 ]
 dev = [
     "gepa[test]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,22 +21,21 @@ dependencies = []
 
 [project.optional-dependencies]
 full = [
-    # Original dependencies for Python < 3.14
-    "litellm>=1.83.0; python_version < '3.14'",
+    # Common dependencies (all Python versions)
+    "litellm>=1.83.0",
+    "tqdm>=4.66.1",
+    "cloudpickle>=3.0.0",
+    # Python < 3.14
     "datasets>=2.14.6; python_version < '3.14'",
     "mlflow>=3.11.1; python_version < '3.14'",
     "wandb; python_version < '3.14'",
-    # Updated dependencies for Python 3.14+
-    "litellm>=1.83.0; python_version >= '3.14'",
+    # Python 3.14+ (higher floors / alternative packages needed for compatibility)
     "datasets>=4.5.0; python_version >= '3.14'",
     "mlflow-skinny>=3.11.1; python_version >= '3.14'",
     "wandb>=0.23.0; python_version >= '3.14'",
     "pyarrow>=22.0.0; python_version >= '3.14'",
     "pydantic>=2.12.0; python_version >= '3.14'",
     "tiktoken>=0.12.0; python_version >= '3.14'",
-    # Common dependencies
-    "tqdm>=4.66.1",
-    "cloudpickle>=3.0.0"
 ]
 dspy = []
 test = [


### PR DESCRIPTION
## Summary

Bump minimum versions for direct dependencies to address open Dependabot security alerts.

| Package | Old | New | Severity | Key CVEs |
|---|---|---|---|---|
| `litellm` | `>=1.64.0` / `>=1.81.0` | `>=1.83.0` | 2 critical, 1 high | Auth bypass (OIDC cache collision), privilege escalation, password hash exposure |
| `mlflow` | `>=3.0.0` | `>=3.11.1` | 3 critical, 3 high, 1 medium | Command injection, path traversal, default password bypass, arbitrary file write, stored XSS |
| `mlflow-skinny` | `>=3.8.1` | `>=3.11.1` | (same as mlflow) | |
| `requests` | unpinned | `>=2.33.0` | 1 medium | Insecure temp file reuse |

### Not addressed (no fix available)

3 mlflow alerts have no patched version yet:
- Critical: FastAPI job endpoints unprotected
- High: Tracing + Assessments access
- Medium: AJAX endpoint authorization bypass

### Transitive dependencies

`aiohttp`, `cryptography`, `pyasn1`, `Pygments` vulnerabilities will be resolved automatically by the litellm/mlflow version bumps pulling newer transitive deps.

## Test plan

- [x] `uv sync --extra dev` resolves successfully
- [x] 430 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)