### PR TITLE
docs: add Google ADK / Gemini Enterprise Agent Platform + Microsoft MAI-Thinking-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ GEPA is integrated into several major frameworks:
 - **[Pydantic](https://pydantic.dev/articles/prompt-optimization-with-gepa)** — Prompt optimization for Pydantic AI.
 - **[OpenAI Cookbook](https://cookbook.openai.com/examples/partners/self_evolving_agents/autonomous_agent_retraining)** — Self-evolving agents with GEPA.
 - **[HuggingFace Cookbook](https://huggingface.co/learn/cookbook/en/dspy_gepa)** — Prompt optimization guide.
-- **[Google ADK](https://adk.dev/optimize/)** — Built-in agent optimization in Google's Agent Development Kit. [Community tutorial](https://raphaelmansuy.github.io/adk_training/blog/gepa-optimization-tutorial/).
+- **[Google ADK / Gemini Enterprise Agent Platform](https://docs.cloud.google.com/gemini-enterprise-agent-platform/optimize/evaluation/optimize-agent)** — `adk optimize` powered by GEPA, also shipped inside Google Cloud's Gemini Enterprise Agent Platform Quality Flywheel. [ADK docs](https://adk.dev/optimize/) · [Community tutorial](https://raphaelmansuy.github.io/adk_training/blog/gepa-optimization-tutorial/).
+- **[Microsoft AI: MAI-Thinking-1](https://microsoft.ai/wp-content/uploads/2026/06/main_20260602_2.pdf)** — Uses GEPA / DSPy to optimize the Qwen3-30B LLM-judge prompt that filters Code pages in the model's pre-training pipeline (~233B tokens of curated data).
 
 ---
 
@@ -390,7 +391,7 @@ Finally:
   - [Comet ML Opik](https://www.comet.com/docs/opik/agent_optimization/algorithms/gepa_optimizer) - Core optimization algorithm in Opik Agent Optimizer.
   - [OpenAI Cookbook](https://cookbook.openai.com/examples/partners/self_evolving_agents/autonomous_agent_retraining) - Self-evolving agents with GEPA.
   - [HuggingFace Cookbook](https://huggingface.co/learn/cookbook/en/dspy_gepa) - Prompt optimization guide.
-  - [Google ADK](https://adk.dev/optimize/) - Built-in agent optimization in Google's Agent Development Kit. [Community tutorial](https://raphaelmansuy.github.io/adk_training/blog/gepa-optimization-tutorial/).
+  - [Google ADK / Gemini Enterprise Agent Platform](https://docs.cloud.google.com/gemini-enterprise-agent-platform/optimize/evaluation/optimize-agent) - `adk optimize` powered by GEPA, also shipped inside Google Cloud's Gemini Enterprise Agent Platform Quality Flywheel. [ADK docs](https://adk.dev/optimize/) · [Community tutorial](https://raphaelmansuy.github.io/adk_training/blog/gepa-optimization-tutorial/).
   - [Contributed Adapters](src/gepa/adapters/) – see our adapter templates and issue tracker to request new integrations.
     - [DefaultAdapter](src/gepa/adapters/default_adapter/) - System Prompt Optimization for a single-turn task.
     - [ConfidenceAdapter](src/gepa/adapters/confidence_adapter/) - Logprob-aware classification optimization using [`llm-structured-confidence`](https://github.com/rodolfonobrega/llm-structured-confidence). Detects lucky guesses by extracting token-level logprobs from structured JSON outputs with `enum` constraints, and feeds confidence diagnostics (logprob, probability, top alternatives) into the reflection LLM. Install with `pip install "gepa[confidence]"`. See the [guide](https://gepa-ai.github.io/gepa/guides/confidence-adapter/).
@@ -401,6 +402,8 @@ Finally:
     - [AnyMaths Adapter](src/gepa/adapters/anymaths_adapter/) - Adapter for optimizing mathematical problem-solving and reasoning tasks. Contributed by [@egmaminta](www.linkedin.com/in/egmaminta).
     - [LangChain Adapter](src/gepa/adapters/langchain_adapter/) - Optimize prompts for any LangChain pipeline: single-turn chat models, tool-using agents built with `create_agent`, custom LangGraph graphs, RAG, and more. Provider-agnostic via LangChain's `init_chat_model`. Install with `pip install "gepa[langchain]"` plus a provider package (e.g. `langchain-openai`).
 - **GEPA uses**
+    - [Microsoft AI: MAI-Thinking-1](https://microsoft.ai/wp-content/uploads/2026/06/main_20260602_2.pdf) — GEPA / DSPy optimizes the Qwen3-30B LLM-judge prompt used to filter Code pages in the pre-training pipeline (~233B tokens curated from ~2,000 human labels).
+    - [Google: Gemini Enterprise Agent Platform — `adk optimize` powered by GEPA](https://docs.cloud.google.com/gemini-enterprise-agent-platform/optimize/evaluation/optimize-agent)
     - [Nous Research Hermes Agent: evolutionary self-improvement with DSPy + GEPA](https://github.com/NousResearch/hermes-agent-self-evolution)
     - [Context Compression using GEPA](https://github.com/Laurian/context-compression-experiments-2508)
     - [GEPA Integration into SuperOptiX-AI](https://github.com/SuperagenticAI/gepa-eval)

--- a/docs/docs/guides/use-cases.md
+++ b/docs/docs/guides/use-cases.md
@@ -105,23 +105,44 @@ Discover how organizations and researchers are using GEPA to optimize AI systems
 
     [:material-arrow-right: View cookbook](https://huggingface.co/learn/cookbook/en/dspy_gepa)
 
--   **Google ADK: Official Agent Optimization**
+-   **Google: ADK + Gemini Enterprise Agent Platform**
 
     ---
 
     ![Google ADK Training](../static/img/use-cases/google_adk.png){ .card-image }
 
-    Google's Agent Development Kit (ADK) uses GEPA as its **built-in agent optimization engine**. The `adk optimize` CLI command runs a `GEPARootAgentPromptOptimizer` to automatically improve agent instructions based on evaluation results.
+    Google ships GEPA as the **official agent-optimization engine** in two places: the open-source [Agent Development Kit](https://adk.dev/optimize/) and Google Cloud's [Gemini Enterprise Agent Platform](https://docs.cloud.google.com/gemini-enterprise-agent-platform/optimize/evaluation/optimize-agent). The platform docs describe the integration directly: *"This command applies the GEPA algorithm to iteratively refine root system instructions by evaluating them against your test suite."*
 
     **Key Features:**
 
     - Official `adk optimize` CLI powered by GEPA
     - `LocalEvalSampler` for running evaluations
     - Automatic prompt rewriting via `GEPARootAgentPromptOptimizer`
+    - Same GEPA pipeline available inside the Gemini Enterprise Agent Platform's "Quality Flywheel" optimization loop
+
+    [:material-arrow-right: Gemini Enterprise Agent Platform docs](https://docs.cloud.google.com/gemini-enterprise-agent-platform/optimize/evaluation/optimize-agent)
 
     [:material-arrow-right: Official ADK docs](https://adk.dev/optimize/)
 
     [:material-arrow-right: Community tutorial](https://raphaelmansuy.github.io/adk_training/blog/gepa-optimization-tutorial/)
+
+-   **Microsoft AI: MAI-Thinking-1 Pre-training Data Curation**
+
+    ---
+
+    The Microsoft AI team's **MAI-Thinking-1** ("Building a Hill-Climbing Machine") uses **GEPA / DSPy to optimize an LLM-judge prompt for filtering pre-training data**. They score each candidate document with a Qwen3-30B judge whose prompt was tuned by GEPA against ~2,000 human labels.
+
+    **From the paper:**
+
+    > "To further improve quality, we score each candidate document using Qwen3-30B. The judge prompt is optimized with GEPA / DSPy (Agrawal et al., 2026) with approximately 2,000 human labels. After filtering out low-quality documents with additional heuristics, we obtain a dataset of approximately 233B tokens."
+
+    **Key Insights:**
+
+    - GEPA-tuned LLM judge drives the Code-pages filtering pipeline that produces **~233B tokens** of high-quality pre-training data
+    - First public report of GEPA being used inside a frontier model's pre-training data pipeline
+    - Demonstrates GEPA's reach beyond inference-time prompt optimization, into upstream data quality
+
+    [:material-arrow-right: Read the paper](https://microsoft.ai/wp-content/uploads/2026/06/main_20260602_2.pdf)
 
 -   **Comet-ml Opik Integration**
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -45,6 +45,8 @@ hide:
   <div class="marquee-wrapper">
     <div class="marquee-track">
       <a href="https://x.com/tobi/status/1963434604741701909" target="_blank">Shopify</a>
+      <a href="https://docs.cloud.google.com/gemini-enterprise-agent-platform/optimize/evaluation/optimize-agent" target="_blank">Google</a>
+      <a href="https://microsoft.ai/wp-content/uploads/2026/06/main_20260602_2.pdf" target="_blank">Microsoft</a>
       <a href="https://developers.openai.com/cookbook/examples/partners/self_evolving_agents/autonomous_agent_retraining" target="_blank">OpenAI</a>
       <a href="https://www.databricks.com/blog/building-state-art-enterprise-agents-90x-cheaper-automated-prompt-optimization" target="_blank">Databricks</a>
       <a href="https://pydantic.dev/articles/prompt-optimization-with-gepa" target="_blank">Pydantic</a>
@@ -70,6 +72,8 @@ hide:
       <a href="https://agenta.ai" target="_blank">Agenta</a>
       <!-- duplicate set for seamless loop -->
       <a href="https://x.com/tobi/status/1963434604741701909" target="_blank">Shopify</a>
+      <a href="https://docs.cloud.google.com/gemini-enterprise-agent-platform/optimize/evaluation/optimize-agent" target="_blank">Google</a>
+      <a href="https://microsoft.ai/wp-content/uploads/2026/06/main_20260602_2.pdf" target="_blank">Microsoft</a>
       <a href="https://developers.openai.com/cookbook/examples/partners/self_evolving_agents/autonomous_agent_retraining" target="_blank">OpenAI</a>
       <a href="https://www.databricks.com/blog/building-state-art-enterprise-agents-90x-cheaper-automated-prompt-optimization" target="_blank">Databricks</a>
       <a href="https://pydantic.dev/articles/prompt-optimization-with-gepa" target="_blank">Pydantic</a>


### PR DESCRIPTION
## Summary

Two new GEPA usages worth surfacing prominently in the docs:

### 1. Google now exposes GEPA inside the **Gemini Enterprise Agent Platform** (in addition to the open-source ADK)

The Cloud docs describe the integration directly:

> "This command applies the GEPA algorithm to iteratively refine root system instructions by evaluating them against your test suite."

Source: <https://docs.cloud.google.com/gemini-enterprise-agent-platform/optimize/evaluation/optimize-agent>

This isn't a new product — it's the same `adk optimize` / `GEPARootAgentPromptOptimizer` pipeline made part of Google Cloud's official Gemini Enterprise Agent Platform "Quality Flywheel". The existing standalone "Google ADK" card on the Showcase page is updated to cover both surfaces with one card.

### 2. Microsoft AI uses **GEPA / DSPy in MAI-Thinking-1's pre-training pipeline**

From the [MAI-Thinking-1 paper](https://microsoft.ai/wp-content/uploads/2026/06/main_20260602_2.pdf) ("Building a Hill-Climbing Machine"), Appendix A.1 (Code pages):

> "To further improve quality, we score each candidate document using Qwen3-30B (Yang et al., 2025). The judge prompt is optimized with GEPA / DSPy (Agrawal et al., 2026) with approximately 2,000 human labels. After filtering out low-quality documents with additional heuristics, we obtain a dataset of approximately 233B tokens."

This is the first publicly reported use of GEPA *inside a frontier model's pre-training data pipeline* — upstream of the model, on data curation. New card under Enterprise & Production.

## Changes

- `docs/docs/guides/use-cases.md`:
  - Replace standalone "Google ADK: Official Agent Optimization" card with combined **Google: ADK + Gemini Enterprise Agent Platform** card (keeps existing ADK + community-tutorial links; adds the Cloud docs link and a verbatim quote from it).
  - New **Microsoft AI: MAI-Thinking-1 Pre-training Data Curation** card with the paper quote.
- `docs/docs/index.md`: add **Google** and **Microsoft** to the homepage "Trusted by teams at" marquee — both halves of the seamless-loop duplicate. Google links to the Cloud docs page; Microsoft links to the paper PDF.
- `README.md`: extend the Integrations table entry to cover Gemini Enterprise Agent Platform; add **Microsoft AI: MAI-Thinking-1** bullet to Integrations; add the same two as the top entries under "GEPA uses".

## Test plan

- [ ] `mkdocs serve` — confirm the merged Google card renders cleanly, the new Microsoft card renders inside Enterprise & Production grid, and Google + Microsoft logos appear in the homepage marquee.
- [ ] External links resolve: Cloud docs page, ADK docs, paper PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)