### PR TITLE
feat: add reflection_lm_kwargs for custom litellm params

### DIFF
--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -49,6 +49,7 @@ def optimize(
     evaluator: Evaluator | None = None,
     # Reflection-based configuration
     reflection_lm: LanguageModel | str | None = None,
+    reflection_lm_kwargs: dict[str, Any] | None = None,
     candidate_selection_strategy: CandidateSelector
     | Literal["pareto", "current_best", "epsilon_greedy", "top_k_pareto"] = "pareto",
     frontier_type: FrontierType = "instance",
@@ -229,7 +230,7 @@ def optimize(
     if isinstance(reflection_lm, str):
         from gepa.lm import LM
 
-        reflection_lm_callable = LM(reflection_lm)
+        reflection_lm_callable = LM(reflection_lm, **(reflection_lm_kwargs or {}))
     elif reflection_lm is not None:
         from gepa.lm import TrackingLM
 

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -734,6 +734,11 @@ class ReflectionConfig:
     reflection_minibatch_size: int | None = None  # Default: 1 for single-instance mode, 3 otherwise
     module_selector: ReflectionComponentSelector | Literal["round_robin", "all"] = "round_robin"
     reflection_lm: LanguageModel | str | None = "openai/gpt-5.1"
+    reflection_lm_kwargs: dict[str, Any] | None = None
+    """Extra keyword arguments forwarded to ``litellm.completion`` when
+    ``reflection_lm`` is a model name string (e.g.
+    ``{"reasoning_effort": "high", "temperature": 0.7}``).
+    Ignored when ``reflection_lm`` is already a callable."""
     reflection_prompt_template: str | dict[str, str] | None = optimize_anything_reflection_prompt_template
     custom_candidate_proposer: ProposalFn | None = None
 
@@ -942,7 +947,7 @@ class GEPAConfig:
         return GEPAConfig(**d)
 
 
-def make_litellm_lm(model_name: str) -> LanguageModel:
+def make_litellm_lm(model_name: str, **kwargs: Any) -> LanguageModel:
     """Convert a LiteLLM model name string to a :class:`LanguageModel` callable.
 
     The returned callable conforms to the ``LanguageModel`` protocol and
@@ -952,10 +957,15 @@ def make_litellm_lm(model_name: str) -> LanguageModel:
     Uses :class:`gepa.lm.LM` which handles reasoning model detection
     (o1/o3/o4/gpt-5), retries with exponential backoff, truncation
     warnings, and ``drop_params=True`` for cross-model compatibility.
+
+    Args:
+        model_name: LiteLLM model identifier (e.g. ``"openai/gpt-5"``).
+        **kwargs: Extra keyword arguments forwarded to ``litellm.completion``
+            (e.g. ``reasoning_effort="high"``, ``temperature=0.7``).
     """
     from gepa.lm import LM
 
-    return LM(model_name)
+    return LM(model_name, **kwargs)
 
 
 class EvaluatorWrapper:
@@ -1325,7 +1335,9 @@ def optimize_anything(
 
     # Convert reflection_lm string to callable
     if isinstance(config.reflection.reflection_lm, str):
-        config.reflection.reflection_lm = make_litellm_lm(config.reflection.reflection_lm)
+        config.reflection.reflection_lm = make_litellm_lm(
+            config.reflection.reflection_lm, **(config.reflection.reflection_lm_kwargs or {})
+        )
     elif config.reflection.reflection_lm is not None and not hasattr(config.reflection.reflection_lm, "total_cost"):
         from gepa.lm import TrackingLM
 


### PR DESCRIPTION
## Summary

Add `reflection_lm_kwargs` parameter so users can pass custom kwargs to litellm (e.g. `reasoning_effort`, `temperature`) when using a string model name for `reflection_lm` — without having to wrap it in a lambda.

**Before (workaround from Slack):**
```python
reflection_lm = lambda prompt: litellm.completion(
    model="openai/gpt-5",
    messages=[{"role": "user", "content": prompt}],
    reasoning_effort="high",
).choices[0].message.content
```

**After:**
```python
# optimize_anything
config = GEPAConfig(
    reflection=ReflectionConfig(
        reflection_lm="openai/gpt-5",
        reflection_lm_kwargs={"reasoning_effort": "high"},
    ),
)

# gepa.optimize
result = gepa.optimize(
    ...,
    reflection_lm="openai/gpt-5",
    reflection_lm_kwargs={"reasoning_effort": "high"},
)
```

### Changes

- `ReflectionConfig.reflection_lm_kwargs: dict[str, Any] | None` — forwarded to `LM()` constructor when `reflection_lm` is a string
- `gepa.optimize(..., reflection_lm_kwargs=...)` — same for the core API
- `make_litellm_lm(model_name, **kwargs)` — now accepts and forwards kwargs

Motivated by Eric Wang's question on Slack about configuring `reasoning_effort` for the reflection LM.

## Test plan

- [x] 476 tests pass
- [x] pyright: 0 errors
- [x] Verified `LM("openai/gpt-4.1-mini", reasoning_effort="high").completion_kwargs` contains the kwarg
- [x] Verified `make_litellm_lm("openai/gpt-5", reasoning_effort="high")` works
- [x] Verified both `ReflectionConfig` and `api.optimize` accept the new parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)