### PR TITLE
docs: add source HTML for optimize_anything blog header diagram

### DIFF
--- a/docs/docs/blog/posts/2026-02-18-introducing-optimize-anything/header_diagram.html
+++ b/docs/docs/blog/posts/2026-02-18-introducing-optimize-anything/header_diagram.html
@@ -1,0 +1,581 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>optimize_anything — Universal String-Based Optimization</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg-primary: #ffffff;
+            --bg-diagram: #ffffff;
+            --bg-loop: #f8fafc;
+            --bg-card: #ffffff;
+            --text-primary: #1e293b;
+            --text-secondary: #64748b;
+            --text-muted: #94a3b8;
+            --accent-blue: #3b82f6;
+            --accent-purple: #7c3aed;
+            --accent-orange: #d97706;
+            --accent-green: #059669;
+            --accent-cyan: #0891b2;
+            --border-light: #e2e8f0;
+            --border-medium: #cbd5e1;
+            --shadow-sm: 0 1px 2px rgba(0,0,0,0.04);
+            --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.06), 0 2px 4px -2px rgba(0,0,0,0.04);
+            --shadow-lg: 0 10px 25px -5px rgba(0,0,0,0.07), 0 4px 6px -4px rgba(0,0,0,0.03);
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: 'Inter', -apple-system, sans-serif;
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 16px;
+        }
+
+        .diagram {
+            width: 1400px;
+            background: var(--bg-diagram);
+            padding: 28px 36px;
+            border-radius: 20px;
+            border: 1.5px solid var(--border-light);
+            box-shadow: var(--shadow-lg);
+        }
+
+        /* Header */
+        .header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 16px;
+            padding-bottom: 14px;
+            border-bottom: 1.5px solid var(--border-light);
+        }
+
+        .title-group {
+            display: flex;
+            align-items: baseline;
+            gap: 16px;
+        }
+
+        .title {
+            font-size: 2rem;
+            font-weight: 800;
+            letter-spacing: -0.03em;
+        }
+
+        .title-main { color: var(--text-primary); }
+        .title-accent { color: var(--accent-purple); }
+
+        .subtitle {
+            font-size: 0.95rem;
+            color: var(--text-secondary);
+        }
+
+        .formula {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.92rem;
+            color: var(--accent-green);
+            background: #f0fdf4;
+            padding: 8px 16px;
+            border-radius: 8px;
+            border: 1.5px solid #bbf7d0;
+        }
+
+        /* Core Insight */
+        .insight {
+            text-align: center;
+            margin-bottom: 20px;
+        }
+
+        .insight-text {
+            font-size: 1.02rem;
+            color: var(--text-secondary);
+            max-width: 1000px;
+            margin: 0 auto;
+            line-height: 1.5;
+        }
+
+        .insight-text em { color: var(--text-primary); font-style: normal; font-weight: 600; }
+        .insight-text strong { color: var(--accent-orange); font-weight: 600; }
+
+        /* Main Loop */
+        .loop-section {
+            background: var(--bg-loop);
+            border: 1.5px solid var(--border-light);
+            border-radius: 16px;
+            padding: 28px 50px 20px 50px;
+            margin-bottom: 24px;
+            box-shadow: var(--shadow-sm);
+        }
+
+        .loop-container {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 24px;
+            position: relative;
+        }
+
+        .node {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .node-box {
+            padding: 16px 26px;
+            border-radius: 12px;
+            text-align: center;
+            min-width: 90px;
+            box-shadow: var(--shadow-md);
+        }
+
+        .node-x .node-box {
+            background: #ffffff;
+            border: 2px solid var(--border-medium);
+        }
+
+        .node-x .node-label { color: var(--text-primary); }
+
+        .node-label {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 1.4rem;
+            font-weight: 700;
+        }
+
+        .node-sublabel {
+            font-size: 0.78rem;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            font-weight: 500;
+        }
+
+        .node-f .node-box {
+            background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+        }
+
+        .node-f .node-label { color: white; }
+
+        .arrow {
+            display: flex;
+            align-items: center;
+            color: #94a3b8;
+        }
+
+        .arrow svg { width: 40px; height: 16px; }
+
+        .output-group {
+            display: flex;
+            gap: 12px;
+            align-items: stretch;
+        }
+
+        .score-box {
+            background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+            padding: 12px 18px;
+            border-radius: 12px;
+            text-align: center;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            box-shadow: var(--shadow-md);
+        }
+
+        .score-label {
+            font-size: 0.72rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: rgba(255,255,255,0.85);
+        }
+
+        .score-value {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 1.3rem;
+            font-weight: 700;
+            color: white;
+        }
+
+        .asi-box {
+            background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+            padding: 10px 16px;
+            border-radius: 12px;
+            min-width: 210px;
+            box-shadow: var(--shadow-md);
+        }
+
+        .asi-title {
+            font-size: 0.78rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            color: white;
+            margin-bottom: 4px;
+            white-space: nowrap;
+        }
+
+        .asi-list {
+            list-style: none;
+            font-size: 0.78rem;
+            color: rgba(255,255,255,0.92);
+        }
+
+        .asi-list li {
+            padding-left: 12px;
+            position: relative;
+            line-height: 1.45;
+        }
+
+        .asi-list li::before {
+            content: '›';
+            position: absolute;
+            left: 0;
+            color: rgba(255,255,255,0.65);
+        }
+
+        .node-llm .node-box {
+            background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%);
+            min-width: 140px;
+        }
+
+        .node-llm .node-label { color: white; }
+
+        /* Loop back indicator */
+        .loop-back-arrow {
+            width: 1060px;
+            height: 36px;
+        }
+
+        .loop-back-label {
+            position: relative;
+            margin-top: 8px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 5px;
+        }
+
+        .xprime {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 1rem;
+            font-weight: 600;
+            color: var(--accent-purple);
+            background: #f5f3ff;
+            border: 1.5px solid #ddd6fe;
+            padding: 4px 12px;
+            border-radius: 6px;
+        }
+
+        .loop-text {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        /* Examples Grid */
+        .examples-label {
+            font-size: 0.82rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            color: var(--text-muted);
+            margin-bottom: 10px;
+        }
+
+        .examples-grid {
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 14px;
+        }
+
+        .example-card {
+            background: var(--bg-card);
+            border: 1.5px solid var(--border-light);
+            border-radius: 12px;
+            padding: 16px 18px;
+            box-shadow: var(--shadow-sm);
+            transition: box-shadow 0.2s, border-color 0.2s;
+        }
+
+        .example-card:hover {
+            box-shadow: var(--shadow-md);
+            border-color: var(--border-medium);
+        }
+
+        .card-icon {
+            width: 36px;
+            height: 36px;
+            border-radius: 8px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin-bottom: 8px;
+        }
+
+        .card-title {
+            font-size: 0.95rem;
+            font-weight: 700;
+            margin-bottom: 8px;
+        }
+
+        .card-params {
+            font-size: 0.82rem;
+            line-height: 1.55;
+        }
+
+        .param-row {
+            display: flex;
+            gap: 6px;
+            white-space: nowrap;
+        }
+
+        .param-key {
+            font-family: 'JetBrains Mono', monospace;
+            font-weight: 600;
+            flex-shrink: 0;
+            color: var(--accent-blue);
+        }
+
+        .param-val {
+            color: var(--text-secondary);
+        }
+
+        /* Card themes */
+        .card-code .card-icon { background: #eff6ff; }
+        .card-code .card-title { color: #2563eb; }
+        .card-code { border-left: 3px solid #3b82f6; }
+
+        .card-numeric .card-icon { background: #ecfdf5; }
+        .card-numeric .card-title { color: #059669; }
+        .card-numeric { border-left: 3px solid #10b981; }
+
+        .card-prompt .card-icon { background: #f5f3ff; }
+        .card-prompt .card-title { color: #7c3aed; }
+        .card-prompt { border-left: 3px solid #8b5cf6; }
+
+        .card-policy .card-icon { background: #fffbeb; }
+        .card-policy .card-title { color: #b45309; }
+        .card-policy { border-left: 3px solid #f59e0b; }
+
+        .asi-highlight {
+            color: var(--accent-orange) !important;
+        }
+    </style>
+</head>
+<body>
+    <div class="diagram">
+        <!-- Header -->
+        <header class="header">
+            <div class="title-group">
+                <h1 class="title">
+                    <span class="title-main">optimize</span><span class="title-accent">_anything</span>
+                </h1>
+                <span class="subtitle">Universal Interface for Text Optimization</span>
+            </div>
+            <code class="formula">
+                maximize f(x: str) → score
+            </code>
+        </header>
+
+        <!-- Core Insight -->
+        <div class="insight">
+            <p class="insight-text">
+                Any optimization problem can be expressed as maximizing evaluator <em>f</em> over strings by serializing artifacts as text.<br>
+                The evaluator returns a score plus <strong>Actionable Side Information (ASI)</strong> — domain context explaining <em>why</em>.
+            </p>
+        </div>
+
+        <!-- Main Loop -->
+        <div class="loop-section">
+            <div class="loop-container">
+                <!-- X input -->
+                <div class="node node-x">
+                    <div class="node-box">
+                        <div class="node-label">x</div>
+                    </div>
+                    <span class="node-sublabel">String</span>
+                </div>
+
+                <div class="arrow">
+                    <svg viewBox="0 0 40 16" fill="none">
+                        <path d="M0 8H32M32 8L26 3M32 8L26 13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    </svg>
+                </div>
+
+                <!-- Evaluator -->
+                <div class="node node-f">
+                    <div class="node-box">
+                        <div class="node-label">f(x)</div>
+                    </div>
+                    <span class="node-sublabel">Evaluator</span>
+                </div>
+
+                <div class="arrow">
+                    <svg viewBox="0 0 40 16" fill="none">
+                        <path d="M0 8H32M32 8L26 3M32 8L26 13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    </svg>
+                </div>
+
+                <!-- Score + ASI -->
+                <div class="output-group">
+                    <div class="score-box">
+                        <div class="score-label">Score</div>
+                        <div class="score-value">87.3</div>
+                    </div>
+                    <div class="asi-box">
+                        <div class="asi-title">Actionable Side Info</div>
+                        <ul class="asi-list">
+                            <li>Why this score?</li>
+                            <li>What went wrong?</li>
+                            <li>Any domain diagnostics...</li>
+                        </ul>
+                    </div>
+                </div>
+
+                <div class="arrow">
+                    <svg viewBox="0 0 40 16" fill="none">
+                        <path d="M0 8H32M32 8L26 3M32 8L26 13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    </svg>
+                </div>
+
+                <!-- LLM -->
+                <div class="node node-llm">
+                    <div class="node-box">
+                        <div class="node-label">
+                            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.8" style="vertical-align: middle; margin-right: 6px;">
+                                <path d="M12 4.5C10.5 4.5 9.3 5.2 8.5 6.2C7.7 5.7 6.7 5.5 5.8 5.8C4.2 6.3 3 7.8 3 9.5C3 10.5 3.3 11.4 3.8 12C3.3 12.6 3 13.5 3 14.5C3 16.2 4.2 17.7 5.8 18.2C6.7 18.5 7.7 18.3 8.5 17.8C9.3 18.8 10.5 19.5 12 19.5"/>
+                                <path d="M12 4.5C13.5 4.5 14.7 5.2 15.5 6.2C16.3 5.7 17.3 5.5 18.2 5.8C19.8 6.3 21 7.8 21 9.5C21 10.5 20.7 11.4 20.2 12C20.7 12.6 21 13.5 21 14.5C21 16.2 19.8 17.7 18.2 18.2C17.3 18.5 16.3 18.3 15.5 17.8C14.7 18.8 13.5 19.5 12 19.5"/>
+                                <path d="M12 4.5V19.5"/>
+                                <path d="M8 9C9 9 10 10 10 12C10 14 9 15 8 15"/>
+                                <path d="M16 9C15 9 14 10 14 12C14 14 15 15 16 15"/>
+                            </svg>LLM
+                        </div>
+                    </div>
+                    <span class="node-sublabel">Intelligent Proposer</span>
+                </div>
+            </div>
+
+            <!-- Loop back -->
+            <div class="loop-back-label">
+                <svg class="loop-back-arrow" viewBox="0 0 1060 36" fill="none">
+                    <path d="M975 0 L975 26 L60 26 L60 0"
+                          stroke="url(#grad)" stroke-width="2.5" fill="none" stroke-linejoin="round"/>
+                    <defs>
+                        <linearGradient id="grad" x1="100%" y1="0%" x2="0%" y2="0%">
+                            <stop offset="0%" stop-color="#8b5cf6"/>
+                            <stop offset="100%" stop-color="#3b82f6"/>
+                        </linearGradient>
+                    </defs>
+                    <polygon points="60,0 49,13 71,13" fill="#3b82f6"/>
+                </svg>
+                <div style="display:flex; align-items:center; gap:10px; margin-top:2px;">
+                    <span class="xprime">x′</span>
+                    <span class="loop-text">Improved string</span>
+                </div>
+            </div>
+        </div>
+
+        <!-- Examples -->
+        <div class="examples-label">Example Instantiations</div>
+        <div class="examples-grid">
+            <!-- Code -->
+            <div class="example-card card-code">
+                <div class="card-icon">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#3b82f6" stroke-width="2">
+                        <polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/>
+                    </svg>
+                </div>
+                <div class="card-title">Code Optimization</div>
+                <div class="card-params">
+                    <div class="param-row"><span class="param-key">x:</span><span class="param-val">CUDA kernel code</span></div>
+                    <div class="param-row"><span class="param-key">f:</span><span class="param-val">−runtime</span></div>
+                    <div class="param-row"><span class="param-key asi-highlight">ASI:</span><span class="param-val">Compiler errors, profiler traces...</span></div>
+                </div>
+            </div>
+
+            <!-- Numeric -->
+            <div class="example-card card-numeric">
+                <div class="card-icon">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#10b981" stroke-width="2">
+                        <path d="M3 3v18h18"/><path d="M18 9l-5 5-4-4-6 6"/>
+                    </svg>
+                </div>
+                <div class="card-title">Numeric Optimization</div>
+                <div class="card-params">
+                    <div class="param-row"><span class="param-key">x:</span><span class="param-val">Params (str) or solver code</span></div>
+                    <div class="param-row"><span class="param-key">f:</span><span class="param-val">−objective</span></div>
+                    <div class="param-row"><span class="param-key asi-highlight">ASI:</span><span class="param-val">Gradients, violations, logs...</span></div>
+                </div>
+            </div>
+
+            <!-- Prompt -->
+            <div class="example-card card-prompt">
+                <div class="card-icon">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8b5cf6" stroke-width="2">
+                        <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/>
+                    </svg>
+                </div>
+                <div class="card-title">Prompt / Agent Harness</div>
+                <div class="card-params">
+                    <div class="param-row"><span class="param-key">x:</span><span class="param-val">Prompt / agent harness code</span></div>
+                    <div class="param-row"><span class="param-key">f:</span><span class="param-val">Accuracy, token cost</span></div>
+                    <div class="param-row"><span class="param-key asi-highlight">ASI:</span><span class="param-val">Reasoning traces, feedback...</span></div>
+                </div>
+            </div>
+
+            <!-- Policy -->
+            <div class="example-card card-policy">
+                <div class="card-icon">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f59e0b" stroke-width="2">
+                        <rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/>
+                    </svg>
+                </div>
+                <div class="card-title">Policy Optimization</div>
+                <div class="card-params">
+                    <div class="param-row"><span class="param-key">x:</span><span class="param-val">Scheduling policy</span></div>
+                    <div class="param-row"><span class="param-key">f:</span><span class="param-val">−cost (efficiency)</span></div>
+                    <div class="param-row"><span class="param-key asi-highlight">ASI:</span><span class="param-val">Job traces, SLA violations...</span></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script>
+        // Dynamically align the loop-back arrow to the exact centers of x and LLM boxes
+        function alignLoopArrow() {
+            const loopSection = document.querySelector('.loop-section');
+            const xBox = document.querySelector('.node-x .node-box');
+            const llmBox = document.querySelector('.node-llm .node-box');
+            const svg = document.querySelector('.loop-back-arrow');
+            if (!loopSection || !xBox || !llmBox || !svg) return;
+
+            const sectionRect = loopSection.getBoundingClientRect();
+            const xRect = xBox.getBoundingClientRect();
+            const llmRect = llmBox.getBoundingClientRect();
+
+            // Centers relative to the loop-section left edge
+            const xCenter = (xRect.left + xRect.width / 2) - sectionRect.left;
+            const llmCenter = (llmRect.left + llmRect.width / 2) - sectionRect.left;
+            const sectionWidth = sectionRect.width;
+
+            // Set SVG viewBox to match section width
+            svg.setAttribute('viewBox', `0 0 ${sectionWidth} 36`);
+            svg.style.width = sectionWidth + 'px';
+
+            // Update path and arrowhead
+            const path = svg.querySelector('path');
+            path.setAttribute('d', `M${llmCenter} 0 L${llmCenter} 26 L${xCenter} 26 L${xCenter} 0`);
+            const arrow = svg.querySelector('polygon');
+            arrow.setAttribute('points', `${xCenter},0 ${xCenter - 11},13 ${xCenter + 11},13`);
+        }
+        window.addEventListener('load', alignLoopArrow);
+        window.addEventListener('resize', alignLoopArrow);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- The header image at the top of the [Introducing optimize_anything](https://gepa-ai.github.io/gepa/blog/2026-02-18-introducing-optimize-anything/) blog post (`images/header_image.png`) was a screenshot of an HTML/CSS diagram, but the source for it was never checked in to `main`.
- The source lived only on the `optimize_anything_pr` branch as `optimize_anything_diagram_v2.html` (added in `e5f955d`, 2026-02-08), and was removed in `041ce7e` before the PR landed.
- This restores it as `docs/docs/blog/posts/2026-02-18-introducing-optimize-anything/header_diagram.html` so the figure is reproducible.

## Test plan
- [ ] Open `header_diagram.html` in a browser and confirm it renders the same diagram as `images/header_image.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)