### PR TITLE
docs(blog): tighten FST TL;DR styling (inline label, no header bar)

### DIFF
--- a/docs/docs/blog/posts/2026-05-11-learning-fast-and-slow/index.md
+++ b/docs/docs/blog/posts/2026-05-11-learning-fast-and-slow/index.md
@@ -39,14 +39,13 @@ citation_keywords: "reinforcement learning, prompt optimization, fast-slow train
 
 # Learning, Fast and Slow: Towards LLMs That Adapt Continually
 
-!!! tip "TL;DR"
-    Adapting an LLM through parameter updates forces every improvement into a single persistent set of weights: task-specific tricks and general reasoning alike. This shrinks the model's distribution toward the trained task, eroding its capacity to learn new ones. Prompt optimization enables fast task-specific adaptations and hence sidesteps this, but cannot, on its own, match the performance ceiling of parameter updates.
+**TL;DR.** Adapting an LLM through parameter updates forces every improvement into a single persistent set of weights: task-specific tricks and general reasoning alike. This shrinks the model's distribution toward the trained task, eroding its capacity to learn new ones. Prompt optimization enables fast task-specific adaptations and hence sidesteps this, but cannot, on its own, match the performance ceiling of parameter updates.
 
-    We introduce **Fast-Slow Training (FST)**, a paradigm for LLM training that optimizes the agent/context layer including prompts as "fast weights" and the network parameters as "slow weights", with the two updates interleaved during training. Fast weights encode task-dependent nuances; enabling slow weights to focus on general capabilities. Across math, code, and general reasoning benchmarks, FST beats weights-only training on every axis we measured. With one recipe, FST:
+We introduce **Fast-Slow Training (FST)**, a paradigm for LLM training that optimizes the agent/context layer including prompts as "fast weights" and the network parameters as "slow weights", with the two updates interleaved during training. Fast weights encode task-dependent nuances; enabling slow weights to focus on general capabilities. Across math, code, and general reasoning benchmarks, FST beats weights-only training on every axis we measured. With one recipe, FST:
 
-    - [Matches RL's performance with up to 3x fewer training steps and lifts the asymptotic ceiling](#data-efficiency) under [ScaleRL](https://arxiv.org/abs/2510.13786)-style scaling-law fits.
-    - [Reaches matched accuracy at ~70% lower KL divergence from the base, preserving the model's ability to keep learning (plasticity).](#plasticity)
-    - [Does a better job at continual learning where weights-only training stalls when the task switches.](#continual-learning)
+- [Matches RL's performance with up to 3x fewer training steps and lifts the asymptotic ceiling](#data-efficiency) under [ScaleRL](https://arxiv.org/abs/2510.13786)-style scaling-law fits.
+- [Reaches matched accuracy at ~70% lower KL divergence from the base, preserving the model's ability to keep learning (plasticity).](#plasticity)
+- [Does a better job at continual learning where weights-only training stalls when the task switches.](#continual-learning)
 
 <figure markdown="span">
   <video controls muted autoplay loop playsinline style="width: 100%; max-width: 800px;">

--- a/docs/docs/blog/posts/2026-05-11-learning-fast-and-slow/index.md
+++ b/docs/docs/blog/posts/2026-05-11-learning-fast-and-slow/index.md
@@ -39,13 +39,14 @@ citation_keywords: "reinforcement learning, prompt optimization, fast-slow train
 
 # Learning, Fast and Slow: Towards LLMs That Adapt Continually
 
-**TL;DR.** Adapting an LLM through parameter updates forces every improvement into a single persistent set of weights: task-specific tricks and general reasoning alike. This shrinks the model's distribution toward the trained task, eroding its capacity to learn new ones. Prompt optimization enables fast task-specific adaptations and hence sidesteps this, but cannot, on its own, match the performance ceiling of parameter updates.
+!!! tip ""
+    **TL;DR.** Adapting an LLM through parameter updates forces every improvement into a single persistent set of weights: task-specific tricks and general reasoning alike. This shrinks the model's distribution toward the trained task, eroding its capacity to learn new ones. Prompt optimization enables fast task-specific adaptations and hence sidesteps this, but cannot, on its own, match the performance ceiling of parameter updates.
 
-We introduce **Fast-Slow Training (FST)**, a paradigm for LLM training that optimizes the agent/context layer including prompts as "fast weights" and the network parameters as "slow weights", with the two updates interleaved during training. Fast weights encode task-dependent nuances; enabling slow weights to focus on general capabilities. Across math, code, and general reasoning benchmarks, FST beats weights-only training on every axis we measured. With one recipe, FST:
+    We introduce **Fast-Slow Training (FST)**, a paradigm for LLM training that optimizes the agent/context layer including prompts as "fast weights" and the network parameters as "slow weights", with the two updates interleaved during training. Fast weights encode task-dependent nuances; enabling slow weights to focus on general capabilities. Across math, code, and general reasoning benchmarks, FST beats weights-only training on every axis we measured. With one recipe, FST:
 
-- [Matches RL's performance with up to 3x fewer training steps and lifts the asymptotic ceiling](#data-efficiency) under [ScaleRL](https://arxiv.org/abs/2510.13786)-style scaling-law fits.
-- [Reaches matched accuracy at ~70% lower KL divergence from the base, preserving the model's ability to keep learning (plasticity).](#plasticity)
-- [Does a better job at continual learning where weights-only training stalls when the task switches.](#continual-learning)
+    - [Matches RL's performance with up to 3x fewer training steps and lifts the asymptotic ceiling](#data-efficiency) under [ScaleRL](https://arxiv.org/abs/2510.13786)-style scaling-law fits.
+    - [Reaches matched accuracy at ~70% lower KL divergence from the base, preserving the model's ability to keep learning (plasticity).](#plasticity)
+    - [Does a better job at continual learning where weights-only training stalls when the task switches.](#continual-learning)
 
 <figure markdown="span">
   <video controls muted autoplay loop playsinline style="width: 100%; max-width: 800px;">


### PR DESCRIPTION
## Summary

Two follow-up edits Kusha pushed directly to `fst-blog/blogpost-rl-gepa` after PR #355 merged. Net effect: the FST blog post's TL;DR admonition no longer renders a separate "TL;DR" header bar — the label is now inline as **TL;DR.** at the start of the first sentence, inside a borderless tip box.

Diff is 2 lines in `docs/docs/blog/posts/2026-05-11-learning-fast-and-slow/index.md`:

- `!!! tip "TL;DR"` → `!!! tip ""` (empty title hides the header bar)
- Body now opens with `**TL;DR.**` inline

Live preview: https://blogpost-rl-gepa.gepa-docs-staging.pages.dev/blog/2026/05/11/learning-fast-and-slow/

## Test plan

- [ ] `mkdocs serve` and confirm the tip box renders without a header bar, with **TL;DR.** as the inline lead-in to the first paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
