### PR TITLE
docs: add Zihao Wang's Hermes + GEPA analysis

### DIFF
--- a/docs/docs/guides/use-cases.md
+++ b/docs/docs/guides/use-cases.md
@@ -167,6 +167,8 @@ Discover how organizations and researchers are using GEPA to optimize AI systems
 
     [:material-arrow-right: Announcement](https://x.com/NousResearch/status/2031137681439109147)
 
+    [:material-arrow-right: Deep dive: "The Agent That Rewrites Itself"](https://soap628.com/blog/hermes-agent-self-evolution/) by Zihao Wang (Fudan University) — analysis of GEPA's reflective mutation, Pareto-based selection, and how Hermes uses GEPA to autonomously evolve agent skills
+
 -   **Production Incident Diagnosis**
 
     ---


### PR DESCRIPTION
## Summary

Add [Zihao Wang's blog post](https://soap628.com/blog/hermes-agent-self-evolution/) as a third link on the existing Nous Research Hermes Agent entry.

The post is a positive, technical deep dive by a Fudan PhD candidate analyzing how Hermes uses GEPA's reflective mutation and Pareto-based selection to autonomously evolve agent skills. Substantive content with concrete numbers (cites the +6-20% over GRPO with 35x fewer rollouts result, +10% over MIPROv2, ~\$2-10 per evolution run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)