### PR TITLE
docs: add Agenta AI LLM-as-a-Judge workshop

### DIFF
--- a/docs/docs/guides/use-cases.md
+++ b/docs/docs/guides/use-cases.md
@@ -418,6 +418,16 @@ Discover how organizations and researchers are using GEPA to optimize AI systems
 
     [:material-arrow-right: Watch the talk](https://www.youtube.com/watch?v=0bkwd9OYqfk)
 
+-   **Judge the Judge: Building LLM Evaluators That Actually Work with GEPA (AI Engineer)**
+
+    ---
+
+    Mahmoud Mabrouk (CEO, Agenta AI) walks through building a calibrated LLM-as-a-judge — from capturing ground truth to optimizing with GEPA and assessing the judge. Presented at AI Engineer conference, April 2026.
+
+    [:material-arrow-right: Watch the workshop](https://www.youtube.com/watch?v=X4dEHRzBLmc)
+
+    [:material-arrow-right: Workshop repo](https://github.com/Agenta-AI/judge-the-judge)
+
 -   **NeurIPS 2025 Workshop: 12.5% → 62.5% Gains**
 
     ---

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -67,6 +67,7 @@ hide:
       <span>Invitae</span>
       <span>Bespoke Labs</span>
       <a href="https://decagon.ai/blog/optimizing-gepa-for-production" target="_blank">Decagon</a>
+      <a href="https://agenta.ai" target="_blank">Agenta</a>
       <!-- duplicate set for seamless loop -->
       <a href="https://x.com/tobi/status/1963434604741701909" target="_blank">Shopify</a>
       <a href="https://developers.openai.com/cookbook/examples/partners/self_evolving_agents/autonomous_agent_retraining" target="_blank">OpenAI</a>
@@ -91,6 +92,7 @@ hide:
       <span>Invitae</span>
       <span>Bespoke Labs</span>
       <a href="https://decagon.ai/blog/optimizing-gepa-for-production" target="_blank">Decagon</a>
+      <a href="https://agenta.ai" target="_blank">Agenta</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary

- Add Mahmoud Mabrouk's (Agenta AI) "Judge the Judge: Building LLM Evaluators That Actually Work with GEPA" workshop from AI Engineer conference (April 2026) to use-cases.md
- Add Agenta to the company carousel on the landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)