### PR TITLE
feat: add LearnabilityBatchSampler — variance-weighted example selection

### DIFF
--- a/src/gepa/strategies/learnability_sampler.py
+++ b/src/gepa/strategies/learnability_sampler.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""Learnability-weighted batch sampler.
+
+Prioritizes training examples where candidate performance varies most —
+these are the examples most likely to benefit from prompt improvements.
+Examples where all candidates score similarly (all high or all low) provide
+less signal for the reflection LM.
+"""
+
+import random
+from typing import Any
+
+from gepa.core.data_loader import DataId, DataLoader
+from gepa.core.state import GEPAState
+from gepa.strategies.batch_sampler import BatchSampler, EpochShuffledBatchSampler
+
+
+class LearnabilityBatchSampler(BatchSampler[DataId, Any]):
+    """Sample training examples weighted by how much candidates disagree on them.
+
+    For each training example that appears in the validation scores, compute
+    the **variance** of scores across all candidates that have been evaluated
+    on it.  Examples with higher variance are sampled with higher probability,
+    because they are the ones where better prompts can make the most difference.
+
+    Falls back to uniform sampling (``EpochShuffledBatchSampler``) for the
+    first few iterations when fewer than ``min_candidates`` have been evaluated.
+
+    Parameters
+    ----------
+    minibatch_size:
+        Number of examples per minibatch.
+    min_candidates:
+        Minimum number of candidates required before learnability weighting
+        kicks in.  Before this threshold, falls back to epoch-shuffled.
+    temperature:
+        Controls how aggressively to favor high-variance examples.
+
+        - ``1.0`` (default) — sample proportional to variance.
+        - ``> 1.0`` — flatten the distribution (closer to uniform).
+        - ``< 1.0`` — sharpen (focus heavily on highest-variance examples).
+        - ``0.0`` — always pick the top-K highest-variance examples.
+
+    rng:
+        Random number generator for reproducibility.
+    """
+
+    def __init__(
+        self,
+        minibatch_size: int,
+        min_candidates: int = 3,
+        temperature: float = 1.0,
+        rng: random.Random | None = None,
+    ):
+        self.minibatch_size = minibatch_size
+        self.min_candidates = min_candidates
+        self.temperature = temperature
+        self.rng = rng or random.Random(0)
+        self._fallback = EpochShuffledBatchSampler(minibatch_size=minibatch_size, rng=self.rng)
+
+    def _compute_learnability(self, state: GEPAState) -> dict[DataId, float]:
+        """Compute per-example score variance across candidates.
+
+        Returns a dict mapping example_id -> variance.  Only includes
+        examples scored by at least ``min_candidates`` candidates.
+        """
+        # Collect all scores per example across candidates
+        scores_by_example: dict[DataId, list[float]] = {}
+        for candidate_scores in state.prog_candidate_val_subscores:
+            for example_id, score in candidate_scores.items():
+                scores_by_example.setdefault(example_id, []).append(score)
+
+        # Compute variance for examples with enough data
+        learnability: dict[DataId, float] = {}
+        for example_id, scores in scores_by_example.items():
+            if len(scores) < self.min_candidates:
+                continue
+            mean = sum(scores) / len(scores)
+            variance = sum((s - mean) ** 2 for s in scores) / len(scores)
+            learnability[example_id] = variance
+
+        return learnability
+
+    def next_minibatch_ids(self, loader: DataLoader[DataId, Any], state: GEPAState) -> list[DataId]:
+        all_ids = list(loader.all_ids())
+        if not all_ids:
+            raise ValueError("Cannot sample a minibatch from an empty loader.")
+
+        learnability = self._compute_learnability(state)
+
+        # Filter to training IDs that have learnability scores
+        scored_ids = [eid for eid in all_ids if eid in learnability]
+
+        # Fall back if not enough data yet
+        if len(scored_ids) < self.minibatch_size:
+            return self._fallback.next_minibatch_ids(loader, state)
+
+        # Compute sampling weights
+        if self.temperature == 0.0:
+            # Deterministic: pick top-K by variance
+            scored_ids.sort(key=lambda eid: learnability[eid], reverse=True)
+            return scored_ids[: self.minibatch_size]
+
+        # Weighted sampling
+        variances = [learnability[eid] for eid in scored_ids]
+        max_var = max(variances) if variances else 1.0
+
+        if max_var == 0.0:
+            # All variances are zero — fall back to uniform
+            return self._fallback.next_minibatch_ids(loader, state)
+
+        # Normalize and apply temperature
+        weights = []
+        for v in variances:
+            normalized = v / max_var  # in [0, 1]
+            # Add small epsilon so zero-variance examples still have nonzero weight
+            w = (normalized + 0.01) ** (1.0 / max(self.temperature, 1e-6))
+            weights.append(w)
+
+        # Sample without replacement
+        selected: list[DataId] = []
+        available_indices = list(range(len(scored_ids)))
+        available_weights = list(weights)
+
+        for _ in range(min(self.minibatch_size, len(scored_ids))):
+            total = sum(available_weights)
+            if total <= 0:
+                break
+            r = self.rng.random() * total
+            cumulative = 0.0
+            chosen_pos = 0
+            for pos, w in enumerate(available_weights):
+                cumulative += w
+                if cumulative >= r:
+                    chosen_pos = pos
+                    break
+            selected.append(scored_ids[available_indices[chosen_pos]])
+            available_indices.pop(chosen_pos)
+            available_weights.pop(chosen_pos)
+
+        # If we couldn't fill the minibatch (unlikely), pad from remaining
+        if len(selected) < self.minibatch_size:
+            remaining = [eid for eid in all_ids if eid not in set(selected)]
+            self.rng.shuffle(remaining)
+            selected.extend(remaining[: self.minibatch_size - len(selected)])
+
+        return selected

--- a/tests/test_learnability_sampler.py
+++ b/tests/test_learnability_sampler.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""Tests for LearnabilityBatchSampler."""
+
+import random
+
+import pytest
+
+from gepa.core.data_loader import ensure_loader
+from gepa.core.state import GEPAState, ValsetEvaluation
+from gepa.strategies.learnability_sampler import LearnabilityBatchSampler
+
+
+@pytest.fixture
+def state_with_candidates():
+    """GEPAState with 4 candidates showing different score patterns."""
+    seed = {"prompt": "seed"}
+    # 5 val examples with deliberate score patterns:
+    #   example 0: all candidates score ~0.5 (low variance)
+    #   example 1: scores vary widely 0.1-0.9 (high variance)
+    #   example 2: all candidates score ~0.9 (low variance, high)
+    #   example 3: scores vary moderately (medium variance)
+    #   example 4: all candidates score ~0.0 (low variance, low)
+    base_eval = ValsetEvaluation(
+        outputs_by_val_id={0: "a", 1: "b", 2: "c", 3: "d", 4: "e"},
+        scores_by_val_id={0: 0.5, 1: 0.1, 2: 0.9, 3: 0.3, 4: 0.0},
+        objective_scores_by_val_id=None,
+    )
+    state = GEPAState(seed, base_eval)
+    state.total_num_evals = 20
+    state.num_full_ds_evals = 4
+
+    # Add 3 more candidates with different score patterns
+    for scores in [
+        {0: 0.5, 1: 0.9, 2: 0.9, 3: 0.7, 4: 0.0},
+        {0: 0.4, 1: 0.5, 2: 0.8, 3: 0.4, 4: 0.1},
+        {0: 0.6, 1: 0.8, 2: 0.9, 3: 0.6, 4: 0.0},
+    ]:
+        state.program_candidates.append({"prompt": f"cand_{len(state.program_candidates)}"})
+        state.prog_candidate_val_subscores.append(scores)
+        state.prog_candidate_objective_scores.append({})
+        state.parent_program_for_candidate.append([0])
+        state.named_predictor_id_to_update_next_for_program_candidate.append(0)
+        state.num_metric_calls_by_discovery.append(0)
+
+    for val_id in state.pareto_front_valset:
+        state.program_at_pareto_front_valset[val_id] = {0, 1, 2, 3}
+
+    assert state.is_consistent()
+    return state
+
+
+class TestLearnabilityComputation:
+    def test_high_variance_example_has_highest_learnability(self, state_with_candidates):
+        sampler = LearnabilityBatchSampler(minibatch_size=2, min_candidates=3)
+        learnability = sampler._compute_learnability(state_with_candidates)
+
+        # Example 1 has scores [0.1, 0.9, 0.5, 0.8] — highest variance
+        # Example 0 has scores [0.5, 0.5, 0.4, 0.6] — low variance
+        # Example 2 has scores [0.9, 0.9, 0.8, 0.9] — low variance
+        assert learnability[1] > learnability[0]
+        assert learnability[1] > learnability[2]
+
+    def test_min_candidates_threshold(self, state_with_candidates):
+        # With min_candidates=10, nothing should qualify
+        sampler = LearnabilityBatchSampler(minibatch_size=2, min_candidates=10)
+        learnability = sampler._compute_learnability(state_with_candidates)
+        assert len(learnability) == 0
+
+
+class TestSamplingBehavior:
+    def test_temperature_zero_picks_highest_variance(self, state_with_candidates):
+        loader = ensure_loader(["ex0", "ex1", "ex2", "ex3", "ex4"])
+        sampler = LearnabilityBatchSampler(
+            minibatch_size=2, min_candidates=3, temperature=0.0, rng=random.Random(42)
+        )
+        ids = sampler.next_minibatch_ids(loader, state_with_candidates)
+        assert len(ids) == 2
+        # Example 1 (highest variance) should always be included
+        assert 1 in ids
+
+    def test_fallback_when_too_few_candidates(self):
+        """Falls back to EpochShuffledBatchSampler when min_candidates not met."""
+        seed = {"prompt": "seed"}
+        base_eval = ValsetEvaluation(
+            outputs_by_val_id={0: "a", 1: "b"},
+            scores_by_val_id={0: 0.5, 1: 0.5},
+            objective_scores_by_val_id=None,
+        )
+        state = GEPAState(seed, base_eval)
+        state.total_num_evals = 2
+        state.num_full_ds_evals = 1
+        state.i = 0
+
+        loader = ensure_loader(["ex0", "ex1"])
+        sampler = LearnabilityBatchSampler(minibatch_size=2, min_candidates=3)
+        ids = sampler.next_minibatch_ids(loader, state)
+        assert len(ids) == 2
+
+    def test_deterministic_with_seed(self, state_with_candidates):
+        loader = ensure_loader(["ex0", "ex1", "ex2", "ex3", "ex4"])
+        sampler1 = LearnabilityBatchSampler(minibatch_size=3, min_candidates=3, rng=random.Random(42))
+        sampler2 = LearnabilityBatchSampler(minibatch_size=3, min_candidates=3, rng=random.Random(42))
+
+        ids1 = sampler1.next_minibatch_ids(loader, state_with_candidates)
+        ids2 = sampler2.next_minibatch_ids(loader, state_with_candidates)
+        assert ids1 == ids2
+
+    def test_high_temperature_approaches_uniform(self, state_with_candidates):
+        """High temperature should make sampling more uniform."""
+        loader = ensure_loader(["ex0", "ex1", "ex2", "ex3", "ex4"])
+        counts: dict[int, int] = {0: 0, 1: 0, 2: 0, 3: 0, 4: 0}
+        for seed in range(200):
+            sampler = LearnabilityBatchSampler(
+                minibatch_size=1, min_candidates=3, temperature=100.0, rng=random.Random(seed)
+            )
+            ids = sampler.next_minibatch_ids(loader, state_with_candidates)
+            counts[ids[0]] += 1
+
+        # With very high temperature, all examples should be sampled somewhat often
+        for eid, count in counts.items():
+            assert count > 10, f"Example {eid} sampled only {count}/200 times at high temperature"
+
+    def test_low_temperature_concentrates(self, state_with_candidates):
+        """Low temperature should concentrate on high-variance examples."""
+        loader = ensure_loader(["ex0", "ex1", "ex2", "ex3", "ex4"])
+        counts: dict[int, int] = {0: 0, 1: 0, 2: 0, 3: 0, 4: 0}
+        for seed in range(200):
+            sampler = LearnabilityBatchSampler(
+                minibatch_size=1, min_candidates=3, temperature=0.1, rng=random.Random(seed)
+            )
+            ids = sampler.next_minibatch_ids(loader, state_with_candidates)
+            counts[ids[0]] += 1
+
+        # Example 1 (highest variance) should dominate
+        assert counts[1] > counts[0]
+        assert counts[1] > counts[2]
+        assert counts[1] > counts[4]


### PR DESCRIPTION
## Summary

Add a new `BatchSampler` that prioritizes training examples where candidate performance varies most — the examples most likely to benefit from prompt improvements.

### How it works

For each training example, compute the **variance** of scores across all evaluated candidates. High variance means candidates disagree on this example, so it's "learnable" — better prompts can make a bigger difference. Low variance (all candidates score similarly) means the example provides less optimization signal.

### Parameters

- **`minibatch_size`** — examples per minibatch
- **`temperature`** — controls sampling concentration:
  - `0.0` — deterministic: always pick the top-K highest-variance examples
  - `1.0` (default) — sample proportional to variance
  - `> 1.0` — flatten toward uniform (exploration)
  - `< 1.0` — sharpen toward highest-variance (exploitation)
- **`min_candidates`** — minimum candidates evaluated before variance weighting activates (falls back to `EpochShuffledBatchSampler` until then)

### Usage

```python
from gepa.strategies.learnability_sampler import LearnabilityBatchSampler

result = gepa.optimize(
    ...,
    batch_sampler=LearnabilityBatchSampler(minibatch_size=5, temperature=0.5),
)
```

## Test plan

- [x] 483 tests pass (7 new)
- [x] pyright: 0 errors
- [x] Tests cover: variance computation, temperature=0 deterministic mode, fallback behavior, determinism with seed, high/low temperature distribution shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)