### PR TITLE
feat: comprehensive agent-readable state export in run_dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,4 @@ __marimo__/
 runs/
 outputs/
 gepa_terminus/
+archive/

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -176,7 +176,7 @@ def optimize(
     - track_best_outputs: Whether to track the best outputs on the validation set. If True, GEPAResult will contain the best outputs obtained for each task in the validation set.
     - display_progress_bar: Show a tqdm progress bar over metric calls when enabled.
     - use_cloudpickle: Use cloudpickle instead of pickle. This can be helpful when the serialized state contains dynamically generated DSPy signatures.
-    - write_agent_state: When True, write an agent-readable directory tree under `run_dir` alongside `gepa_state.bin` (candidates/, pareto/, iterations/, rejected_proposals/, eval_cache/). Also records extra eval trace payloads per iteration so rejected proposals carry before/after scores and trajectories. Default False; turn on when an agent (e.g. Claude Code) will read the run directory.
+    - write_agent_state: When True, write an agent-readable directory tree under `run_dir` alongside `gepa_state.bin` (`iterations/NNNNN/` + `pareto/`). Each loop iteration gets its own subdir (accepted or rejected) with `meta.json`, `components/`, `trace.json` (before/after scores + trajectories); accepted ones also get `val_scores.json`, `outputs/`, `trajectories/`. Seed is `iterations/00000/`. Default False; turn on when an agent (e.g. Claude Code) will read the run directory.
 
     # Evaluation caching
     - cache_evaluation: Whether to cache the (score, output, objective_scores) of (candidate, example) pairs. If True and a cache entry exists, GEPA will skip the fitness evaluation and use the cached results. This helps avoid redundant evaluations and saves metric calls. Defaults to False.

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -84,6 +84,7 @@ def optimize(
     track_best_outputs: bool = True,
     display_progress_bar: bool = False,
     use_cloudpickle: bool = False,
+    write_agent_state: bool = False,
     # Evaluation caching
     cache_evaluation: bool = False,
     # Reproducibility
@@ -175,6 +176,7 @@ def optimize(
     - track_best_outputs: Whether to track the best outputs on the validation set. If True, GEPAResult will contain the best outputs obtained for each task in the validation set.
     - display_progress_bar: Show a tqdm progress bar over metric calls when enabled.
     - use_cloudpickle: Use cloudpickle instead of pickle. This can be helpful when the serialized state contains dynamically generated DSPy signatures.
+    - write_agent_state: When True, write an agent-readable directory tree under `run_dir` alongside `gepa_state.bin` (candidates/, pareto/, iterations/, rejected_proposals/, eval_cache/). Also records extra eval trace payloads per iteration so rejected proposals carry before/after scores and trajectories. Default False; turn on when an agent (e.g. Claude Code) will read the run directory.
 
     # Evaluation caching
     - cache_evaluation: Whether to cache the (score, output, objective_scores) of (candidate, example) pairs. If True and a cache entry exists, GEPA will skip the fitness evaluation and use the cached results. This helps avoid redundant evaluations and saves metric calls. Defaults to False.
@@ -429,6 +431,7 @@ def optimize(
         val_evaluation_policy=val_evaluation_policy,
         acceptance_criterion=acceptance_criterion_instance,
         use_cloudpickle=use_cloudpickle,
+        write_agent_state=write_agent_state,
         evaluation_cache=evaluation_cache,
     )
 

--- a/src/gepa/core/adapter.py
+++ b/src/gepa/core/adapter.py
@@ -41,6 +41,8 @@ class ProposalFn(Protocol):
         candidate: dict[str, str],
         reflective_dataset: Mapping[str, Sequence[Mapping[str, Any]]],
         components_to_update: list[str],
+        *,
+        metadata: Mapping[str, Any] | None = None,
     ) -> dict[str, str]:
         """
         - Given the current `candidate`, a reflective dataset (as returned by
@@ -49,6 +51,18 @@ class ProposalFn(Protocol):
           to implement their own instruction proposal logic. For example, the user can use
           a different LLM, implement DSPy signatures, etc. Another example can be situations
           where 2 or more components need to be updated together (coupled updates).
+
+        - `metadata` is an open-ended dict of context hints supplied by the engine on
+          every call.           Custom proposers read only the keys they care about. Keys GEPA
+          currently populates:
+            * `"iteration"`: int — 1-indexed iteration number (matches the
+              ``Iteration N:`` log line and, when ``write_agent_state=True``,
+              the on-disk ``iterations/NNNNN/`` subdir). Seed is id 0; the
+              first loop proposal runs at id 1.
+            * `"parent_iteration_id"`: int — on-disk iteration id of the
+              parent candidate.
+          Future keys may be added without changing this signature — existing proposers
+          simply ignore them.
 
         Returns
         - Dict[str, str] mapping component names to newly proposed component texts.

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -181,20 +181,23 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         if setter is not None:
             setter(state.adapter_state)
 
-    def _write_agent_candidate_files(
+    def _write_agent_iteration_files(
         self,
-        candidate_idx: int,
+        iteration_id: int,
         valset_evaluation: ValsetEvaluation[RolloutOutput, DataId],
     ) -> None:
-        """Write per-val_id outputs and trajectories for an accepted candidate.
+        """Write per-val_id outputs/trajectories for an iteration's full valset eval.
 
         Called only when ``write_agent_state`` is enabled and ``run_dir`` is
-        set. Produces ``candidates/<idx>/outputs/<val_id>.json`` and, when the
-        valset evaluation captured them, ``candidates/<idx>/trajectories/<val_id>.json``.
+        set. Produces ``iterations/<iter_id>/outputs/<val_id>.json`` and, when
+        the valset evaluation captured them,
+        ``iterations/<iter_id>/trajectories/<val_id>.json``. The iteration id
+        is ``0`` for the seed and ``state.i + 1`` for accepted loop proposals
+        (the same numbering ``GEPAState._save_agent_directory`` uses).
         """
         if not self.write_agent_state or self.run_dir is None:
             return
-        base = os.path.join(self.run_dir, "candidates", f"{candidate_idx:05d}")
+        base = os.path.join(self.run_dir, "iterations", f"{iteration_id:05d}")
         outputs = valset_evaluation.outputs_by_val_id or {}
         if outputs:
             out_dir = os.path.join(base, "outputs")
@@ -263,7 +266,16 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         new_program: dict[str, str],
         state: GEPAState[RolloutOutput, DataId],
         parent_program_idx: list[int],
+        iteration: int | None = None,
     ) -> tuple[int, int]:
+        # ``iteration`` is the 1-indexed display/on-disk iteration id for the
+        # proposal being processed — same numbering ``ctx.iteration`` uses
+        # (``state.i + 1`` in sequential mode; the context's pre-stamped
+        # value in parallel mode). Defaults to ``state.i + 1`` so merge and
+        # other callers that don't thread it through still get the right
+        # value.
+        if iteration is None:
+            iteration = state.i + 1
         num_metric_calls_by_discovery = state.total_num_evals
         valset_evaluation = self._evaluate_on_valset(new_program, state)
         state.num_full_ds_evals += 1
@@ -280,9 +292,13 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             valset_evaluation=valset_evaluation,
             run_dir=self.run_dir,
             num_metric_calls_by_discovery_of_new_program=num_metric_calls_by_discovery,
+            iteration=iteration,
         )
 
-        self._write_agent_candidate_files(new_program_idx, valset_evaluation)
+        # ``iteration`` is already the on-disk iteration id (1-indexed,
+        # matching ``ctx.iteration`` and the numbering
+        # ``GEPAState._save_agent_directory`` uses). No shift needed.
+        self._write_agent_iteration_files(iteration, valset_evaluation)
 
         # Compute best program immediately after state update (before callbacks)
         # to ensure is_best_program reflects the updated Pareto front
@@ -419,6 +435,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             new_program=proposal.candidate,
             state=state,
             parent_program_idx=proposal.parent_program_ids,
+            iteration=iteration,
         )
 
         self._log_proposal_lm_calls(iteration, proposal, candidate_idx=new_idx)
@@ -653,9 +670,9 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             evaluation_cache=self._initial_evaluation_cache,
         )
 
-        # Seed lands at idx 0; persist its outputs/trajectories alongside
-        # subsequent candidates when agent state is enabled.
-        self._write_agent_candidate_files(0, seed_valset_evaluation)
+        # Seed is iteration id 0 — outputs/trajectories go under
+        # iterations/00000/ alongside subsequent loop iterations.
+        self._write_agent_iteration_files(0, seed_valset_evaluation)
 
         # Restore adapter state from persisted state (only has effect on resume)
         self._sync_state_to_adapter(state)

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -28,6 +28,7 @@ from gepa.core.callbacks import (
 )
 from gepa.core.data_loader import DataId, DataLoader, ensure_loader
 from gepa.core.state import EvaluationCache, FrontierType, GEPAState, ValsetEvaluation, initialize_gepa_state
+from gepa.gepa_utils import try_json_serialize
 from gepa.logging.experiment_tracker import ExperimentTracker
 from gepa.logging.logger import LoggerProtocol
 from gepa.logging.utils import log_detailed_metrics_after_discovering_new_program
@@ -48,23 +49,6 @@ except ImportError:
     tqdm = None
 
 
-def _try_json_serialize(obj: Any) -> Any:
-    """Best-effort JSON-safe conversion. Returns obj if serializable, else str(obj)."""
-    if obj is None or isinstance(obj, str | int | float | bool):
-        return obj
-    if isinstance(obj, dict):
-        return {str(k): _try_json_serialize(v) for k, v in obj.items()}
-    if isinstance(obj, list | tuple):
-        return [_try_json_serialize(v) for v in obj]
-    try:
-        import json
-
-        json.dumps(obj)
-        return obj
-    except (TypeError, ValueError, OverflowError):
-        return str(obj)
-
-
 def _record_proposal_evals(trace_entry: dict, proposal: "CandidateProposal") -> None:
     """Capture evaluation side_info from a proposal into the iteration trace.
 
@@ -77,17 +61,17 @@ def _record_proposal_evals(trace_entry: dict, proposal: "CandidateProposal") -> 
         eb = proposal.eval_before
         trace_entry["eval_before"] = {
             "scores": eb.scores,
-            "outputs": _try_json_serialize(eb.outputs),
+            "outputs": try_json_serialize(eb.outputs),
             "objective_scores": eb.objective_scores,
-            "trajectories": _try_json_serialize(eb.trajectories),
+            "trajectories": try_json_serialize(eb.trajectories),
         }
     if proposal.eval_after is not None:
         ea = proposal.eval_after
         trace_entry["eval_after"] = {
             "scores": ea.scores,
-            "outputs": _try_json_serialize(ea.outputs),
+            "outputs": try_json_serialize(ea.outputs),
             "objective_scores": ea.objective_scores,
-            "trajectories": _try_json_serialize(ea.trajectories),
+            "trajectories": try_json_serialize(ea.trajectories),
         }
 
 

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -48,6 +48,49 @@ except ImportError:
     tqdm = None
 
 
+def _try_json_serialize(obj: Any) -> Any:
+    """Best-effort JSON-safe conversion. Returns obj if serializable, else str(obj)."""
+    if obj is None or isinstance(obj, str | int | float | bool):
+        return obj
+    if isinstance(obj, dict):
+        return {str(k): _try_json_serialize(v) for k, v in obj.items()}
+    if isinstance(obj, list | tuple):
+        return [_try_json_serialize(v) for v in obj]
+    try:
+        import json
+
+        json.dumps(obj)
+        return obj
+    except (TypeError, ValueError, OverflowError):
+        return str(obj)
+
+
+def _record_proposal_evals(trace_entry: dict, proposal: "CandidateProposal") -> None:
+    """Capture evaluation side_info from a proposal into the iteration trace.
+
+    This records the subsample evaluation data (scores, outputs, trajectories/
+    side_info) for both the parent and the child candidate so that agents
+    reading ``gepa_state.json`` have the feedback needed to propose better
+    candidates.
+    """
+    if proposal.eval_before is not None:
+        eb = proposal.eval_before
+        trace_entry["eval_before"] = {
+            "scores": eb.scores,
+            "outputs": _try_json_serialize(eb.outputs),
+            "objective_scores": eb.objective_scores,
+            "trajectories": _try_json_serialize(eb.trajectories),
+        }
+    if proposal.eval_after is not None:
+        ea = proposal.eval_after
+        trace_entry["eval_after"] = {
+            "scores": ea.scores,
+            "outputs": _try_json_serialize(ea.outputs),
+            "objective_scores": ea.objective_scores,
+            "trajectories": _try_json_serialize(ea.trajectories),
+        }
+
+
 class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
     """Orchestrates the optimization loop using pluggable candidate proposers."""
 
@@ -365,7 +408,12 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             self.logger.log(f"Iteration {iteration}: Reflective mutation did not propose a new candidate")
             return False
 
+        # Capture evaluation side_info into the trace for agent consumption
+        _record_proposal_evals(trace_entry, output.proposal)
+
         accepted = self._accept_reflective_proposal(output.proposal, iteration, state)
+        trace_entry["proposal_accepted"] = accepted
+        trace_entry["proposed_candidate"] = output.proposal.candidate
 
         if accepted and self.merge_proposer is not None:
             self.merge_proposer.last_iter_found_new_program = True

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
 # https://github.com/gepa-ai/gepa
 
+import json
 import os
 import traceback
 from collections.abc import Sequence
@@ -28,7 +29,7 @@ from gepa.core.callbacks import (
 )
 from gepa.core.data_loader import DataId, DataLoader, ensure_loader
 from gepa.core.state import EvaluationCache, FrontierType, GEPAState, ValsetEvaluation, initialize_gepa_state
-from gepa.gepa_utils import try_json_serialize
+from gepa.gepa_utils import json_default, try_json_serialize
 from gepa.logging.experiment_tracker import ExperimentTracker
 from gepa.logging.logger import LoggerProtocol
 from gepa.logging.utils import log_detailed_metrics_after_discovering_new_program
@@ -180,6 +181,37 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         if setter is not None:
             setter(state.adapter_state)
 
+    def _write_agent_candidate_files(
+        self,
+        candidate_idx: int,
+        valset_evaluation: ValsetEvaluation[RolloutOutput, DataId],
+    ) -> None:
+        """Write per-val_id outputs and trajectories for an accepted candidate.
+
+        Called only when ``write_agent_state`` is enabled and ``run_dir`` is
+        set. Produces ``candidates/<idx>/outputs/<val_id>.json`` and, when the
+        valset evaluation captured them, ``candidates/<idx>/trajectories/<val_id>.json``.
+        """
+        if not self.write_agent_state or self.run_dir is None:
+            return
+        base = os.path.join(self.run_dir, "candidates", f"{candidate_idx:05d}")
+        outputs = valset_evaluation.outputs_by_val_id or {}
+        if outputs:
+            out_dir = os.path.join(base, "outputs")
+            os.makedirs(out_dir, exist_ok=True)
+            for val_id, output in outputs.items():
+                path = os.path.join(out_dir, f"{val_id}.json")
+                with open(path, "w") as f:
+                    json.dump(try_json_serialize(output), f, indent=2, default=json_default)
+        trajectories = valset_evaluation.trajectories_by_val_id or {}
+        if trajectories:
+            traj_dir = os.path.join(base, "trajectories")
+            os.makedirs(traj_dir, exist_ok=True)
+            for val_id, traj in trajectories.items():
+                path = os.path.join(traj_dir, f"{val_id}.json")
+                with open(path, "w") as f:
+                    json.dump(try_json_serialize(traj), f, indent=2, default=json_default)
+
     def _evaluate_on_valset(
         self,
         program: dict[str, str],
@@ -188,10 +220,35 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         valset = self.valset
         assert valset is not None
 
-        val_ids = self.val_evaluation_policy.get_eval_batch(valset, state)
+        val_ids = list(self.val_evaluation_policy.get_eval_batch(valset, state))
+
+        # When write_agent_state is on, bypass the cache so we can capture
+        # trajectories (which the cache does not store).
+        if self.write_agent_state:
+            batch = valset.fetch(val_ids)
+            eval_result = self.adapter.evaluate(batch, program, capture_traces=True)
+            outputs_by_val_idx = dict(zip(val_ids, eval_result.outputs, strict=False))
+            scores_by_val_idx = dict(zip(val_ids, eval_result.scores, strict=False))
+            objective_by_val_idx = (
+                dict(zip(val_ids, eval_result.objective_scores, strict=False))
+                if eval_result.objective_scores is not None
+                else None
+            )
+            trajectories_by_val_idx = (
+                dict(zip(val_ids, eval_result.trajectories, strict=False))
+                if eval_result.trajectories is not None
+                else None
+            )
+            state.increment_evals(len(val_ids))
+            return ValsetEvaluation(
+                outputs_by_val_id=outputs_by_val_idx,
+                scores_by_val_id=scores_by_val_idx,
+                objective_scores_by_val_id=objective_by_val_idx,
+                trajectories_by_val_id=trajectories_by_val_idx,
+            )
 
         outputs_by_val_idx, scores_by_val_idx, objective_by_val_idx, num_actual_evals = state.cached_evaluate_full(
-            program, list(val_ids), valset.fetch, self.evaluator
+            program, val_ids, valset.fetch, self.evaluator
         )
         state.increment_evals(num_actual_evals)
 
@@ -224,6 +281,8 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             run_dir=self.run_dir,
             num_metric_calls_by_discovery_of_new_program=num_metric_calls_by_discovery,
         )
+
+        self._write_agent_candidate_files(new_program_idx, valset_evaluation)
 
         # Compute best program immediately after state update (before callbacks)
         # to ensure is_best_program reflects the updated Pareto front
@@ -531,6 +590,27 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             program: dict[str, str],
         ) -> ValsetEvaluation[RolloutOutput, DataId]:
             all_ids = list(valset.all_ids())
+            if self.write_agent_state:
+                eval_result = self.adapter.evaluate(valset.fetch(all_ids), program, capture_traces=True)
+                outputs_dict = dict(zip(all_ids, eval_result.outputs, strict=False))
+                scores_dict = dict(zip(all_ids, eval_result.scores, strict=False))
+                objective_scores_dict = (
+                    dict(zip(all_ids, eval_result.objective_scores, strict=False))
+                    if eval_result.objective_scores is not None
+                    else None
+                )
+                trajectories_dict = (
+                    dict(zip(all_ids, eval_result.trajectories, strict=False))
+                    if eval_result.trajectories is not None
+                    else None
+                )
+                return ValsetEvaluation(
+                    outputs_by_val_id=outputs_dict,
+                    scores_by_val_id=scores_dict,
+                    objective_scores_by_val_id=objective_scores_dict,
+                    trajectories_by_val_id=trajectories_dict,
+                )
+
             outputs, scores, objective_scores = self.evaluator(valset.fetch(all_ids), program)
             outputs_dict = dict(zip(all_ids, outputs, strict=False))
             scores_dict = dict(zip(all_ids, scores, strict=False))
@@ -572,6 +652,10 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             frontier_type=self.frontier_type,
             evaluation_cache=self._initial_evaluation_cache,
         )
+
+        # Seed lands at idx 0; persist its outputs/trajectories alongside
+        # subsequent candidates when agent state is enabled.
+        self._write_agent_candidate_files(0, seed_valset_evaluation)
 
         # Restore adapter state from persisted state (only has effect on resume)
         self._sync_state_to_adapter(state)

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -101,6 +101,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         display_progress_bar: bool = False,
         raise_on_exception: bool = True,
         use_cloudpickle: bool = False,
+        write_agent_state: bool = False,
         # Budget and Stop Condition
         stop_callback: StopperProtocol | None = None,
         val_evaluation_policy: EvaluationPolicy[DataId, DataInst] | None = None,
@@ -152,6 +153,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         self.track_best_outputs = track_best_outputs
         self.display_progress_bar = display_progress_bar
         self.use_cloudpickle = use_cloudpickle
+        self.write_agent_state = write_agent_state
 
         self.num_parallel_proposals = num_parallel_proposals
         self.raise_on_exception = raise_on_exception
@@ -393,11 +395,13 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             return False
 
         # Capture evaluation side_info into the trace for agent consumption
-        _record_proposal_evals(trace_entry, output.proposal)
+        if self.write_agent_state:
+            _record_proposal_evals(trace_entry, output.proposal)
 
         accepted = self._accept_reflective_proposal(output.proposal, iteration, state)
-        trace_entry["proposal_accepted"] = accepted
-        trace_entry["proposed_candidate"] = output.proposal.candidate
+        if self.write_agent_state:
+            trace_entry["proposal_accepted"] = accepted
+            trace_entry["proposed_candidate"] = output.proposal.candidate
 
         if accepted and self.merge_proposer is not None:
             self.merge_proposer.last_iter_found_new_program = True
@@ -668,7 +672,11 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             iteration_started = False
             try:
                 self._sync_adapter_state_to_state(state)
-                state.save(self.run_dir, use_cloudpickle=self.use_cloudpickle)
+                state.save(
+                    self.run_dir,
+                    use_cloudpickle=self.use_cloudpickle,
+                    write_agent_state=self.write_agent_state,
+                )
                 notify_callbacks(
                     self.callbacks,
                     "on_state_saved",
@@ -816,7 +824,11 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             progress_bar.close()
 
         self._sync_adapter_state_to_state(state)
-        state.save(self.run_dir, use_cloudpickle=self.use_cloudpickle)
+        state.save(
+            self.run_dir,
+            use_cloudpickle=self.use_cloudpickle,
+            write_agent_state=self.write_agent_state,
+        )
 
         # Notify optimization end
         best_candidate_idx = self.val_evaluation_policy.get_best_program(state)

--- a/src/gepa/core/state.py
+++ b/src/gepa/core/state.py
@@ -4,6 +4,7 @@
 import hashlib
 import json
 import os
+import re
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
@@ -31,6 +32,14 @@ CacheKey: TypeAlias = tuple[CandidateHash, DataId]
 def _candidate_hash(candidate: dict[str, str]) -> CandidateHash:
     """Compute a deterministic hash of a candidate dictionary."""
     return hashlib.sha256(json.dumps(sorted(candidate.items())).encode()).hexdigest()
+
+
+_COMPONENT_NAME_SANITIZER = re.compile(r"[^A-Za-z0-9_.-]")
+
+
+def _sanitize_component_name(name: str) -> str:
+    """Collapse component names to filesystem-safe characters."""
+    return _COMPONENT_NAME_SANITIZER.sub("_", name)
 
 
 @dataclass
@@ -296,14 +305,33 @@ class GEPAState(Generic[RolloutOutput, DataId]):
             for hook in hooks:
                 hook(self.total_num_evals, count)
 
-    def _atomic_write_json(self, run_dir: str, filename: str, data: Any) -> None:
-        target_path = os.path.join(run_dir, filename)
+    def _atomic_write_json(self, run_dir: str, rel_path: str, data: Any) -> None:
+        target_path = os.path.join(run_dir, rel_path)
+        parent = os.path.dirname(target_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
         tmp_path = target_path + ".tmp"
         with open(tmp_path, "w") as f:
             json.dump(data, f, indent=2, default=json_default)
         os.replace(tmp_path, target_path)
 
-    def save(self, run_dir: str | None, *, use_cloudpickle: bool = False) -> None:
+    def _atomic_write_text(self, run_dir: str, rel_path: str, data: str) -> None:
+        target_path = os.path.join(run_dir, rel_path)
+        parent = os.path.dirname(target_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        tmp_path = target_path + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.write(data)
+        os.replace(tmp_path, target_path)
+
+    def save(
+        self,
+        run_dir: str | None,
+        *,
+        use_cloudpickle: bool = False,
+        write_agent_state: bool = False,
+    ) -> None:
         if run_dir is None:
             return
         if use_cloudpickle:
@@ -345,41 +373,71 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         if self.program_candidates:
             self._atomic_write_json(run_dir, "candidates.json", self.program_candidates)
 
-        # Save comprehensive agent-readable state
-        self._save_agent_state(run_dir)
+        # Opt-in directory layout for agent consumption
+        if write_agent_state:
+            self._save_agent_directory(run_dir)
 
-    def _save_agent_state(self, run_dir: str) -> None:
-        """Write a comprehensive JSON export of the optimization state.
+    def _save_agent_directory(self, run_dir: str) -> None:
+        """Write agent-readable state as a directory of small files.
 
-        Designed for consumption by autonomous agents (e.g. Claude Code) that
-        need the full picture — all candidates, per-datapoint scores, Pareto
-        frontiers, lineage, and evaluation history — in a single readable file.
+        Partitions the run's state into discrete JSON/text files so an agent
+        (e.g. Claude Code) can navigate it without loading a monolithic blob
+        into its context. The pickled ``gepa_state.bin`` remains the source of
+        truth for resume; this tree is output-only.
         """
-        num_candidates = len(self.program_candidates)
+        self._save_candidates_dir(run_dir)
+        self._save_pareto_dir(run_dir)
+        self._save_iterations_dir(run_dir)
+        self._save_rejected_proposals_dir(run_dir)
+        self._save_eval_cache_dir(run_dir)
+        self._save_index(run_dir)
 
-        # --- Build per-candidate records ---
-        candidates = []
-        for idx in range(num_candidates):
+    def _save_candidates_dir(self, run_dir: str) -> None:
+        for idx in range(len(self.program_candidates)):
             avg_score, coverage = self.get_program_average_val_subset(idx)
-            val_scores = self.prog_candidate_val_subscores[idx]
-            obj_scores = self.prog_candidate_objective_scores[idx]
             parents = self.parent_program_for_candidate[idx]
-            metric_calls = self.num_metric_calls_by_discovery[idx] if idx < len(self.num_metric_calls_by_discovery) else None
+            metric_calls = (
+                self.num_metric_calls_by_discovery[idx]
+                if idx < len(self.num_metric_calls_by_discovery)
+                else None
+            )
+            obj_scores = self.prog_candidate_objective_scores[idx]
+            base = f"candidates/{idx:05d}"
+            self._atomic_write_json(
+                run_dir,
+                f"{base}/meta.json",
+                {
+                    "idx": idx,
+                    "parent_ids": [p for p in parents if p is not None],
+                    "avg_val_score": avg_score,
+                    "num_val_scored": coverage,
+                    "metric_calls_to_discover": metric_calls,
+                    "objective_scores": obj_scores if obj_scores else {},
+                },
+            )
+            val_scores = self.prog_candidate_val_subscores[idx]
+            self._atomic_write_json(
+                run_dir,
+                f"{base}/val_scores.json",
+                {str(k): v for k, v in val_scores.items()},
+            )
+            self._save_components(run_dir, idx)
 
-            candidates.append({
-                "idx": idx,
-                "texts": self.program_candidates[idx],
-                "parent_ids": [p for p in parents if p is not None],
-                "avg_val_score": avg_score,
-                "num_val_scored": coverage,
-                "metric_calls_to_discover": metric_calls,
-                "val_scores": {str(k): v for k, v in val_scores.items()},
-                "objective_scores": obj_scores if obj_scores else {},
-            })
+    def _save_components(self, run_dir: str, idx: int) -> None:
+        cand = self.program_candidates[idx]
+        base = f"candidates/{idx:05d}/components"
+        index_map: dict[str, str] = {}
+        used: set[str] = set()
+        for i, (name, text) in enumerate(cand.items()):
+            safe = _sanitize_component_name(name)
+            if not safe or safe in used:
+                safe = f"component_{i:02d}"
+            used.add(safe)
+            index_map[name] = f"{safe}.txt"
+            self._atomic_write_text(run_dir, f"{base}/{safe}.txt", text)
+        self._atomic_write_json(run_dir, f"{base}/_index.json", index_map)
 
-        # --- Build Pareto frontier ---
-        pareto: dict[str, Any] = {}
-
+    def _save_pareto_dir(self, run_dir: str) -> None:
         if self.frontier_type in ("instance", "hybrid"):
             instance_front: dict[str, Any] = {}
             for val_id, best_score in self.pareto_front_valset.items():
@@ -388,7 +446,7 @@ class GEPAState(Generic[RolloutOutput, DataId]):
                     "best_score": best_score,
                     "best_candidates": best_progs,
                 }
-            pareto["instance_front"] = instance_front
+            self._atomic_write_json(run_dir, "pareto/instance_front.json", instance_front)
 
         if self.frontier_type in ("objective", "hybrid"):
             obj_front: dict[str, Any] = {}
@@ -398,7 +456,7 @@ class GEPAState(Generic[RolloutOutput, DataId]):
                     "best_score": best_score,
                     "best_candidates": best_progs,
                 }
-            pareto["objective_front"] = obj_front
+            self._atomic_write_json(run_dir, "pareto/objective_front.json", obj_front)
 
         if self.frontier_type == "cartesian":
             cartesian_front: dict[str, Any] = {}
@@ -408,10 +466,61 @@ class GEPAState(Generic[RolloutOutput, DataId]):
                     "best_score": best_score,
                     "best_candidates": best_progs,
                 }
-            pareto["cartesian_front"] = cartesian_front
+            self._atomic_write_json(run_dir, "pareto/cartesian_front.json", cartesian_front)
 
-        # --- Derived analytics ---
-        # Hardest validation examples (lowest best score on Pareto front)
+    def _save_iterations_dir(self, run_dir: str) -> None:
+        for entry in self.full_program_trace:
+            i = entry.get("i")
+            if i is None:
+                continue
+            self._atomic_write_json(run_dir, f"iterations/{i:05d}.json", entry)
+
+    def _save_rejected_proposals_dir(self, run_dir: str) -> None:
+        for entry in self.full_program_trace:
+            if entry.get("proposal_accepted") is not False:
+                continue
+            if "proposed_candidate" not in entry:
+                continue
+            i = entry.get("i")
+            if i is None:
+                continue
+            self._atomic_write_json(
+                run_dir,
+                f"rejected_proposals/{i:05d}.json",
+                {
+                    "iteration": i,
+                    "candidate": entry["proposed_candidate"],
+                    "parent_ids": [entry.get("selected_program_candidate")],
+                    "subsample_ids": entry.get("subsample_ids"),
+                    "subsample_scores_before": entry.get("subsample_scores"),
+                    "subsample_scores_after": entry.get("new_subsample_scores"),
+                    "eval_before": entry.get("eval_before"),
+                    "eval_after": entry.get("eval_after"),
+                },
+            )
+
+    def _save_eval_cache_dir(self, run_dir: str) -> None:
+        if self.evaluation_cache is None:
+            return
+        for idx, cand in enumerate(self.program_candidates):
+            cand_entries: dict[str, Any] = {}
+            for val_id in self.prog_candidate_val_subscores[idx]:
+                cached = self.evaluation_cache.get(cand, val_id)
+                if cached is not None:
+                    cand_entries[str(val_id)] = {
+                        "score": cached.score,
+                        "output": try_json_serialize(cached.output),
+                        "objective_scores": cached.objective_scores,
+                    }
+            if cand_entries:
+                self._atomic_write_json(
+                    run_dir, f"eval_cache/{idx:05d}.json", cand_entries
+                )
+
+    def _save_index(self, run_dir: str) -> None:
+        """Write the small top-level index that points at the rest of the tree."""
+        num_candidates = len(self.program_candidates)
+
         hardest: list[dict[str, Any]] = []
         if self.pareto_front_valset:
             sorted_examples = sorted(self.pareto_front_valset.items(), key=lambda x: x[1])
@@ -423,49 +532,18 @@ class GEPAState(Generic[RolloutOutput, DataId]):
                     "best_candidates": best_progs,
                 })
 
-        # Best candidate
         full_scores = self.program_full_scores_val_set
-        best_idx = int(max(range(num_candidates), key=lambda i: full_scores[i])) if num_candidates > 0 else 0
+        best_idx = (
+            int(max(range(num_candidates), key=lambda i: full_scores[i]))
+            if num_candidates > 0
+            else 0
+        )
 
-        # All candidates on the Pareto front (unique across all frontier keys)
         front_candidates: set[int] = set()
-        front_map = self.get_pareto_front_mapping()
-        for prog_set in front_map.values():
+        for prog_set in self.get_pareto_front_mapping().values():
             front_candidates.update(prog_set)
 
-        # --- Evaluation cache export ---
-        cache_export: dict[str, dict[str, Any]] = {}
-        if self.evaluation_cache is not None:
-            for idx, cand in enumerate(self.program_candidates):
-                cand_entries: dict[str, Any] = {}
-                # Check all known val_ids for this candidate
-                for val_id in self.prog_candidate_val_subscores[idx]:
-                    cached = self.evaluation_cache.get(cand, val_id)
-                    if cached is not None:
-                        cand_entries[str(val_id)] = {
-                            "score": cached.score,
-                            "output": try_json_serialize(cached.output),
-                            "objective_scores": cached.objective_scores,
-                        }
-                if cand_entries:
-                    cache_export[str(idx)] = cand_entries
-
-        # --- Rejected proposals (extracted from iteration log) ---
-        rejected_proposals: list[dict[str, Any]] = []
-        for entry in self.full_program_trace:
-            if entry.get("proposal_accepted") is False and "proposed_candidate" in entry:
-                rejected_proposals.append({
-                    "iteration": entry.get("i"),
-                    "candidate": entry["proposed_candidate"],
-                    "parent_ids": [entry.get("selected_program_candidate")],
-                    "subsample_ids": entry.get("subsample_ids"),
-                    "subsample_scores_before": entry.get("subsample_scores"),
-                    "subsample_scores_after": entry.get("new_subsample_scores"),
-                    "eval_before": entry.get("eval_before"),
-                    "eval_after": entry.get("eval_after"),
-                })
-
-        state_export: dict[str, Any] = {
+        index: dict[str, Any] = {
             "schema_version": 2,
             "iteration": self.i,
             "total_metric_calls": self.total_num_evals,
@@ -479,14 +557,16 @@ class GEPAState(Generic[RolloutOutput, DataId]):
                 "pareto_front_candidate_idxs": sorted(front_candidates),
                 "hardest_examples": hardest,
             },
-            "candidates": candidates,
-            "pareto_front": pareto,
-            "rejected_proposals": rejected_proposals,
-            "evaluation_cache": cache_export if cache_export else None,
-            "iteration_log": self.full_program_trace,
+            "layout": {
+                "candidates_dir": "candidates/",
+                "pareto_dir": "pareto/",
+                "iterations_dir": "iterations/",
+                "rejected_proposals_dir": "rejected_proposals/",
+                "eval_cache_dir": "eval_cache/",
+            },
         }
 
-        self._atomic_write_json(run_dir, "gepa_state.json", state_export)
+        self._atomic_write_json(run_dir, "gepa_state.json", index)
 
     @staticmethod
     def load(run_dir: str) -> "GEPAState[RolloutOutput, DataId]":

--- a/src/gepa/core/state.py
+++ b/src/gepa/core/state.py
@@ -345,6 +345,115 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         if self.program_candidates:
             self._atomic_write_json(run_dir, "candidates.json", self.program_candidates)
 
+        # Save comprehensive agent-readable state
+        self._save_agent_state(run_dir)
+
+    def _save_agent_state(self, run_dir: str) -> None:
+        """Write a comprehensive JSON export of the optimization state.
+
+        Designed for consumption by autonomous agents (e.g. Claude Code) that
+        need the full picture — all candidates, per-datapoint scores, Pareto
+        frontiers, lineage, and evaluation history — in a single readable file.
+        """
+        num_candidates = len(self.program_candidates)
+
+        # --- Build per-candidate records ---
+        candidates = []
+        for idx in range(num_candidates):
+            avg_score, coverage = self.get_program_average_val_subset(idx)
+            val_scores = self.prog_candidate_val_subscores[idx]
+            obj_scores = self.prog_candidate_objective_scores[idx]
+            parents = self.parent_program_for_candidate[idx]
+            metric_calls = self.num_metric_calls_by_discovery[idx] if idx < len(self.num_metric_calls_by_discovery) else None
+
+            candidates.append({
+                "idx": idx,
+                "texts": self.program_candidates[idx],
+                "parent_ids": [p for p in parents if p is not None],
+                "avg_val_score": avg_score,
+                "num_val_scored": coverage,
+                "metric_calls_to_discover": metric_calls,
+                "val_scores": {str(k): v for k, v in val_scores.items()},
+                "objective_scores": obj_scores if obj_scores else {},
+            })
+
+        # --- Build Pareto frontier ---
+        pareto: dict[str, Any] = {}
+
+        if self.frontier_type in ("instance", "hybrid"):
+            instance_front: dict[str, Any] = {}
+            for val_id, best_score in self.pareto_front_valset.items():
+                best_progs = sorted(self.program_at_pareto_front_valset.get(val_id, set()))
+                instance_front[str(val_id)] = {
+                    "best_score": best_score,
+                    "best_candidates": best_progs,
+                }
+            pareto["instance_front"] = instance_front
+
+        if self.frontier_type in ("objective", "hybrid"):
+            obj_front: dict[str, Any] = {}
+            for obj_name, best_score in self.objective_pareto_front.items():
+                best_progs = sorted(self.program_at_pareto_front_objectives.get(obj_name, set()))
+                obj_front[obj_name] = {
+                    "best_score": best_score,
+                    "best_candidates": best_progs,
+                }
+            pareto["objective_front"] = obj_front
+
+        if self.frontier_type == "cartesian":
+            cartesian_front: dict[str, Any] = {}
+            for key, best_score in self.pareto_front_cartesian.items():
+                best_progs = sorted(self.program_at_pareto_front_cartesian.get(key, set()))
+                cartesian_front[str(key)] = {
+                    "best_score": best_score,
+                    "best_candidates": best_progs,
+                }
+            pareto["cartesian_front"] = cartesian_front
+
+        # --- Derived analytics ---
+        # Hardest validation examples (lowest best score on Pareto front)
+        hardest: list[dict[str, Any]] = []
+        if self.pareto_front_valset:
+            sorted_examples = sorted(self.pareto_front_valset.items(), key=lambda x: x[1])
+            for val_id, score in sorted_examples[:20]:
+                best_progs = sorted(self.program_at_pareto_front_valset.get(val_id, set()))
+                hardest.append({
+                    "val_id": str(val_id),
+                    "best_score": score,
+                    "best_candidates": best_progs,
+                })
+
+        # Best candidate
+        full_scores = self.program_full_scores_val_set
+        best_idx = int(max(range(num_candidates), key=lambda i: full_scores[i])) if num_candidates > 0 else 0
+
+        # All candidates on the Pareto front (unique across all frontier keys)
+        front_candidates: set[int] = set()
+        front_map = self.get_pareto_front_mapping()
+        for prog_set in front_map.values():
+            front_candidates.update(prog_set)
+
+        state_export: dict[str, Any] = {
+            "schema_version": 1,
+            "iteration": self.i,
+            "total_metric_calls": self.total_num_evals,
+            "num_full_val_evals": self.num_full_ds_evals,
+            "frontier_type": self.frontier_type,
+            "component_names": self.list_of_named_predictors,
+            "summary": {
+                "num_candidates": num_candidates,
+                "best_candidate_idx": best_idx,
+                "best_avg_score": full_scores[best_idx] if num_candidates > 0 else None,
+                "pareto_front_candidate_idxs": sorted(front_candidates),
+                "hardest_examples": hardest,
+            },
+            "candidates": candidates,
+            "pareto_front": pareto,
+            "iteration_log": self.full_program_trace,
+        }
+
+        self._atomic_write_json(run_dir, "gepa_state.json", state_export)
+
     @staticmethod
     def load(run_dir: str) -> "GEPAState[RolloutOutput, DataId]":
         with open(os.path.join(run_dir, "gepa_state.bin"), "rb") as f:

--- a/src/gepa/core/state.py
+++ b/src/gepa/core/state.py
@@ -12,7 +12,7 @@ from typing import Any, ClassVar, Generic, Literal, TypeAlias
 
 from gepa.core.adapter import RolloutOutput
 from gepa.core.data_loader import DataId
-from gepa.gepa_utils import json_default, try_json_serialize
+from gepa.gepa_utils import json_default
 from gepa.logging.logger import LoggerProtocol
 
 # Types for GEPAState
@@ -146,6 +146,9 @@ class ValsetEvaluation(Generic[RolloutOutput, DataId]):
     outputs_by_val_id: dict[DataId, RolloutOutput]
     scores_by_val_id: dict[DataId, float]
     objective_scores_by_val_id: dict[DataId, ObjectiveScores] | None = None
+    # Populated only when the engine is run with ``write_agent_state=True`` —
+    # full valset trajectories are expensive, so default eval paths skip them.
+    trajectories_by_val_id: dict[DataId, Any] | None = None
 
 
 class GEPAState(Generic[RolloutOutput, DataId]):
@@ -389,7 +392,6 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         self._save_pareto_dir(run_dir)
         self._save_iterations_dir(run_dir)
         self._save_rejected_proposals_dir(run_dir)
-        self._save_eval_cache_dir(run_dir)
         self._save_index(run_dir)
 
     def _save_candidates_dir(self, run_dir: str) -> None:
@@ -499,24 +501,6 @@ class GEPAState(Generic[RolloutOutput, DataId]):
                 },
             )
 
-    def _save_eval_cache_dir(self, run_dir: str) -> None:
-        if self.evaluation_cache is None:
-            return
-        for idx, cand in enumerate(self.program_candidates):
-            cand_entries: dict[str, Any] = {}
-            for val_id in self.prog_candidate_val_subscores[idx]:
-                cached = self.evaluation_cache.get(cand, val_id)
-                if cached is not None:
-                    cand_entries[str(val_id)] = {
-                        "score": cached.score,
-                        "output": try_json_serialize(cached.output),
-                        "objective_scores": cached.objective_scores,
-                    }
-            if cand_entries:
-                self._atomic_write_json(
-                    run_dir, f"eval_cache/{idx:05d}.json", cand_entries
-                )
-
     def _save_index(self, run_dir: str) -> None:
         """Write the small top-level index that points at the rest of the tree."""
         num_candidates = len(self.program_candidates)
@@ -562,7 +546,6 @@ class GEPAState(Generic[RolloutOutput, DataId]):
                 "pareto_dir": "pareto/",
                 "iterations_dir": "iterations/",
                 "rejected_proposals_dir": "rejected_proposals/",
-                "eval_cache_dir": "eval_cache/",
             },
         }
 

--- a/src/gepa/core/state.py
+++ b/src/gepa/core/state.py
@@ -11,7 +11,7 @@ from typing import Any, ClassVar, Generic, Literal, TypeAlias
 
 from gepa.core.adapter import RolloutOutput
 from gepa.core.data_loader import DataId
-from gepa.gepa_utils import json_default
+from gepa.gepa_utils import json_default, try_json_serialize
 from gepa.logging.logger import LoggerProtocol
 
 # Types for GEPAState
@@ -433,8 +433,40 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         for prog_set in front_map.values():
             front_candidates.update(prog_set)
 
+        # --- Evaluation cache export ---
+        cache_export: dict[str, dict[str, Any]] = {}
+        if self.evaluation_cache is not None:
+            for idx, cand in enumerate(self.program_candidates):
+                cand_entries: dict[str, Any] = {}
+                # Check all known val_ids for this candidate
+                for val_id in self.prog_candidate_val_subscores[idx]:
+                    cached = self.evaluation_cache.get(cand, val_id)
+                    if cached is not None:
+                        cand_entries[str(val_id)] = {
+                            "score": cached.score,
+                            "output": try_json_serialize(cached.output),
+                            "objective_scores": cached.objective_scores,
+                        }
+                if cand_entries:
+                    cache_export[str(idx)] = cand_entries
+
+        # --- Rejected proposals (extracted from iteration log) ---
+        rejected_proposals: list[dict[str, Any]] = []
+        for entry in self.full_program_trace:
+            if entry.get("proposal_accepted") is False and "proposed_candidate" in entry:
+                rejected_proposals.append({
+                    "iteration": entry.get("i"),
+                    "candidate": entry["proposed_candidate"],
+                    "parent_ids": [entry.get("selected_program_candidate")],
+                    "subsample_ids": entry.get("subsample_ids"),
+                    "subsample_scores_before": entry.get("subsample_scores"),
+                    "subsample_scores_after": entry.get("new_subsample_scores"),
+                    "eval_before": entry.get("eval_before"),
+                    "eval_after": entry.get("eval_after"),
+                })
+
         state_export: dict[str, Any] = {
-            "schema_version": 1,
+            "schema_version": 2,
             "iteration": self.i,
             "total_metric_calls": self.total_num_evals,
             "num_full_val_evals": self.num_full_ds_evals,
@@ -449,6 +481,8 @@ class GEPAState(Generic[RolloutOutput, DataId]):
             },
             "candidates": candidates,
             "pareto_front": pareto,
+            "rejected_proposals": rejected_proposals,
+            "evaluation_cache": cache_export if cache_export else None,
             "iteration_log": self.full_program_trace,
         }
 

--- a/src/gepa/core/state.py
+++ b/src/gepa/core/state.py
@@ -162,7 +162,7 @@ class GEPAState(Generic[RolloutOutput, DataId]):
     returned by :func:`~gepa.optimize_anything.optimize_anything`.
     """
 
-    _VALIDATION_SCHEMA_VERSION: ClassVar[int] = 5
+    _VALIDATION_SCHEMA_VERSION: ClassVar[int] = 6
     # Attributes that are runtime-only and should not be serialized (e.g., callback hooks, caches)
     _EXCLUDED_FROM_SERIALIZATION: ClassVar[frozenset[str]] = frozenset({"_budget_hooks"})
 
@@ -170,6 +170,12 @@ class GEPAState(Generic[RolloutOutput, DataId]):
     parent_program_for_candidate: list[list[ProgramIdx | None]]
     prog_candidate_val_subscores: list[dict[DataId, float]]
     prog_candidate_objective_scores: list[ObjectiveScores]
+    # On-disk iteration id for each candidate (indexed by candidate idx).
+    # Seed = 0; accepted loop candidates get the 1-indexed iteration id
+    # at which they were discovered (``ctx.iteration`` ==
+    # ``state.i + 1``). Maintained in lockstep with ``program_candidates``
+    # so lookups are O(1) instead of requiring a trace scan.
+    iteration_ids_by_candidate_idx: list[int]
 
     pareto_front_valset: dict[DataId, float]
     program_at_pareto_front_valset: dict[DataId, set[ProgramIdx]]
@@ -209,6 +215,8 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         evaluation_cache: "EvaluationCache[RolloutOutput, DataId] | None" = None,
     ):
         self.program_candidates = [dict(seed_candidate)]
+        # Seed owns on-disk iteration id 0.
+        self.iteration_ids_by_candidate_idx = [0]
         self.prog_candidate_val_subscores = [dict(base_evaluation.scores_by_val_id)]
 
         base_objective_aggregates = self._aggregate_objective_scores(base_evaluation.objective_scores_by_val_id)
@@ -271,6 +279,7 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         assert len(self.program_candidates) == len(self.prog_candidate_val_subscores)
         assert len(self.program_candidates) == len(self.prog_candidate_objective_scores)
         assert len(self.program_candidates) == len(self.num_metric_calls_by_discovery)
+        assert len(self.program_candidates) == len(self.iteration_ids_by_candidate_idx)
 
         assert len(self.pareto_front_valset) == len(self.program_at_pareto_front_valset)
         assert set(self.pareto_front_valset.keys()) == set(self.program_at_pareto_front_valset.keys())
@@ -383,125 +392,192 @@ class GEPAState(Generic[RolloutOutput, DataId]):
     def _save_agent_directory(self, run_dir: str) -> None:
         """Write agent-readable state as a directory of small files.
 
-        Partitions the run's state into discrete JSON/text files so an agent
-        (e.g. Claude Code) can navigate it without loading a monolithic blob
-        into its context. The pickled ``gepa_state.bin`` remains the source of
-        truth for resume; this tree is output-only.
+        Partitions the run's state into per-iteration subdirs so an agent
+        (e.g. Claude Code) can navigate a single timeline — both accepted
+        candidates *and* rejected proposals live under ``iterations/NNNNN/``.
+        ``iterations/00000/`` is always the seed (``candidate_idx=0``); subsequent
+        directories correspond to ``state.i + 1`` (the loop iteration that
+        produced the proposal, shifted so the seed owns id 0). The pickled
+        ``gepa_state.bin`` remains the source of truth for resume; this tree
+        is output-only.
         """
-        self._save_candidates_dir(run_dir)
-        self._save_pareto_dir(run_dir)
-        self._save_iterations_dir(run_dir)
-        self._save_rejected_proposals_dir(run_dir)
-        self._save_index(run_dir)
+        cand_to_iter = self._candidate_idx_to_iteration_id()
+        self._save_seed_iteration_dir(run_dir)
+        self._save_proposal_iteration_dirs(run_dir, cand_to_iter)
+        self._save_pareto_dir(run_dir, cand_to_iter)
+        self._save_index(run_dir, cand_to_iter)
 
-    def _save_candidates_dir(self, run_dir: str) -> None:
-        for idx in range(len(self.program_candidates)):
-            avg_score, coverage = self.get_program_average_val_subset(idx)
-            parents = self.parent_program_for_candidate[idx]
-            metric_calls = (
-                self.num_metric_calls_by_discovery[idx]
-                if idx < len(self.num_metric_calls_by_discovery)
-                else None
-            )
-            obj_scores = self.prog_candidate_objective_scores[idx]
-            base = f"candidates/{idx:05d}"
-            self._atomic_write_json(
-                run_dir,
-                f"{base}/meta.json",
-                {
-                    "idx": idx,
-                    "parent_ids": [p for p in parents if p is not None],
-                    "avg_val_score": avg_score,
-                    "num_val_scored": coverage,
-                    "metric_calls_to_discover": metric_calls,
-                    "objective_scores": obj_scores if obj_scores else {},
-                },
-            )
-            val_scores = self.prog_candidate_val_subscores[idx]
-            self._atomic_write_json(
-                run_dir,
-                f"{base}/val_scores.json",
-                {str(k): v for k, v in val_scores.items()},
-            )
-            self._save_components(run_dir, idx)
+    def iteration_id_for_candidate_idx(self, candidate_idx: int) -> int | None:
+        """On-disk iteration id for the accepted candidate at ``candidate_idx``.
 
-    def _save_components(self, run_dir: str, idx: int) -> None:
-        cand = self.program_candidates[idx]
-        base = f"candidates/{idx:05d}/components"
+        O(1) lookup against :attr:`iteration_ids_by_candidate_idx`, which is
+        maintained in lockstep with :attr:`program_candidates` by
+        :meth:`update_state_with_new_program`. Returns ``None`` for
+        out-of-range indices.
+        """
+        if candidate_idx < 0 or candidate_idx >= len(self.iteration_ids_by_candidate_idx):
+            return None
+        return self.iteration_ids_by_candidate_idx[candidate_idx]
+
+    def _candidate_idx_to_iteration_id(self) -> dict[int, int]:
+        """Map candidate idx (internal) → on-disk iteration id.
+
+        Backed by :attr:`iteration_ids_by_candidate_idx`, so this is just a
+        zipped view — no trace scan needed.
+        """
+        return dict(enumerate(self.iteration_ids_by_candidate_idx))
+
+    def _save_seed_iteration_dir(self, run_dir: str) -> None:
+        """Write ``iterations/00000/`` — the seed candidate (candidate_idx 0)."""
+        avg_score, coverage = self.get_program_average_val_subset(0)
+        metric_calls = self.num_metric_calls_by_discovery[0] if self.num_metric_calls_by_discovery else 0
+        obj_scores = self.prog_candidate_objective_scores[0] if self.prog_candidate_objective_scores else {}
+        base = "iterations/00000"
+        self._atomic_write_json(
+            run_dir,
+            f"{base}/meta.json",
+            {
+                "iteration_id": 0,
+                "is_seed": True,
+                "accepted": True,
+                "candidate_idx": 0,
+                "parent_iteration_ids": [],
+                "avg_val_score": avg_score,
+                "num_val_scored": coverage,
+                "metric_calls_to_discover": metric_calls,
+                "objective_scores": obj_scores,
+            },
+        )
+        self._atomic_write_json(
+            run_dir,
+            f"{base}/val_scores.json",
+            {str(k): v for k, v in self.prog_candidate_val_subscores[0].items()},
+        )
+        self._save_components_dir(run_dir, base, self.program_candidates[0])
+
+    def _save_proposal_iteration_dirs(self, run_dir: str, cand_to_iter: dict[int, int]) -> None:
+        """Write one ``iterations/NNNNN/`` per loop trace entry.
+
+        Covers both accepted and rejected proposals. Iteration id is
+        ``state.i + 1`` so the seed keeps id ``0``.
+        """
+        for entry in self.full_program_trace:
+            trace_i = entry.get("i")
+            if trace_i is None:
+                continue
+            iter_id = trace_i + 1
+            base = f"iterations/{iter_id:05d}"
+            accepted = entry.get("proposal_accepted")
+            candidate_idx = entry.get("new_program_idx") if accepted else None
+            parent_candidate_idx = entry.get("selected_program_candidate")
+            parent_iter_ids = (
+                [cand_to_iter[parent_candidate_idx]]
+                if parent_candidate_idx is not None and parent_candidate_idx in cand_to_iter
+                else []
+            )
+
+            # The candidate text to archive under components/: for accepted
+            # iterations this is the newly accepted program; for rejected
+            # iterations it's the proposed (now discarded) candidate.
+            components: dict[str, str] | None = None
+            if accepted and candidate_idx is not None and candidate_idx < len(self.program_candidates):
+                components = self.program_candidates[candidate_idx]
+            elif "proposed_candidate" in entry and isinstance(entry["proposed_candidate"], dict):
+                components = entry["proposed_candidate"]
+
+            meta: dict[str, Any] = {
+                "iteration_id": iter_id,
+                "trace_i": trace_i,
+                "accepted": bool(accepted) if accepted is not None else None,
+                "parent_iteration_ids": parent_iter_ids,
+                "candidate_idx": candidate_idx,
+                "subsample_ids": entry.get("subsample_ids"),
+                "subsample_scores_before": entry.get("subsample_scores"),
+                "subsample_scores_after": entry.get("new_subsample_scores"),
+            }
+            if accepted and candidate_idx is not None and candidate_idx < len(self.prog_candidate_val_subscores):
+                avg_score, coverage = self.get_program_average_val_subset(candidate_idx)
+                meta["avg_val_score"] = avg_score
+                meta["num_val_scored"] = coverage
+                obj_scores = self.prog_candidate_objective_scores[candidate_idx]
+                if obj_scores:
+                    meta["objective_scores"] = obj_scores
+                metric_calls = (
+                    self.num_metric_calls_by_discovery[candidate_idx]
+                    if candidate_idx < len(self.num_metric_calls_by_discovery)
+                    else None
+                )
+                if metric_calls is not None:
+                    meta["metric_calls_to_discover"] = metric_calls
+            self._atomic_write_json(run_dir, f"{base}/meta.json", meta)
+
+            if components is not None:
+                self._save_components_dir(run_dir, base, components)
+
+            if accepted and candidate_idx is not None and candidate_idx < len(self.prog_candidate_val_subscores):
+                self._atomic_write_json(
+                    run_dir,
+                    f"{base}/val_scores.json",
+                    {str(k): v for k, v in self.prog_candidate_val_subscores[candidate_idx].items()},
+                )
+
+            # Raw trace entry (includes eval_before/eval_after with outputs
+            # and trajectories captured on the subsample). Kept for
+            # debugging — the structured meta.json above is the primary
+            # agent-facing artifact.
+            self._atomic_write_json(run_dir, f"{base}/trace.json", entry)
+
+    def _save_components_dir(self, run_dir: str, base: str, components: dict[str, str]) -> None:
+        """Write ``<base>/components/<stem>.txt`` plus ``_index.json``."""
         index_map: dict[str, str] = {}
         used: set[str] = set()
-        for i, (name, text) in enumerate(cand.items()):
+        for i, (name, text) in enumerate(components.items()):
             safe = _sanitize_component_name(name)
             if not safe or safe in used:
                 safe = f"component_{i:02d}"
             used.add(safe)
             index_map[name] = f"{safe}.txt"
-            self._atomic_write_text(run_dir, f"{base}/{safe}.txt", text)
-        self._atomic_write_json(run_dir, f"{base}/_index.json", index_map)
+            self._atomic_write_text(run_dir, f"{base}/components/{safe}.txt", text)
+        self._atomic_write_json(run_dir, f"{base}/components/_index.json", index_map)
 
-    def _save_pareto_dir(self, run_dir: str) -> None:
+    def _save_pareto_dir(self, run_dir: str, cand_to_iter: dict[int, int]) -> None:
+        """Write Pareto frontier files keyed by iteration id (not candidate idx).
+
+        Keeping the on-disk representation iteration-id-keyed means the agent
+        never sees the internal candidate numbering; everything is anchored
+        on the ``iterations/`` timeline.
+        """
+        def _iter_ids(candidate_idxs: "set[int]") -> list[int]:
+            return sorted({cand_to_iter[c] for c in candidate_idxs if c in cand_to_iter})
+
         if self.frontier_type in ("instance", "hybrid"):
             instance_front: dict[str, Any] = {}
             for val_id, best_score in self.pareto_front_valset.items():
-                best_progs = sorted(self.program_at_pareto_front_valset.get(val_id, set()))
                 instance_front[str(val_id)] = {
                     "best_score": best_score,
-                    "best_candidates": best_progs,
+                    "best_iteration_ids": _iter_ids(self.program_at_pareto_front_valset.get(val_id, set())),
                 }
             self._atomic_write_json(run_dir, "pareto/instance_front.json", instance_front)
 
         if self.frontier_type in ("objective", "hybrid"):
             obj_front: dict[str, Any] = {}
             for obj_name, best_score in self.objective_pareto_front.items():
-                best_progs = sorted(self.program_at_pareto_front_objectives.get(obj_name, set()))
                 obj_front[obj_name] = {
                     "best_score": best_score,
-                    "best_candidates": best_progs,
+                    "best_iteration_ids": _iter_ids(self.program_at_pareto_front_objectives.get(obj_name, set())),
                 }
             self._atomic_write_json(run_dir, "pareto/objective_front.json", obj_front)
 
         if self.frontier_type == "cartesian":
             cartesian_front: dict[str, Any] = {}
             for key, best_score in self.pareto_front_cartesian.items():
-                best_progs = sorted(self.program_at_pareto_front_cartesian.get(key, set()))
                 cartesian_front[str(key)] = {
                     "best_score": best_score,
-                    "best_candidates": best_progs,
+                    "best_iteration_ids": _iter_ids(self.program_at_pareto_front_cartesian.get(key, set())),
                 }
             self._atomic_write_json(run_dir, "pareto/cartesian_front.json", cartesian_front)
 
-    def _save_iterations_dir(self, run_dir: str) -> None:
-        for entry in self.full_program_trace:
-            i = entry.get("i")
-            if i is None:
-                continue
-            self._atomic_write_json(run_dir, f"iterations/{i:05d}.json", entry)
-
-    def _save_rejected_proposals_dir(self, run_dir: str) -> None:
-        for entry in self.full_program_trace:
-            if entry.get("proposal_accepted") is not False:
-                continue
-            if "proposed_candidate" not in entry:
-                continue
-            i = entry.get("i")
-            if i is None:
-                continue
-            self._atomic_write_json(
-                run_dir,
-                f"rejected_proposals/{i:05d}.json",
-                {
-                    "iteration": i,
-                    "candidate": entry["proposed_candidate"],
-                    "parent_ids": [entry.get("selected_program_candidate")],
-                    "subsample_ids": entry.get("subsample_ids"),
-                    "subsample_scores_before": entry.get("subsample_scores"),
-                    "subsample_scores_after": entry.get("new_subsample_scores"),
-                    "eval_before": entry.get("eval_before"),
-                    "eval_after": entry.get("eval_after"),
-                },
-            )
-
-    def _save_index(self, run_dir: str) -> None:
+    def _save_index(self, run_dir: str, cand_to_iter: dict[int, int]) -> None:
         """Write the small top-level index that points at the rest of the tree."""
         num_candidates = len(self.program_candidates)
 
@@ -509,43 +585,47 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         if self.pareto_front_valset:
             sorted_examples = sorted(self.pareto_front_valset.items(), key=lambda x: x[1])
             for val_id, score in sorted_examples[:20]:
-                best_progs = sorted(self.program_at_pareto_front_valset.get(val_id, set()))
+                best_iters = sorted({
+                    cand_to_iter[c]
+                    for c in self.program_at_pareto_front_valset.get(val_id, set())
+                    if c in cand_to_iter
+                })
                 hardest.append({
                     "val_id": str(val_id),
                     "best_score": score,
-                    "best_candidates": best_progs,
+                    "best_iteration_ids": best_iters,
                 })
 
         full_scores = self.program_full_scores_val_set
-        best_idx = (
+        best_candidate_idx = (
             int(max(range(num_candidates), key=lambda i: full_scores[i]))
             if num_candidates > 0
             else 0
         )
+        best_iter_id = cand_to_iter.get(best_candidate_idx)
 
-        front_candidates: set[int] = set()
+        front_candidate_idxs: set[int] = set()
         for prog_set in self.get_pareto_front_mapping().values():
-            front_candidates.update(prog_set)
+            front_candidate_idxs.update(prog_set)
+        front_iter_ids = sorted({cand_to_iter[c] for c in front_candidate_idxs if c in cand_to_iter})
 
         index: dict[str, Any] = {
-            "schema_version": 2,
+            "schema_version": 3,
             "iteration": self.i,
             "total_metric_calls": self.total_num_evals,
             "num_full_val_evals": self.num_full_ds_evals,
             "frontier_type": self.frontier_type,
             "component_names": self.list_of_named_predictors,
             "summary": {
-                "num_candidates": num_candidates,
-                "best_candidate_idx": best_idx,
-                "best_avg_score": full_scores[best_idx] if num_candidates > 0 else None,
-                "pareto_front_candidate_idxs": sorted(front_candidates),
+                "num_iterations": len(cand_to_iter),
+                "best_iteration_id": best_iter_id,
+                "best_avg_score": full_scores[best_candidate_idx] if num_candidates > 0 else None,
+                "pareto_front_iteration_ids": front_iter_ids,
                 "hardest_examples": hardest,
             },
             "layout": {
-                "candidates_dir": "candidates/",
-                "pareto_dir": "pareto/",
                 "iterations_dir": "iterations/",
-                "rejected_proposals_dir": "rejected_proposals/",
+                "pareto_dir": "pareto/",
             },
         }
 
@@ -575,6 +655,7 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         assert len(state.program_candidates) == len(state.num_metric_calls_by_discovery)
         assert len(state.program_candidates) == len(state.parent_program_for_candidate)
         assert len(state.program_candidates) == len(state.named_predictor_id_to_update_next_for_program_candidate)
+        assert len(state.program_candidates) == len(state.iteration_ids_by_candidate_idx)
         assert len(state.pareto_front_valset) == len(state.program_at_pareto_front_valset)
         assert set(state.pareto_front_valset.keys()) == set(state.program_at_pareto_front_valset.keys())
         assert set(state.objective_pareto_front.keys()) == set(state.program_at_pareto_front_objectives.keys())
@@ -623,6 +704,22 @@ class GEPAState(Generic[RolloutOutput, DataId]):
             d["evaluation_cache"] = None
         if "adapter_state" not in d:
             d["adapter_state"] = {}
+        if "iteration_ids_by_candidate_idx" not in d:
+            # v5 → v6: reconstruct on-disk iteration ids by walking the
+            # full trace. Seed gets 0; every accepted trace entry maps its
+            # ``new_program_idx`` to ``trace_i + 1``. Missing entries fall
+            # back to ``-1`` (shouldn't happen for a consistent state, but
+            # keeps the list length aligned with ``program_candidates``).
+            mapping = {0: 0}
+            for entry in d.get("full_program_trace", []):
+                if not entry.get("proposal_accepted"):
+                    continue
+                cand_idx = entry.get("new_program_idx")
+                trace_i = entry.get("i")
+                if cand_idx is None or trace_i is None:
+                    continue
+                mapping[cand_idx] = trace_i + 1
+            d["iteration_ids_by_candidate_idx"] = [mapping.get(i, -1) for i in range(num_candidates)]
         d["validation_schema_version"] = GEPAState._VALIDATION_SCHEMA_VERSION
 
     @staticmethod
@@ -737,9 +834,18 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         valset_evaluation: ValsetEvaluation,
         run_dir: str | None,
         num_metric_calls_by_discovery_of_new_program: int,
+        iteration: int | None = None,
     ) -> ProgramIdx:
+        # ``iteration`` is the 1-indexed on-disk iteration id for the
+        # proposal that produced this candidate — same numbering
+        # ``ctx.iteration`` uses (``state.i + 1``). Seed is iter id 0, so
+        # loop iterations start at 1. Falls back to ``self.i + 1`` when
+        # the caller hasn't plumbed it.
+        if iteration is None:
+            iteration = self.i + 1
         new_program_idx = len(self.program_candidates)
         self.program_candidates.append(dict(new_program))
+        self.iteration_ids_by_candidate_idx.append(iteration)
         self.num_metric_calls_by_discovery.append(num_metric_calls_by_discovery_of_new_program)
 
         max_predictor_id = max(

--- a/src/gepa/gepa_utils.py
+++ b/src/gepa/gepa_utils.py
@@ -14,6 +14,23 @@ def json_default(x):
         return repr(x)
 
 
+def try_json_serialize(obj: Any) -> Any:
+    """Best-effort JSON-safe conversion. Returns *obj* if serializable, else ``str(obj)``."""
+    if obj is None or isinstance(obj, str | int | float | bool):
+        return obj
+    if isinstance(obj, dict):
+        return {str(k): try_json_serialize(v) for k, v in obj.items()}
+    if isinstance(obj, list | tuple):
+        return [try_json_serialize(v) for v in obj]
+    try:
+        import json
+
+        json.dumps(obj)
+        return obj
+    except (TypeError, ValueError, OverflowError):
+        return str(obj)
+
+
 def idxmax(lst: list[float]) -> int:
     """Return the index of the maximum value in a list."""
     max_val = max(lst)

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -462,10 +462,13 @@ class EngineConfig:
     raise_on_exception: bool = True
     use_cloudpickle: bool = True
     track_best_outputs: bool = True
-    # Write an agent-readable directory tree (candidates/, pareto/, iterations/,
-    # rejected_proposals/, eval_cache/) under ``run_dir`` on every save. Default
-    # off — when enabled, each iteration records extra eval trace payloads so
-    # the rejected_proposals files have before/after scores and trajectories.
+    # Write an agent-readable directory tree (``iterations/NNNNN/`` +
+    # ``pareto/``) under ``run_dir`` on every save. Each loop iteration —
+    # accepted or rejected — gets its own directory with ``meta.json``,
+    # ``components/``, ``trace.json`` (with before/after scores and
+    # trajectories), plus ``val_scores.json`` + ``outputs/`` + ``trajectories/``
+    # for accepted ones. The seed is pinned at ``iterations/00000/``. Default
+    # off.
     write_agent_state: bool = False
 
     # Simple stopping conditions

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -462,6 +462,11 @@ class EngineConfig:
     raise_on_exception: bool = True
     use_cloudpickle: bool = True
     track_best_outputs: bool = True
+    # Write an agent-readable directory tree (candidates/, pareto/, iterations/,
+    # rejected_proposals/, eval_cache/) under ``run_dir`` on every save. Default
+    # off — when enabled, each iteration records extra eval trace payloads so
+    # the rejected_proposals files have before/after scores and trajectories.
+    write_agent_state: bool = False
 
     # Simple stopping conditions
     max_metric_calls: int | None = None
@@ -1607,6 +1612,7 @@ def optimize_anything(
         val_evaluation_policy=config.engine.val_evaluation_policy,
         acceptance_criterion=acceptance_criterion_instance,
         use_cloudpickle=config.engine.use_cloudpickle,
+        write_agent_state=config.engine.write_agent_state,
         evaluation_cache=evaluation_cache,
         num_parallel_proposals=_resolve_num_parallel_proposals(
             config.engine.num_parallel_proposals,

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -122,20 +122,37 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
         candidate: dict[str, str],
         reflective_dataset: Mapping[str, Sequence[Mapping[str, Any]]],
         components_to_update: list[str],
+        *,
+        metadata: Mapping[str, Any] | None = None,
     ) -> tuple[dict[str, str], dict[str, str | list[dict[str, Any]]], dict[str, str]]:
         """Propose new instruction texts for the given components.
 
+        ``metadata`` is an open-ended context dict forwarded unconditionally
+        to ``custom_candidate_proposer``. Keys GEPA currently supplies:
+        ``"iteration"`` — the 1-indexed iteration number (same value shown
+        in ``Iteration N:`` log lines; equals ``state.i + 1`` and the
+        on-disk ``iterations/NNNNN/`` id) — and ``"parent_iteration_id"``
+        (on-disk iteration id of the parent candidate). The adapter-owned
+        ``propose_new_texts`` path keeps its legacy 3-positional signature.
+
         Returns:
             A tuple of (new_texts, prompts, raw_lm_outputs) where each is a
-            dict keyed by component name.  When the adapter or a custom proposer
-            handles the call, prompts and raw_lm_outputs are empty dicts.
+            dict keyed by component name. When the adapter or a custom
+            proposer handles the call, prompts and raw_lm_outputs are empty
+            dicts.
         """
         empty: dict[str, str | list[dict[str, Any]]] = {}
         if self.adapter.propose_new_texts is not None:
             return self.adapter.propose_new_texts(candidate, reflective_dataset, components_to_update), empty, {}
 
         if self.custom_candidate_proposer is not None:
-            return self.custom_candidate_proposer(candidate, reflective_dataset, components_to_update), empty, {}
+            new_texts = self.custom_candidate_proposer(
+                candidate,
+                reflective_dataset,
+                components_to_update,
+                metadata=metadata,
+            )
+            return new_texts, empty, {}
 
         if self.reflection_lm is None:
             raise ValueError("reflection_lm must be provided when adapter.propose_new_texts is None.")
@@ -366,8 +383,19 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
                 ),
             )
 
+            # Context dict forwarded to custom proposers. Resolve the
+            # parent's on-disk iteration id (what the agent sees under
+            # ``iterations/NNNNN/``) rather than leaking the internal
+            # candidate idx through the API surface.
+            parent_iteration_id = state.iteration_id_for_candidate_idx(ctx.curr_prog_id)
             new_texts, prompts, raw_lm_outputs = self.propose_new_texts(
-                ctx.curr_prog, reflective_dataset, predictor_names_to_update
+                ctx.curr_prog,
+                reflective_dataset,
+                predictor_names_to_update,
+                metadata={
+                    "iteration": ctx.iteration,
+                    "parent_iteration_id": parent_iteration_id,
+                },
             )
 
             notify_callbacks(

--- a/tests/test_candidate_selector.py
+++ b/tests/test_candidate_selector.py
@@ -46,6 +46,9 @@ def mock_state():
     state.num_metric_calls_by_discovery.append(0)
     state.num_metric_calls_by_discovery.append(0)
 
+    state.iteration_ids_by_candidate_idx.append(1)
+    state.iteration_ids_by_candidate_idx.append(2)
+
     # Update pareto front to include all candidates
     for i in range(len(state.pareto_front_valset)):
         state.program_at_pareto_front_valset[i] = {0, 1, 2}

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -115,8 +115,8 @@ def test_gepa_state_save_and_initialize(run_dir):
     assert state.__dict__ == result.__dict__
 
 
-def test_agent_state_json_export(run_dir):
-    """save() writes a comprehensive gepa_state.json for agent consumption."""
+def test_agent_state_directory_layout(run_dir):
+    """save(write_agent_state=True) writes a directory tree of small files."""
     seed = {"system_prompt": "You are helpful."}
     valset_out = ValsetEvaluation(
         outputs_by_val_id={0: "out0", 1: "out1", 2: "out2"},
@@ -131,54 +131,76 @@ def test_agent_state_json_export(run_dir):
     state = state_mod.GEPAState(seed, valset_out, frontier_type="hybrid")
     state.total_num_evals = 10
     state.num_full_ds_evals = 1
-    state.save(run_dir)
+    state.save(run_dir, write_agent_state=True)
 
-    import json
+    run_dir_path = Path(str(run_dir))
 
-    agent_state_path = os.path.join(str(run_dir), "gepa_state.json")
-    assert os.path.exists(agent_state_path)
-    with open(agent_state_path) as f:
-        data = json.load(f)
+    # Top-level index is the small navigation file.
+    with open(run_dir_path / "gepa_state.json") as f:
+        index = json.load(f)
+    assert index["schema_version"] == 2
+    assert index["frontier_type"] == "hybrid"
+    assert index["iteration"] == state.i
+    assert index["component_names"] == ["system_prompt"]
+    assert index["summary"]["num_candidates"] == 1
+    assert index["summary"]["best_candidate_idx"] == 0
+    assert index["summary"]["hardest_examples"][0]["best_score"] == 0.3
+    assert "candidates_dir" in index["layout"]
+    # Bulky payloads must not live in the index.
+    assert "candidates" not in index
+    assert "iteration_log" not in index
+    assert "rejected_proposals" not in index
 
-    # Check top-level structure
-    assert data["schema_version"] == 2
-    assert data["frontier_type"] == "hybrid"
-    assert "candidates" in data
-    assert "pareto_front" in data
-    assert "summary" in data
-    assert "iteration_log" in data
+    # Candidate subtree.
+    cand_meta_path = run_dir_path / "candidates" / "00000" / "meta.json"
+    assert cand_meta_path.exists()
+    with open(cand_meta_path) as f:
+        meta = json.load(f)
+    assert meta["idx"] == 0
+    assert meta["num_val_scored"] == 3
+    assert meta["parent_ids"] == []
+    assert meta["avg_val_score"] == pytest.approx(0.5)
 
-    # Check candidate data
-    assert len(data["candidates"]) == 1
-    cand = data["candidates"][0]
-    assert cand["idx"] == 0
-    assert cand["texts"] == {"system_prompt": "You are helpful."}
-    assert cand["avg_val_score"] > 0
-    assert cand["num_val_scored"] == 3
-    assert "0" in cand["val_scores"]
-    assert cand["val_scores"]["0"] == 0.3
+    with open(run_dir_path / "candidates" / "00000" / "val_scores.json") as f:
+        val_scores = json.load(f)
+    assert val_scores == {"0": 0.3, "1": 0.7, "2": 0.5}
 
-    # Check Pareto front
-    assert "instance_front" in data["pareto_front"]
-    assert "objective_front" in data["pareto_front"]
+    # Component text lives as raw .txt, mapped from real name via _index.json.
+    with open(run_dir_path / "candidates" / "00000" / "components" / "_index.json") as f:
+        comp_index = json.load(f)
+    assert comp_index == {"system_prompt": "system_prompt.txt"}
+    comp_path = run_dir_path / "candidates" / "00000" / "components" / "system_prompt.txt"
+    assert comp_path.read_text() == "You are helpful."
 
-    # Check summary
-    assert data["summary"]["num_candidates"] == 1
-    assert data["summary"]["best_candidate_idx"] == 0
-    assert len(data["summary"]["hardest_examples"]) > 0
-    # Hardest example should be val_id=0 with score 0.3
-    assert data["summary"]["hardest_examples"][0]["best_score"] == 0.3
-
-    # Check rejected_proposals section exists
-    assert "rejected_proposals" in data
-    assert isinstance(data["rejected_proposals"], list)
-
-    # Check evaluation_cache field exists (None since cache not enabled)
-    assert "evaluation_cache" in data
+    # Pareto subtree — only files matching frontier_type should exist.
+    assert (run_dir_path / "pareto" / "instance_front.json").exists()
+    assert (run_dir_path / "pareto" / "objective_front.json").exists()
+    assert not (run_dir_path / "pareto" / "cartesian_front.json").exists()
 
 
-def test_agent_state_with_cache_and_rejection(run_dir):
-    """Agent state exports evaluation cache and rejected proposals."""
+def test_agent_state_default_off(run_dir):
+    """save() without write_agent_state=True does not create the agent tree."""
+    seed = {"system_prompt": "hi"}
+    valset_out = ValsetEvaluation(
+        outputs_by_val_id={0: "out"},
+        scores_by_val_id={0: 0.5},
+        objective_scores_by_val_id=None,
+    )
+    state = state_mod.GEPAState(seed, valset_out)
+    state.total_num_evals = 1
+    state.num_full_ds_evals = 1
+    state.save(run_dir)  # default: write_agent_state=False
+
+    run_dir_path = Path(str(run_dir))
+    assert not (run_dir_path / "gepa_state.json").exists()
+    assert not (run_dir_path / "candidates").exists()
+    assert not (run_dir_path / "pareto").exists()
+    # Legacy outputs still produced.
+    assert (run_dir_path / "gepa_state.bin").exists()
+
+
+def test_agent_state_cache_and_rejected_proposals(run_dir):
+    """eval_cache/ and rejected_proposals/ get their own per-item files."""
     seed = {"prompt": "hello"}
     valset_out = ValsetEvaluation(
         outputs_by_val_id={0: "out0", 1: "out1"},
@@ -189,14 +211,12 @@ def test_agent_state_with_cache_and_rejection(run_dir):
     state.total_num_evals = 10
     state.num_full_ds_evals = 1
 
-    # Enable evaluation cache and populate it
     state.evaluation_cache = state_mod.EvaluationCache()
     state.evaluation_cache.put({"prompt": "hello"}, 0, "cached_output_0", 0.5)
     state.evaluation_cache.put({"prompt": "hello"}, 1, "cached_output_1", 0.5)
 
-    # Simulate a rejected proposal in the trace
     state.full_program_trace.append({
-        "i": 0,
+        "i": 7,
         "selected_program_candidate": 0,
         "subsample_ids": [0],
         "subsample_scores": [0.5],
@@ -207,30 +227,63 @@ def test_agent_state_with_cache_and_rejection(run_dir):
         "eval_after": {"scores": [0.3], "trajectories": ["trace_after"]},
     })
 
-    state.save(run_dir)
+    state.save(run_dir, write_agent_state=True)
 
-    import json
+    run_dir_path = Path(str(run_dir))
 
-    with open(os.path.join(str(run_dir), "gepa_state.json")) as f:
-        data = json.load(f)
+    # Eval cache: one file per candidate, keyed by val_id inside.
+    cache_file = run_dir_path / "eval_cache" / "00000.json"
+    assert cache_file.exists()
+    with open(cache_file) as f:
+        cache = json.load(f)
+    assert cache["0"]["score"] == 0.5
+    assert cache["0"]["output"] == "cached_output_0"
+    assert cache["1"]["output"] == "cached_output_1"
 
-    # Check evaluation cache
-    assert data["evaluation_cache"] is not None
-    assert "0" in data["evaluation_cache"]  # candidate idx 0
-    assert "0" in data["evaluation_cache"]["0"]  # val_id 0
-    assert data["evaluation_cache"]["0"]["0"]["score"] == 0.5
-    assert data["evaluation_cache"]["0"]["0"]["output"] == "cached_output_0"
-
-    # Check rejected proposals
-    assert len(data["rejected_proposals"]) == 1
-    rej = data["rejected_proposals"][0]
+    # Rejected proposal: one file per rejecting iteration.
+    rej_file = run_dir_path / "rejected_proposals" / "00007.json"
+    assert rej_file.exists()
+    with open(rej_file) as f:
+        rej = json.load(f)
+    assert rej["iteration"] == 7
     assert rej["candidate"] == {"prompt": "rejected attempt"}
     assert rej["parent_ids"] == [0]
-    assert rej["subsample_ids"] == [0]
     assert rej["subsample_scores_before"] == [0.5]
     assert rej["subsample_scores_after"] == [0.3]
     assert rej["eval_before"]["trajectories"] == ["trace_before"]
     assert rej["eval_after"]["trajectories"] == ["trace_after"]
+
+    # Iteration trace file for the same iteration also written.
+    iter_file = run_dir_path / "iterations" / "00007.json"
+    assert iter_file.exists()
+    with open(iter_file) as f:
+        iter_entry = json.load(f)
+    assert iter_entry["i"] == 7
+    assert iter_entry["proposal_accepted"] is False
+
+
+def test_agent_state_sanitizes_component_names(run_dir):
+    """Component names with unsafe filesystem chars get sanitized; _index.json preserves the real name."""
+    seed = {"sys/prompt v1": "hello", "sys prompt": "world"}
+    valset_out = ValsetEvaluation(
+        outputs_by_val_id={0: "out"},
+        scores_by_val_id={0: 0.5},
+        objective_scores_by_val_id=None,
+    )
+    state = state_mod.GEPAState(seed, valset_out)
+    state.total_num_evals = 1
+    state.num_full_ds_evals = 1
+    state.save(run_dir, write_agent_state=True)
+
+    comp_dir = Path(str(run_dir)) / "candidates" / "00000" / "components"
+    with open(comp_dir / "_index.json") as f:
+        index = json.load(f)
+    # Real names preserved as keys; slashes and spaces become underscores in filenames.
+    assert set(index.keys()) == {"sys/prompt v1", "sys prompt"}
+    for real_name, fname in index.items():
+        assert "/" not in fname
+        assert " " not in fname
+        assert (comp_dir / fname).read_text() == seed[real_name]
 
 
 def test_budget_hooks_excluded_from_serialization(run_dir):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -199,8 +199,8 @@ def test_agent_state_default_off(run_dir):
     assert (run_dir_path / "gepa_state.bin").exists()
 
 
-def test_agent_state_cache_and_rejected_proposals(run_dir):
-    """eval_cache/ and rejected_proposals/ get their own per-item files."""
+def test_agent_state_rejected_proposals(run_dir):
+    """rejected_proposals/ and iterations/ get their own per-item files."""
     seed = {"prompt": "hello"}
     valset_out = ValsetEvaluation(
         outputs_by_val_id={0: "out0", 1: "out1"},
@@ -210,10 +210,6 @@ def test_agent_state_cache_and_rejected_proposals(run_dir):
     state = state_mod.GEPAState(seed, valset_out)
     state.total_num_evals = 10
     state.num_full_ds_evals = 1
-
-    state.evaluation_cache = state_mod.EvaluationCache()
-    state.evaluation_cache.put({"prompt": "hello"}, 0, "cached_output_0", 0.5)
-    state.evaluation_cache.put({"prompt": "hello"}, 1, "cached_output_1", 0.5)
 
     state.full_program_trace.append({
         "i": 7,
@@ -230,15 +226,6 @@ def test_agent_state_cache_and_rejected_proposals(run_dir):
     state.save(run_dir, write_agent_state=True)
 
     run_dir_path = Path(str(run_dir))
-
-    # Eval cache: one file per candidate, keyed by val_id inside.
-    cache_file = run_dir_path / "eval_cache" / "00000.json"
-    assert cache_file.exists()
-    with open(cache_file) as f:
-        cache = json.load(f)
-    assert cache["0"]["score"] == 0.5
-    assert cache["0"]["output"] == "cached_output_0"
-    assert cache["1"]["output"] == "cached_output_1"
 
     # Rejected proposal: one file per rejecting iteration.
     rej_file = run_dir_path / "rejected_proposals" / "00007.json"
@@ -260,6 +247,100 @@ def test_agent_state_cache_and_rejected_proposals(run_dir):
         iter_entry = json.load(f)
     assert iter_entry["i"] == 7
     assert iter_entry["proposal_accepted"] is False
+
+    # Eval cache is no longer exported to the tree.
+    assert not (run_dir_path / "eval_cache").exists()
+    index = json.loads((run_dir_path / "gepa_state.json").read_text())
+    assert "eval_cache_dir" not in index["layout"]
+
+
+def test_agent_state_e2e_writes_per_candidate_outputs_and_trajectories(run_dir):
+    """Running the engine with write_agent_state=True writes per-candidate
+    outputs/ and trajectories/ alongside the directory tree."""
+    import gepa as gepa_mod
+
+    trainset = [{"id": i, "difficulty": i + 2} for i in range(2)]
+    valset = [{"id": i, "difficulty": i + 2} for i in range(2)]
+
+    class DummyAdapter:
+        def evaluate(self, batch, candidate, capture_traces=False):
+            weight = int(candidate["system_prompt"].split("=")[-1])
+            outputs = [{"id": item["id"], "weight": weight} for item in batch]
+            scores = [min(1.0, (weight + 1) / item["difficulty"]) for item in batch]
+            trajectories = (
+                [{"score": s, "weight": weight} for s in scores] if capture_traces else None
+            )
+            return EvaluationBatch(outputs=outputs, scores=scores, trajectories=trajectories)
+
+        def make_reflective_dataset(self, candidate, eval_batch, components_to_update):
+            return dict.fromkeys(components_to_update, [{"score": s} for s in eval_batch.scores])
+
+        def propose_new_texts(self, candidate, reflective_dataset, components_to_update):
+            weight = int(candidate["system_prompt"].split("=")[-1])
+            return dict.fromkeys(components_to_update, f"weight={weight + 1}")
+
+    gepa_mod.optimize(
+        seed_candidate={"system_prompt": "weight=0"},
+        trainset=trainset,
+        valset=valset,
+        adapter=DummyAdapter(),
+        reflection_lm=None,
+        max_metric_calls=6,
+        run_dir=str(run_dir),
+        write_agent_state=True,
+    )
+
+    run_dir_path = Path(str(run_dir))
+
+    # Seed (idx 0) outputs and trajectories written.
+    assert (run_dir_path / "candidates" / "00000" / "outputs" / "0.json").exists()
+    assert (run_dir_path / "candidates" / "00000" / "outputs" / "1.json").exists()
+    assert (run_dir_path / "candidates" / "00000" / "trajectories" / "0.json").exists()
+    with open(run_dir_path / "candidates" / "00000" / "outputs" / "0.json") as f:
+        seed_out = json.load(f)
+    assert seed_out == {"id": 0, "weight": 0}
+    with open(run_dir_path / "candidates" / "00000" / "trajectories" / "0.json") as f:
+        seed_traj = json.load(f)
+    assert seed_traj["weight"] == 0
+
+    # At least one accepted descendant candidate should also have outputs.
+    cand_dirs = sorted((run_dir_path / "candidates").iterdir())
+    assert len(cand_dirs) >= 2
+    for cand_dir in cand_dirs[1:]:
+        assert (cand_dir / "outputs" / "0.json").exists()
+        assert (cand_dir / "trajectories" / "0.json").exists()
+
+
+def test_agent_state_off_does_not_write_outputs(run_dir):
+    """With write_agent_state=False (default), no outputs/ subtree is produced."""
+    import gepa as gepa_mod
+
+    trainset = [{"id": 0, "difficulty": 2}]
+    valset = [{"id": 0, "difficulty": 2}]
+
+    class DummyAdapter:
+        def evaluate(self, batch, candidate, capture_traces=False):
+            return EvaluationBatch(outputs=[{"id": 0}], scores=[0.5], trajectories=None)
+
+        def make_reflective_dataset(self, candidate, eval_batch, components_to_update):
+            return dict.fromkeys(components_to_update, [{"score": 0.5}])
+
+        def propose_new_texts(self, candidate, reflective_dataset, components_to_update):
+            return dict.fromkeys(components_to_update, "new")
+
+    gepa_mod.optimize(
+        seed_candidate={"system_prompt": "x"},
+        trainset=trainset,
+        valset=valset,
+        adapter=DummyAdapter(),
+        reflection_lm=None,
+        max_metric_calls=2,
+        run_dir=str(run_dir),
+    )
+
+    run_dir_path = Path(str(run_dir))
+    assert not (run_dir_path / "candidates").exists()
+    assert not (run_dir_path / "gepa_state.json").exists()
 
 
 def test_agent_state_sanitizes_component_names(run_dir):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -141,7 +141,7 @@ def test_agent_state_json_export(run_dir):
         data = json.load(f)
 
     # Check top-level structure
-    assert data["schema_version"] == 1
+    assert data["schema_version"] == 2
     assert data["frontier_type"] == "hybrid"
     assert "candidates" in data
     assert "pareto_front" in data
@@ -168,6 +168,69 @@ def test_agent_state_json_export(run_dir):
     assert len(data["summary"]["hardest_examples"]) > 0
     # Hardest example should be val_id=0 with score 0.3
     assert data["summary"]["hardest_examples"][0]["best_score"] == 0.3
+
+    # Check rejected_proposals section exists
+    assert "rejected_proposals" in data
+    assert isinstance(data["rejected_proposals"], list)
+
+    # Check evaluation_cache field exists (None since cache not enabled)
+    assert "evaluation_cache" in data
+
+
+def test_agent_state_with_cache_and_rejection(run_dir):
+    """Agent state exports evaluation cache and rejected proposals."""
+    seed = {"prompt": "hello"}
+    valset_out = ValsetEvaluation(
+        outputs_by_val_id={0: "out0", 1: "out1"},
+        scores_by_val_id={0: 0.5, 1: 0.5},
+        objective_scores_by_val_id=None,
+    )
+    state = state_mod.GEPAState(seed, valset_out)
+    state.total_num_evals = 10
+    state.num_full_ds_evals = 1
+
+    # Enable evaluation cache and populate it
+    state.evaluation_cache = state_mod.EvaluationCache()
+    state.evaluation_cache.put({"prompt": "hello"}, 0, "cached_output_0", 0.5)
+    state.evaluation_cache.put({"prompt": "hello"}, 1, "cached_output_1", 0.5)
+
+    # Simulate a rejected proposal in the trace
+    state.full_program_trace.append({
+        "i": 0,
+        "selected_program_candidate": 0,
+        "subsample_ids": [0],
+        "subsample_scores": [0.5],
+        "new_subsample_scores": [0.3],
+        "proposal_accepted": False,
+        "proposed_candidate": {"prompt": "rejected attempt"},
+        "eval_before": {"scores": [0.5], "trajectories": ["trace_before"]},
+        "eval_after": {"scores": [0.3], "trajectories": ["trace_after"]},
+    })
+
+    state.save(run_dir)
+
+    import json
+
+    with open(os.path.join(str(run_dir), "gepa_state.json")) as f:
+        data = json.load(f)
+
+    # Check evaluation cache
+    assert data["evaluation_cache"] is not None
+    assert "0" in data["evaluation_cache"]  # candidate idx 0
+    assert "0" in data["evaluation_cache"]["0"]  # val_id 0
+    assert data["evaluation_cache"]["0"]["0"]["score"] == 0.5
+    assert data["evaluation_cache"]["0"]["0"]["output"] == "cached_output_0"
+
+    # Check rejected proposals
+    assert len(data["rejected_proposals"]) == 1
+    rej = data["rejected_proposals"][0]
+    assert rej["candidate"] == {"prompt": "rejected attempt"}
+    assert rej["parent_ids"] == [0]
+    assert rej["subsample_ids"] == [0]
+    assert rej["subsample_scores_before"] == [0.5]
+    assert rej["subsample_scores_after"] == [0.3]
+    assert rej["eval_before"]["trajectories"] == ["trace_before"]
+    assert rej["eval_after"]["trajectories"] == ["trace_after"]
 
 
 def test_budget_hooks_excluded_from_serialization(run_dir):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -116,7 +116,11 @@ def test_gepa_state_save_and_initialize(run_dir):
 
 
 def test_agent_state_directory_layout(run_dir):
-    """save(write_agent_state=True) writes a directory tree of small files."""
+    """save(write_agent_state=True) writes a unified iterations/ tree.
+
+    Seed lands at iterations/00000/ (is_seed=True); there are no separate
+    ``candidates/`` or ``rejected_proposals/`` trees any more.
+    """
     seed = {"system_prompt": "You are helpful."}
     valset_out = ValsetEvaluation(
         outputs_by_val_id={0: "out0", 1: "out1", 2: "out2"},
@@ -138,44 +142,54 @@ def test_agent_state_directory_layout(run_dir):
     # Top-level index is the small navigation file.
     with open(run_dir_path / "gepa_state.json") as f:
         index = json.load(f)
-    assert index["schema_version"] == 2
+    assert index["schema_version"] == 3
     assert index["frontier_type"] == "hybrid"
     assert index["iteration"] == state.i
     assert index["component_names"] == ["system_prompt"]
-    assert index["summary"]["num_candidates"] == 1
-    assert index["summary"]["best_candidate_idx"] == 0
+    assert index["summary"]["num_iterations"] == 1
+    assert index["summary"]["best_iteration_id"] == 0
     assert index["summary"]["hardest_examples"][0]["best_score"] == 0.3
-    assert "candidates_dir" in index["layout"]
-    # Bulky payloads must not live in the index.
-    assert "candidates" not in index
-    assert "iteration_log" not in index
-    assert "rejected_proposals" not in index
+    assert index["layout"] == {"iterations_dir": "iterations/", "pareto_dir": "pareto/"}
 
-    # Candidate subtree.
-    cand_meta_path = run_dir_path / "candidates" / "00000" / "meta.json"
-    assert cand_meta_path.exists()
-    with open(cand_meta_path) as f:
+    # Legacy trees must be absent.
+    assert not (run_dir_path / "candidates").exists()
+    assert not (run_dir_path / "rejected_proposals").exists()
+
+    # Seed iteration subtree.
+    seed_meta_path = run_dir_path / "iterations" / "00000" / "meta.json"
+    assert seed_meta_path.exists()
+    with open(seed_meta_path) as f:
         meta = json.load(f)
-    assert meta["idx"] == 0
+    assert meta["iteration_id"] == 0
+    assert meta["is_seed"] is True
+    assert meta["accepted"] is True
+    assert meta["candidate_idx"] == 0
     assert meta["num_val_scored"] == 3
-    assert meta["parent_ids"] == []
+    assert meta["parent_iteration_ids"] == []
     assert meta["avg_val_score"] == pytest.approx(0.5)
 
-    with open(run_dir_path / "candidates" / "00000" / "val_scores.json") as f:
+    with open(run_dir_path / "iterations" / "00000" / "val_scores.json") as f:
         val_scores = json.load(f)
     assert val_scores == {"0": 0.3, "1": 0.7, "2": 0.5}
 
     # Component text lives as raw .txt, mapped from real name via _index.json.
-    with open(run_dir_path / "candidates" / "00000" / "components" / "_index.json") as f:
+    with open(run_dir_path / "iterations" / "00000" / "components" / "_index.json") as f:
         comp_index = json.load(f)
     assert comp_index == {"system_prompt": "system_prompt.txt"}
-    comp_path = run_dir_path / "candidates" / "00000" / "components" / "system_prompt.txt"
+    comp_path = run_dir_path / "iterations" / "00000" / "components" / "system_prompt.txt"
     assert comp_path.read_text() == "You are helpful."
 
     # Pareto subtree — only files matching frontier_type should exist.
     assert (run_dir_path / "pareto" / "instance_front.json").exists()
     assert (run_dir_path / "pareto" / "objective_front.json").exists()
     assert not (run_dir_path / "pareto" / "cartesian_front.json").exists()
+
+    # Pareto files now key on iteration ids, not candidate idxs.
+    with open(run_dir_path / "pareto" / "instance_front.json") as f:
+        front = json.load(f)
+    for entry in front.values():
+        assert "best_iteration_ids" in entry
+        assert "best_candidates" not in entry
 
 
 def test_agent_state_default_off(run_dir):
@@ -193,14 +207,17 @@ def test_agent_state_default_off(run_dir):
 
     run_dir_path = Path(str(run_dir))
     assert not (run_dir_path / "gepa_state.json").exists()
-    assert not (run_dir_path / "candidates").exists()
+    assert not (run_dir_path / "iterations").exists()
     assert not (run_dir_path / "pareto").exists()
     # Legacy outputs still produced.
     assert (run_dir_path / "gepa_state.bin").exists()
 
 
 def test_agent_state_rejected_proposals(run_dir):
-    """rejected_proposals/ and iterations/ get their own per-item files."""
+    """Rejected proposals live under iterations/NNNNN/ alongside accepted ones.
+
+    On-disk iteration id = trace ``i`` + 1 (seed owns id 0).
+    """
     seed = {"prompt": "hello"}
     valset_out = ValsetEvaluation(
         outputs_by_val_id={0: "out0", 1: "out1"},
@@ -227,36 +244,40 @@ def test_agent_state_rejected_proposals(run_dir):
 
     run_dir_path = Path(str(run_dir))
 
-    # Rejected proposal: one file per rejecting iteration.
-    rej_file = run_dir_path / "rejected_proposals" / "00007.json"
-    assert rej_file.exists()
-    with open(rej_file) as f:
-        rej = json.load(f)
-    assert rej["iteration"] == 7
-    assert rej["candidate"] == {"prompt": "rejected attempt"}
-    assert rej["parent_ids"] == [0]
-    assert rej["subsample_scores_before"] == [0.5]
-    assert rej["subsample_scores_after"] == [0.3]
-    assert rej["eval_before"]["trajectories"] == ["trace_before"]
-    assert rej["eval_after"]["trajectories"] == ["trace_after"]
+    iter_dir = run_dir_path / "iterations" / "00008"
+    assert iter_dir.is_dir()
 
-    # Iteration trace file for the same iteration also written.
-    iter_file = run_dir_path / "iterations" / "00007.json"
-    assert iter_file.exists()
-    with open(iter_file) as f:
-        iter_entry = json.load(f)
-    assert iter_entry["i"] == 7
-    assert iter_entry["proposal_accepted"] is False
+    with open(iter_dir / "meta.json") as f:
+        meta = json.load(f)
+    assert meta["iteration_id"] == 8
+    assert meta["trace_i"] == 7
+    assert meta["accepted"] is False
+    assert meta["candidate_idx"] is None
+    assert meta["parent_iteration_ids"] == [0]
+    assert meta["subsample_scores_before"] == [0.5]
+    assert meta["subsample_scores_after"] == [0.3]
+    assert "avg_val_score" not in meta  # rejected: no full valset eval
 
-    # Eval cache is no longer exported to the tree.
-    assert not (run_dir_path / "eval_cache").exists()
-    index = json.loads((run_dir_path / "gepa_state.json").read_text())
-    assert "eval_cache_dir" not in index["layout"]
+    # Components archived even for rejected proposals.
+    comp_path = iter_dir / "components" / "prompt.txt"
+    assert comp_path.exists()
+    assert comp_path.read_text() == "rejected attempt"
+
+    # Raw trace entry kept alongside for debugging.
+    with open(iter_dir / "trace.json") as f:
+        trace = json.load(f)
+    assert trace["i"] == 7
+    assert trace["proposal_accepted"] is False
+    assert trace["eval_before"]["trajectories"] == ["trace_before"]
+
+    # Legacy trees gone.
+    assert not (run_dir_path / "rejected_proposals").exists()
+    assert not (run_dir_path / "candidates").exists()
 
 
-def test_agent_state_e2e_writes_per_candidate_outputs_and_trajectories(run_dir):
-    """Running the engine with write_agent_state=True writes per-candidate
-    outputs/ and trajectories/ alongside the directory tree."""
+def test_agent_state_e2e_writes_per_iteration_outputs_and_trajectories(run_dir):
+    """Running the engine with write_agent_state=True writes per-iteration
+    outputs/ and trajectories/ under iterations/<iter_id>/."""
     import gepa as gepa_mod
 
     trainset = [{"id": i, "difficulty": i + 2} for i in range(2)]
@@ -292,23 +313,26 @@ def test_agent_state_e2e_writes_per_candidate_outputs_and_trajectories(run_dir):
 
     run_dir_path = Path(str(run_dir))
 
-    # Seed (idx 0) outputs and trajectories written.
-    assert (run_dir_path / "candidates" / "00000" / "outputs" / "0.json").exists()
-    assert (run_dir_path / "candidates" / "00000" / "outputs" / "1.json").exists()
-    assert (run_dir_path / "candidates" / "00000" / "trajectories" / "0.json").exists()
-    with open(run_dir_path / "candidates" / "00000" / "outputs" / "0.json") as f:
+    # Seed at iterations/00000/ — outputs and trajectories present.
+    assert (run_dir_path / "iterations" / "00000" / "outputs" / "0.json").exists()
+    assert (run_dir_path / "iterations" / "00000" / "outputs" / "1.json").exists()
+    assert (run_dir_path / "iterations" / "00000" / "trajectories" / "0.json").exists()
+    with open(run_dir_path / "iterations" / "00000" / "outputs" / "0.json") as f:
         seed_out = json.load(f)
     assert seed_out == {"id": 0, "weight": 0}
-    with open(run_dir_path / "candidates" / "00000" / "trajectories" / "0.json") as f:
+    with open(run_dir_path / "iterations" / "00000" / "trajectories" / "0.json") as f:
         seed_traj = json.load(f)
     assert seed_traj["weight"] == 0
 
-    # At least one accepted descendant candidate should also have outputs.
-    cand_dirs = sorted((run_dir_path / "candidates").iterdir())
-    assert len(cand_dirs) >= 2
-    for cand_dir in cand_dirs[1:]:
-        assert (cand_dir / "outputs" / "0.json").exists()
-        assert (cand_dir / "trajectories" / "0.json").exists()
+    # At least one accepted descendant iteration should also have outputs.
+    iter_dirs = sorted(d for d in (run_dir_path / "iterations").iterdir() if d.is_dir())
+    assert len(iter_dirs) >= 2
+    accepted_with_outputs = [
+        d for d in iter_dirs[1:] if (d / "outputs" / "0.json").exists()
+    ]
+    assert accepted_with_outputs, "at least one accepted proposal should have outputs"
+    for iter_dir in accepted_with_outputs:
+        assert (iter_dir / "trajectories" / "0.json").exists()
 
 
 def test_agent_state_off_does_not_write_outputs(run_dir):
@@ -339,7 +363,7 @@ def test_agent_state_off_does_not_write_outputs(run_dir):
     )
 
     run_dir_path = Path(str(run_dir))
-    assert not (run_dir_path / "candidates").exists()
+    assert not (run_dir_path / "iterations").exists()
     assert not (run_dir_path / "gepa_state.json").exists()
 
 
@@ -356,7 +380,7 @@ def test_agent_state_sanitizes_component_names(run_dir):
     state.num_full_ds_evals = 1
     state.save(run_dir, write_agent_state=True)
 
-    comp_dir = Path(str(run_dir)) / "candidates" / "00000" / "components"
+    comp_dir = Path(str(run_dir)) / "iterations" / "00000" / "components"
     with open(comp_dir / "_index.json") as f:
         index = json.load(f)
     # Real names preserved as keys; slashes and spaces become underscores in filenames.
@@ -556,20 +580,30 @@ def test_adapter_state_save_and_load(run_dir):
     assert loaded.adapter_state == {"key": "value", "nested": {"a": [1, 2, 3]}}
 
 
-def test_upgrade_state_dict_adds_adapter_state():
-    """Migration adds adapter_state={} when missing (v4 → v5)."""
+def test_upgrade_state_dict_adds_missing_fields():
+    """Migration fills in adapter_state + iteration_ids_by_candidate_idx (v5 → v6)."""
     d = {
-        "program_candidates": [{"a": "b"}],
-        "prog_candidate_objective_scores": [{}],
+        "program_candidates": [{"a": "b"}, {"a": "c"}],
+        "prog_candidate_objective_scores": [{}, {}],
         "objective_pareto_front": {},
         "program_at_pareto_front_objectives": {},
         "frontier_type": "instance",
         "pareto_front_cartesian": {},
         "program_at_pareto_front_cartesian": {},
         "evaluation_cache": None,
+        "full_program_trace": [
+            {
+                "i": 3,
+                "proposal_accepted": True,
+                "new_program_idx": 1,
+            }
+        ],
     }
     state_mod.GEPAState._upgrade_state_dict(d)
     assert d["adapter_state"] == {}
+    # Seed (candidate_idx 0) → iteration id 0; accepted candidate_idx 1
+    # discovered at trace i=3 → iteration id 4.
+    assert d["iteration_ids_by_candidate_idx"] == [0, 4]
     assert d["validation_schema_version"] == state_mod.GEPAState._VALIDATION_SCHEMA_VERSION
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -115,6 +115,61 @@ def test_gepa_state_save_and_initialize(run_dir):
     assert state.__dict__ == result.__dict__
 
 
+def test_agent_state_json_export(run_dir):
+    """save() writes a comprehensive gepa_state.json for agent consumption."""
+    seed = {"system_prompt": "You are helpful."}
+    valset_out = ValsetEvaluation(
+        outputs_by_val_id={0: "out0", 1: "out1", 2: "out2"},
+        scores_by_val_id={0: 0.3, 1: 0.7, 2: 0.5},
+        objective_scores_by_val_id={
+            0: {"accuracy": 0.3, "latency": 0.9},
+            1: {"accuracy": 0.7, "latency": 0.8},
+            2: {"accuracy": 0.5, "latency": 0.7},
+        },
+    )
+
+    state = state_mod.GEPAState(seed, valset_out, frontier_type="hybrid")
+    state.total_num_evals = 10
+    state.num_full_ds_evals = 1
+    state.save(run_dir)
+
+    import json
+
+    agent_state_path = os.path.join(str(run_dir), "gepa_state.json")
+    assert os.path.exists(agent_state_path)
+    with open(agent_state_path) as f:
+        data = json.load(f)
+
+    # Check top-level structure
+    assert data["schema_version"] == 1
+    assert data["frontier_type"] == "hybrid"
+    assert "candidates" in data
+    assert "pareto_front" in data
+    assert "summary" in data
+    assert "iteration_log" in data
+
+    # Check candidate data
+    assert len(data["candidates"]) == 1
+    cand = data["candidates"][0]
+    assert cand["idx"] == 0
+    assert cand["texts"] == {"system_prompt": "You are helpful."}
+    assert cand["avg_val_score"] > 0
+    assert cand["num_val_scored"] == 3
+    assert "0" in cand["val_scores"]
+    assert cand["val_scores"]["0"] == 0.3
+
+    # Check Pareto front
+    assert "instance_front" in data["pareto_front"]
+    assert "objective_front" in data["pareto_front"]
+
+    # Check summary
+    assert data["summary"]["num_candidates"] == 1
+    assert data["summary"]["best_candidate_idx"] == 0
+    assert len(data["summary"]["hardest_examples"]) > 0
+    # Hardest example should be val_id=0 with score 0.3
+    assert data["summary"]["hardest_examples"][0]["best_score"] == 0.3
+
+
 def test_budget_hooks_excluded_from_serialization(run_dir):
     """Budget hooks are runtime-only and should not be serialized."""
     seed = {"model": "m"}


### PR DESCRIPTION
## Summary

When `run_dir` is provided, GEPA now writes `gepa_state.json` — a comprehensive, agent-readable export of the full optimization state. This is designed for consumption by autonomous agents (e.g. Claude Code) that need the complete picture to propose better candidates.

### What's in `gepa_state.json`

```
{
  "schema_version": 1,
  "iteration": ...,
  "total_metric_calls": ...,
  "frontier_type": ...,
  "component_names": [...],

  "candidates": [
    {
      "idx": 0,
      "texts": {"system_prompt": "..."},
      "parent_ids": [],
      "avg_val_score": 0.85,
      "num_val_scored": 100,
      "metric_calls_to_discover": 0,
      "val_scores": {"0": 0.9, "1": 0.8, ...},
      "objective_scores": {"accuracy": 0.85}
    }, ...
  ],

  "pareto_front": {
    "instance_front": { "<val_id>": {"best_score": ..., "best_candidates": [...]} },
    "objective_front": { "<metric>": {"best_score": ..., "best_candidates": [...]} }
  },

  "summary": {
    "best_candidate_idx": 7,
    "best_avg_score": 0.92,
    "pareto_front_candidate_idxs": [0, 3, 5, 7],
    "hardest_examples": [{"val_id": "3", "best_score": 0.2, ...}, ...]
  },

  "iteration_log": [...]
}
```

### Side-info capture

Proposal evaluation data (`eval_before`, `eval_after`) is now recorded in the iteration trace with:
- Per-example scores
- Outputs (best-effort JSON serialization)
- Trajectories/side_info (best-effort JSON serialization)
- Whether the proposal was accepted/rejected
- The proposed candidate text

This gives agents the feedback needed to understand WHY proposals succeeded or failed.

### What's still missing (future work)

- **Full valset evaluation outputs/side_info** — the full validation eval uses `capture_traces=False` for performance, so only scores are available per-candidate per-datapoint, not outputs or side_info
- **Rejected candidate texts** — only accepted candidates are in `program_candidates`; rejected proposals are now in the iteration log but weren't before
- **Evaluation cache export** — the `EvaluationCache` is in the pickle but not JSON-exported

## Test plan

- [x] 447 tests pass (1 new test for agent state export)
- [x] pyright: 0 errors
- [x] ruff: 0 errors
- [x] New test verifies JSON structure, candidate data, pareto front, and hardest examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)