### PR TITLE
docs: add Attack Selection (Pivotal Research + Redwood) use-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ Finally:
     - [GEPA in Go Programming Language](https://github.com/XiaoConstantine/dspy-go)
     - [100% accuracy using GEPA on the clock-hands problem](https://colab.research.google.com/drive/1W-XNxKL2CXFoUTwrL7GLCZ7J7uZgXsut?usp=sharing)
     - [Prompt Optimization for Reliable Backdoor Detection in AI-Generated Code](https://www.lesswrong.com/posts/bALBxf3yGGx4bvvem/prompt-optimization-can-enable-ai-control-research)
+    - [Attack Selection Reduces Safety in Concentrated AI Control Settings (Pivotal Research + Redwood) — GEPA-optimized red-team prompts outperform handwritten rubric prompts at evading trusted monitoring](https://arxiv.org/abs/2602.04930)
     - [Teaching LLMs to Diagnose Production Incidents with ATLAS+GEPA](https://www.arc.computer/blog/atlas-sre-diagnosis)
     - [DataBricks: Building State-of-the-Art Enterprise Agents 90x Cheaper with GEPA](https://www.databricks.com/blog/building-state-art-enterprise-agents-90x-cheaper-automated-prompt-optimization)
     - [comet-ml/opik adds support for GEPA](https://www.comet.com/docs/opik/agent_optimization/algorithms/gepa_optimizer)

--- a/docs/docs/guides/use-cases.md
+++ b/docs/docs/guides/use-cases.md
@@ -486,6 +486,20 @@ Discover how organizations and researchers are using GEPA to optimize AI systems
 
     [:material-arrow-right: Read the post](https://www.lesswrong.com/posts/vRpLPZpmECCfxHfv6/paper-prompt-optimization-makes-misalignment-legible)
 
+-   **Attack Selection in AI Control (Pivotal Research + Redwood)**
+
+    ---
+
+    Schaeffer, Khandelwal & Tracy (Pivotal Research / Oxford / Redwood Research) use GEPA to red-team attack-selection prompts in the BigCodeBench backdooring setting, finding that the **GEPA-optimized prompt is the strongest attack** they tested — outperforming handwritten rubric prompts at evading trusted monitoring.
+
+    **Key Results:**
+
+    - GEPA-optimized prompt drives safety to **59%** at 0.5% auditing budget vs the handwritten rubric prompt's **79%** (lower = more effective attack); approaches the "monitor prompt leaked" upper bound of 53%
+    - AUC across auditing budgets: **GEPA 1.37 < Rubric 1.46** (lower = stronger)
+    - Transfers across monitors (GPT-4.1 Nano, Claude 3.5 Haiku, Gemini 2.0 Flash Lite) and attacker models (GPT-4.1 Mini, Claude Haiku 4.5)
+
+    [:material-arrow-right: Read the paper](https://arxiv.org/abs/2602.04930)
+
 -   **Automated Risk-of-Bias Assessment of Clinical Trials**
 
     ---


### PR DESCRIPTION
## Summary

Adds the [Attack Selection Reduces Safety in Concentrated AI Control Settings against Trusted Monitoring](https://arxiv.org/abs/2602.04930) paper (Schaeffer, Khandelwal & Tracy — Pivotal Research / Oxford / Redwood Research) to the use-cases page and README.

## Why this is a positive GEPA result

The paper benchmarks GEPA against handwritten rubric prompts for red-team attack selection in BigCodeBench backdooring, and the **GEPA-optimized prompt is the strongest attack tested**:

- **Safety at 0.5% auditing budget:** 99% (always-attack baseline) → 79% (handwritten rubric prompt) → **59% (GEPA-optimized prompt)** → 53% (monitor-prompt-leaked upper bound). Lower = more effective attack; GEPA approaches the leak baseline.
- **AUC across auditing budgets:** GEPA 1.37 < Rubric 1.46. Lower = stronger attack performance.
- **Transfers:** results hold across three monitors (GPT-4.1 Nano, Claude 3.5 Haiku, Gemini 2.0 Flash Lite) and two attacker models (GPT-4.1 Mini, Claude Haiku 4.5).
- The authors note that GEPA assigns a few good attacks much lower quality scores, making attack-insertion-threshold optimization more robust under distribution shift between APPS (train) and BigCodeBench (test).

It's framed as AI safety / control research — the takeaway for monitoring is that adversarial attack selection erodes safety — but the underlying methodological result is that GEPA outperforms handwritten prompts. Fits alongside the existing "Prompt Optimization Makes Misalignment Legible" (Biddulph & Carroll) entry.

## Changes

- `docs/docs/guides/use-cases.md`: new card in Research & Academic, immediately after the Misalignment-Legible card
- `README.md`: matching bullet in the "GEPA uses" list under the Backdoor Detection entry

## Test plan

- [ ] `mkdocs serve` and confirm the card renders inside Research & Academic without disturbing the grid layout
- [ ] arXiv link resolves on the live page

🤖 Generated with [Claude Code](https://claude.com/claude-code)