### PR TITLE
docs: add RLM-GEPA on AppWorld use-case (Gabriel Lespérance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ Finally:
     - [100% accuracy using GEPA on the clock-hands problem](https://colab.research.google.com/drive/1W-XNxKL2CXFoUTwrL7GLCZ7J7uZgXsut?usp=sharing)
     - [Prompt Optimization for Reliable Backdoor Detection in AI-Generated Code](https://www.lesswrong.com/posts/bALBxf3yGGx4bvvem/prompt-optimization-can-enable-ai-control-research)
     - [Attack Selection Reduces Safety in Concentrated AI Control Settings (Pivotal Research + Redwood) — GEPA-optimized red-team prompts outperform handwritten rubric prompts at evading trusted monitoring](https://arxiv.org/abs/2602.04930)
+    - [Going recursive: RLM-GEPA on AppWorld (Gabriel Lespérance) — PredictRLM(GPT-5.5 low) hits 0.917 TGC / 0.839 SGC unoptimized (beats leaderboard 0.804 SGC); RLM-GEPA lifts to 0.940 TGC / 0.911 SGC](https://x.com/GabLesperance/status/2060754345247863075)
     - [Teaching LLMs to Diagnose Production Incidents with ATLAS+GEPA](https://www.arc.computer/blog/atlas-sre-diagnosis)
     - [DataBricks: Building State-of-the-Art Enterprise Agents 90x Cheaper with GEPA](https://www.databricks.com/blog/building-state-art-enterprise-agents-90x-cheaper-automated-prompt-optimization)
     - [comet-ml/opik adds support for GEPA](https://www.comet.com/docs/opik/agent_optimization/algorithms/gepa_optimizer)

--- a/docs/docs/guides/use-cases.md
+++ b/docs/docs/guides/use-cases.md
@@ -276,6 +276,21 @@ Discover how organizations and researchers are using GEPA to optimize AI systems
 
     [:material-arrow-right: View tutorial](https://www.rajapatnaik.com/blog/2025/10/23/langgraph-dspy-gepa-researcher)
 
+-   **RLM-GEPA on AppWorld: Beating the Public Leaderboard**
+
+    ---
+
+    Gabriel Lespérance ports GEPA to optimize **RLM skills** (not weights) for the **AppWorld** agent benchmark (email, calendar, Spotify, Venmo, shopping, todo over realistic app APIs). Unoptimized `PredictRLM(GPT-5.5 low)` already exceeds the public leaderboard; RLM-GEPA pushes it further.
+
+    **Key Results:**
+
+    - Unoptimized `PredictRLM(GPT-5.5 low)`: **0.917 TGC / 0.839 SGC** on test_normal vs current public leaderboard high-water mark of 0.804 SGC
+    - RLM-GEPA optimized: **0.940 TGC / 0.911 SGC** on test_normal (+2.3pp TGC, +7.2pp SGC)
+    - test_challenge transfer: 0.914 TGC / 0.820 SGC unoptimized → 0.911 TGC / 0.849 SGC optimized
+    - Optimizer reads execution traces + evaluator feedback, rewrites the skill instructions only (held-out splits reserved)
+
+    [:material-arrow-right: Read the thread](https://x.com/GabLesperance/status/2060754345247863075)
+
 </div>
 
 ---


### PR DESCRIPTION
## Summary

Links Gabriel Lespérance's thread on porting GEPA to optimize RLM skills (not weights) for the [AppWorld](https://appworld.dev) agent benchmark — realistic app APIs across email, calendar, Spotify, Venmo, shopping, todo lists.

## Why it's worth linking

The unoptimized RLM baseline already exceeds the current public AppWorld leaderboard, and RLM-GEPA pushes it further:

- **Unoptimized** `PredictRLM(GPT-5.5 low)`: **0.917 TGC / 0.839 SGC** on test_normal (above the current public high-water mark of 0.869 TGC / 0.804 SGC)
- **RLM-GEPA optimized**: **0.940 TGC / 0.911 SGC** on test_normal (+2.3pp TGC, +7.2pp SGC)
- **test_challenge transfer**: 0.914 TGC / 0.820 SGC unoptimized → 0.911 TGC / 0.849 SGC optimized (+2.9pp SGC; -0.3pp TGC)
- Optimizer rewrites only the AppWorld skill instructions using execution traces + evaluator feedback; held-out splits reserved

Beats Context Labs HALO's published AppWorld test_normal SGC (0.732 for Sonnet 4.6, 0.482 for Gemini 3 Flash) and Alibaba's AgentRL leaderboard entry (0.804 SGC). The optimizer-on-train, select-on-dev, report-on-test discipline is clean.

## Changes

- `docs/docs/guides/use-cases.md`: new card under **AI Coding Agents & Research Tools**, after the DeepResearch Agent entry
- `README.md`: matching bullet under **GEPA uses**

## Test plan

- [ ] `mkdocs serve` and confirm the card renders without disturbing the grid
- [ ] x.com link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)