### PR TITLE
docs: add intertwineai dspy-agent-skills $0 reproducibility writeup

### DIFF
--- a/docs/docs/guides/use-cases.md
+++ b/docs/docs/guides/use-cases.md
@@ -1095,6 +1095,22 @@ Discover how organizations and researchers are using GEPA to optimize AI systems
 
     [:material-arrow-right: Read the blog](https://decagon.ai/blog/optimizing-gepa-for-production)
 
+-   **$0 Reproducible GEPA Examples: How a 1.2B Model Got +25 Points**
+
+    ---
+
+    Three end-to-end GEPA runs (RAG QA with citations, multi-step math reasoning, typed invoice extraction) entirely on OpenRouter's free tier — zero spend, single-seed reproducibility. Demonstrates a surprising saturation lesson: larger task LMs often leave GEPA with nothing to optimize because every minibatch is already all-correct. Using a 1.2B task LM (Liquid LFM 2.5) lifted math reasoning from **45% → 70%** through 5 accepted mutations.
+
+    **Key insights:**
+
+    - **Baseline saturation:** GLM 4.5 Air (32B) and Ministral 8B both accept zero mutations on grade-school math — no failure signal means no reflection
+    - **Task-LM matching matters:** Pick a model that fails on enough examples to generate signal, not the largest available
+    - **Format problems vs knowledge problems:** On RAG QA, GEPA's +18.85pt gain came from teaching consistent citation emission, not new knowledge
+
+    [:material-arrow-right: Read the writeup](https://codeandcontext.ai/inside-the-examples-how-gepa-lifted-a-1-2b-model-by-25-points/)
+
+    [:material-arrow-right: Clone and reproduce](https://github.com/intertwine/dspy-agent-skills)
+
 </div>
 
 ---


### PR DESCRIPTION
## Summary

Add community writeup ["Inside the examples: how GEPA lifted a 1.2B model by 25 points"](https://codeandcontext.ai/inside-the-examples-how-gepa-lifted-a-1-2b-model-by-25-points/) to use-cases.md.

Highlights three end-to-end GEPA examples reproducible on OpenRouter's free tier (zero spend), and surfaces an important practical lesson: **task-LM saturation** — larger models often leave GEPA with nothing to optimize because every minibatch is all-correct. Using a 1.2B model (Liquid LFM 2.5) produced enough failure signal for GEPA to improve math reasoning from 45% → 70% through 5 accepted mutations.

Companion repo: https://github.com/intertwine/dspy-agent-skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)