### PR TITLE
docs: drop redundant candidate prompt from AIME side_info

### DIFF
--- a/docs/docs/blog/posts/2026-02-18-introducing-optimize-anything/appendix/appendix-e-aime-prompt-optimization.snippet
+++ b/docs/docs/blog/posts/2026-02-18-introducing-optimize-anything/appendix/appendix-e-aime-prompt-optimization.snippet
@@ -22,7 +22,6 @@
         side_info = {
             "score": score,
             "input": example.input,
-            "prompt": candidate,
             "output": prediction.answer,
             "reasoning": getattr(prediction, "reasoning", ""),
             "execution_feedback": feedback,

--- a/examples/aime_math/main.py
+++ b/examples/aime_math/main.py
@@ -20,7 +20,6 @@ def evaluate(candidate: str, example) -> tuple[float, SideInfo]:
     side_info = {
         "score": score,
         "input": example.input,
-        "prompt": candidate,
         "output": prediction.answer,
         "reasoning": getattr(prediction, "reasoning", ""),
         "execution_feedback": feedback,


### PR DESCRIPTION
## Summary

Closes #289.

The AIME `optimize_anything` example included `"prompt": candidate` in the evaluator's `side_info` return value. GEPA already passes the current candidate to the reflection LM via the `<curr_param>` placeholder, so this duplicates the candidate in the reflection context and wastes tokens.

Removed the redundant key in two places:
- `docs/docs/blog/posts/2026-02-18-introducing-optimize-anything/appendix/appendix-e-aime-prompt-optimization.snippet`
- `examples/aime_math/main.py`

## Test plan

- [x] `uv run pre-commit run --files <changed files>` passes
- [x] `uv run pyright` passes (0 errors)
- [x] No behavior change — the example still produces the same `score` and the same `side_info` structure minus the duplicate `prompt` field