### PR TITLE
feat: ReflectionLM protocol + batch-based parallel proposals (#329 Phases 1 & 4)

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -75,6 +75,7 @@ jobs:
     name: Run Tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
@@ -150,6 +151,7 @@ jobs:
     name: Build Package
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:

--- a/docs/docs/guides/parallel-proposals.md
+++ b/docs/docs/guides/parallel-proposals.md
@@ -47,7 +47,9 @@ from gepa.strategies.proposal_selection import (
 
 ## Using them
 
-Both `gepa.optimize()` and `optimize_anything` accept the strategies directly:
+`gepa.optimize()` accepts the strategies directly; in `optimize_anything`
+they are fields of `EngineConfig` (`EngineConfig(sampling_strategy=...,
+selection_strategy=...)`):
 
 ```python
 import gepa
@@ -135,6 +137,9 @@ does **not** apply — structurally, because there is no per-evaluation call to
 scope them to — is `oa.log()` and stdout/stderr capture: return diagnostics
 inside each pair's `side_info` instead.
 
+In single-task mode (no `dataset`/`valset`) the `example` slot of each
+pair is `None` — mirror of the evaluator path, which omits `example` entirely.
+
 `evaluator=` is optional when `batch_evaluator=` is set. With only a batch
 function, *everything* routes through it: multi-pair work (minibatch stages,
 valset/seed/merge evaluations) as grouped calls, and single-pair resolutions
@@ -152,7 +157,10 @@ iteration emits separate `on_budget_updated` events for the parent-evaluation
 and child-evaluation stages (plus one per accepted candidate's full-valset
 evaluation), and `metric_calls_used` remains monotonic with self-consistent
 deltas. If you aggregate budget events, sum `metric_calls_delta` rather than
-counting events.
+counting events. Note that budget overshoot past `max_metric_calls` scales with
+the per-iteration proposal count (the stop condition is checked between
+iterations): with `PxNSampling(p=4, n=4)` a single iteration can spend up to
+16 minibatches + 16 child evaluations beyond the limit.
 
 ## Advanced: custom reflection strategies
 

--- a/docs/docs/guides/parallel-proposals.md
+++ b/docs/docs/guides/parallel-proposals.md
@@ -13,10 +13,9 @@ The defaults (`SingleMutationSampling` + `AllImprovements`) reproduce classic
 GEPA behavior exactly: one parent, one mutation per iteration. Existing runs
 do not change.
 
-!!! note "Replaces `num_parallel_proposals`"
-    Versions v0.1.2/v0.1.3 briefly shipped an experimental integer knob,
-    `EngineConfig.num_parallel_proposals`. It is replaced by the strategies on
-    this page (see [RFC #329](https://github.com/gepa-ai/gepa/issues/329)).
+!!! note
+    These strategies are the interface for multi-proposal iterations
+    (design: [RFC #329](https://github.com/gepa-ai/gepa/issues/329)).
 
 ## Sampling strategies
 
@@ -67,10 +66,12 @@ result = gepa.optimize(
 )
 ```
 
-Acceptance is unchanged: every proposal is still evaluated on its minibatch
-and only improvements (per the configured `acceptance_criterion`) are
-considered by the selection strategy. The engine remains the single accept
-authority.
+Every proposal is still evaluated on its minibatch. The selection strategy
+is the authority over which proposals enter the pool: it receives **all**
+evaluated proposals plus the configured `acceptance_criterion`. The built-in
+strategies apply the criterion (so defaults only admit improvements); a custom
+strategy may deliberately surface a proposal the criterion would reject — e.g.
+an exploration pick. Anything not selected fires `on_candidate_rejected`.
 
 ## Where the parallelism actually runs: `batch_evaluate`
 
@@ -92,6 +93,30 @@ Third-party adapters that only implement `evaluate()` keep working unmodified
 is batched analogously: the built-in stateless reflector batches all
 per-component reflection calls via `litellm.batch_completion`.
 
+### `batch_evaluator`: one external call for the whole batch
+
+In `optimize_anything`, you can take over batching entirely: pass
+`batch_evaluator=` and GEPA hands you **all pending `(candidate, example)`
+pairs in a single call** — submit them as one provider batch job, one Slurm
+array, one Ray job — and return one result per pair (`score` or
+`(score, side_info)`).
+
+```python
+def my_batch_eval(pairs, opt_states):   # opt_states is optional — declare it to receive warm-start state
+    jobs = [submit(candidate, example) for candidate, example in pairs]
+    return [(job.score(), {"log": job.diagnostics()}) for job in jobs]
+
+optimize_anything(evaluator=my_eval, batch_evaluator=my_batch_eval, ...)
+```
+
+The contract, precisely: str-candidate unwrapping, per-pair `opt_states`
+injection (if your signature accepts it), exception policy
+(`raise_on_exception`), warm-start history, and output packaging all match the
+sequential path. What does **not** apply — structurally, because there is no
+per-evaluation call to scope them to — is `oa.log()` and stdout/stderr
+capture: return diagnostics inside each pair's `side_info` instead.
+`evaluator=` is still required for single-pair features such as the refiner.
+
 ## Budget accounting and events
 
 Totals are identical to the sequential path, at finer event granularity: each
@@ -105,7 +130,8 @@ counting events.
 
 The reflection call itself is a seam (`ReflectionLM`,
 [RFC #329](https://github.com/gepa-ai/gepa/issues/329)): pass
-`reflection_strategy=` to `gepa.optimize()` to replace the stateless
+`reflection_strategy=` to `gepa.optimize()` (or set
+`ReflectionConfig.reflection_strategy` in `optimize_anything`) to replace the stateless
 single-call reflector with a stateful or aggregating implementation (e.g.
 session-based reflection, or map-reduce aggregation over parallel reflections
 as in [ComBEE, PR #307](https://github.com/gepa-ai/gepa/pull/307)).

--- a/docs/docs/guides/parallel-proposals.md
+++ b/docs/docs/guides/parallel-proposals.md
@@ -111,11 +111,20 @@ optimize_anything(evaluator=my_eval, batch_evaluator=my_batch_eval, ...)
 
 The contract, precisely: str-candidate unwrapping, per-pair `opt_states`
 injection (if your signature accepts it), exception policy
-(`raise_on_exception`), warm-start history, and output packaging all match the
-sequential path. What does **not** apply — structurally, because there is no
-per-evaluation call to scope them to — is `oa.log()` and stdout/stderr
-capture: return diagnostics inside each pair's `side_info` instead.
-`evaluator=` is still required for single-pair features such as the refiner.
+(`raise_on_exception`), **evaluation caching** (shared store and keys with the
+sequential path — only cache misses reach your function, still as one call),
+warm-start history, and output packaging all match the sequential path. What
+does **not** apply — structurally, because there is no per-evaluation call to
+scope them to — is `oa.log()` and stdout/stderr capture: return diagnostics
+inside each pair's `side_info` instead.
+
+`evaluator=` is optional when `batch_evaluator=` is set. With only a batch
+function, *everything* routes through it: multi-pair work (minibatch stages,
+valset/seed/merge evaluations) as grouped calls, and single-pair resolutions
+(refiner steps) as **singleton batches** — make your function efficient for
+`len(pairs) == 1` if you enable the refiner. When both are provided, grouped
+work prefers `batch_evaluator` and singles use `evaluator` (whose per-call
+`oa.log()`/stdio capture then applies to those calls).
 
 ## Budget accounting and events
 

--- a/docs/docs/guides/parallel-proposals.md
+++ b/docs/docs/guides/parallel-proposals.md
@@ -135,7 +135,10 @@ sequential path — only cache misses reach your function, still as one call),
 warm-start history, and output packaging all match the sequential path. What
 does **not** apply — structurally, because there is no per-evaluation call to
 scope them to — is `oa.log()` and stdout/stderr capture: return diagnostics
-inside each pair's `side_info` instead.
+inside each pair's `side_info` instead. If the whole batch call raises with
+`raise_on_exception=False`, each affected pair's `side_info` carries
+`{"error": ..., "_gepa_transient_failure": True}`; such results are never
+cached, so they are re-evaluated on the next run.
 
 In single-task mode (no `dataset`/`valset`) the `example` slot of each
 pair is `None` — mirror of the evaluator path, which omits `example` entirely.

--- a/docs/docs/guides/parallel-proposals.md
+++ b/docs/docs/guides/parallel-proposals.md
@@ -1,0 +1,113 @@
+# Parallel Proposals: Sampling & Selection Strategies
+
+GEPA's reflective mutation loop can generate and evaluate **multiple candidate
+proposals per iteration**. This is controlled by two small, composable
+strategy objects rather than a numeric knob:
+
+- a **sampling strategy** decides *which (parent, minibatch) proposal tasks*
+  are attempted this iteration, and
+- a **selection strategy** decides *which of the resulting improvements* enter
+  the candidate pool.
+
+The defaults (`SingleMutationSampling` + `AllImprovements`) reproduce classic
+GEPA behavior exactly: one parent, one mutation per iteration. Existing runs
+do not change.
+
+!!! note "Replaces `num_parallel_proposals`"
+    Versions v0.1.2/v0.1.3 briefly shipped an experimental integer knob,
+    `EngineConfig.num_parallel_proposals`. It is replaced by the strategies on
+    this page (see [RFC #329](https://github.com/gepa-ai/gepa/issues/329)).
+
+## Sampling strategies
+
+```python
+from gepa.strategies.proposal_sampling import (
+    SingleMutationSampling,  # default: 1 parent, 1 mutation
+    SameParentSampling,      # n mutations of the same parent
+    IndependentSampling,     # n independent (parent, minibatch) tasks
+    PxNSampling,             # p parents x n mutations each
+)
+```
+
+| Strategy | Per iteration | Use when |
+|---|---|---|
+| `SingleMutationSampling()` | 1 parent, 1 mutation | Default; classic GEPA |
+| `SameParentSampling(n=4)` | 1 parent, `n` mutations | Exploit a strong parent with diverse edits |
+| `IndependentSampling(n=4)` | `n` parents, 1 mutation each | Explore the frontier broadly |
+| `PxNSampling(p=2, n=2)` | `p` parents × `n` mutations | Balanced explore/exploit |
+
+## Selection strategies
+
+```python
+from gepa.strategies.proposal_selection import (
+    AllImprovements,   # default: every improving proposal joins the pool
+    BestImprovement,   # only the single best improvement joins
+    TopKImprovements,  # the k best improvements join
+)
+```
+
+## Using them
+
+Both `gepa.optimize()` and `optimize_anything` accept the strategies directly:
+
+```python
+import gepa
+from gepa.strategies.proposal_sampling import PxNSampling
+from gepa.strategies.proposal_selection import TopKImprovements
+
+result = gepa.optimize(
+    seed_candidate=seed,
+    trainset=trainset,
+    valset=valset,
+    task_lm="openai/gpt-4.1-mini",
+    reflection_lm="openai/gpt-5",
+    max_metric_calls=600,
+    sampling_strategy=PxNSampling(p=2, n=2),
+    selection_strategy=TopKImprovements(k=2),
+)
+```
+
+Acceptance is unchanged: every proposal is still evaluated on its minibatch
+and only improvements (per the configured `acceptance_criterion`) are
+considered by the selection strategy. The engine remains the single accept
+authority.
+
+## Where the parallelism actually runs: `batch_evaluate`
+
+Multi-proposal iterations batch their evaluations at the **adapter edge**. The
+engine and proposer stay sequential; adapters opt into true parallelism by
+implementing one optional method:
+
+```python
+class MyAdapter:
+    def evaluate(self, batch, candidate, capture_traces=False): ...
+
+    # Optional. When absent, GEPA calls evaluate() once per item.
+    def batch_evaluate(self, items: list[tuple[Candidate, list]]) -> list[EvaluationBatch]:
+        ...  # e.g. fan out across threads, processes, or an eval service
+```
+
+Third-party adapters that only implement `evaluate()` keep working unmodified
+(`default_batch_evaluate` is the sequential fallback). The reflection LM side
+is batched analogously: the built-in stateless reflector batches all
+per-component reflection calls via `litellm.batch_completion`.
+
+## Budget accounting and events
+
+Totals are identical to the sequential path, at finer event granularity: each
+iteration emits separate `on_budget_updated` events for the parent-evaluation
+and child-evaluation stages (plus one per accepted candidate's full-valset
+evaluation), and `metric_calls_used` remains monotonic with self-consistent
+deltas. If you aggregate budget events, sum `metric_calls_delta` rather than
+counting events.
+
+## Advanced: custom reflection strategies
+
+The reflection call itself is a seam (`ReflectionLM`,
+[RFC #329](https://github.com/gepa-ai/gepa/issues/329)): pass
+`reflection_strategy=` to `gepa.optimize()` to replace the stateless
+single-call reflector with a stateful or aggregating implementation (e.g.
+session-based reflection, or map-reduce aggregation over parallel reflections
+as in [ComBEE, PR #307](https://github.com/gepa-ai/gepa/pull/307)).
+Implementations provide `reflect()`; `reflect_many()` is optional and enables
+batched reflection.

--- a/docs/docs/guides/parallel-proposals.md
+++ b/docs/docs/guides/parallel-proposals.md
@@ -73,6 +73,23 @@ strategies apply the criterion (so defaults only admit improvements); a custom
 strategy may deliberately surface a proposal the criterion would reject — e.g.
 an exploration pick. Anything not selected fires `on_candidate_rejected`.
 
+## Choosing an evaluation tier
+
+Three tiers, from easiest to most control — they compose, and none replaces
+the others:
+
+| Tier | You write | You get | Reach for it when |
+|---|---|---|---|
+| `parallel=False` | a singleton `evaluator(candidate, example)` | sequential, deterministic evaluation on the caller thread | debugging, or your evaluator is not thread-safe (shared state, GPU contexts) |
+| `parallel=True` *(default)* | the same singleton evaluator | automatic thread-pool concurrency **with the full per-call feature surface**: `oa.log()`/stdio capture, per-pair exception isolation, per-call `opt_state` | the common case — I/O-bound evaluators (LLM calls, HTTP) |
+| `batch_evaluator=` | a function over **all pending pairs at once** | one grouped external call: provider batch APIs, cluster/Slurm/Ray dispatch, vLLM server batching, cross-pair dedup, CPU-bound work beyond the GIL | threads-over-singletons can't express your batching |
+
+When `batch_evaluator` is provided, it is the preferred transport for all
+grouped evaluations — the `parallel=True` thread pool is not used for them
+(a log line notes this). Providing **both** gives grouped work to the batch
+function and single-pair resolutions (refiner steps) to the evaluator, whose
+per-call features apply there.
+
 ## Where the parallelism actually runs: `batch_evaluate`
 
 Multi-proposal iterations batch their evaluations at the **adapter edge**. The
@@ -122,7 +139,9 @@ inside each pair's `side_info` instead.
 function, *everything* routes through it: multi-pair work (minibatch stages,
 valset/seed/merge evaluations) as grouped calls, and single-pair resolutions
 (refiner steps) as **singleton batches** — make your function efficient for
-`len(pairs) == 1` if you enable the refiner. When both are provided, grouped
+`len(pairs) == 1` if you enable the refiner, and thread-safe if you combine
+the refiner with `parallel=True` (refinement loops run on the thread pool and
+may call it concurrently). When both are provided, grouped
 work prefers `batch_evaluator` and singles use `evaluator` (whose per-call
 `oa.log()`/stdio capture then applies to those calls).
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
         - Candidate Selection Strategies: guides/candidate-selection.md
         - Acceptance Criterion: guides/acceptance-criterion.md
         - Batch Sampling: guides/batch-sampling.md
+        - Parallel Proposals: guides/parallel-proposals.md
         - Using Callbacks: guides/callbacks.md
         - Cost & Token Tracking: guides/cost-tracking.md
         - Experiment Tracking: guides/experiment-tracking.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,11 @@ dependencies = []
 [project.optional-dependencies]
 full = [
     # Common dependencies (all Python versions)
-    "litellm>=1.83.0",
+    # litellm 1.92.0 ships no cp314 wheels and its sdist fails to build on
+    # Python 3.14 (bundled pyo3 0.23.5 predates the 3.14 ABI); cap on 3.14
+    # until upstream publishes cp314 wheels.
+    "litellm>=1.83.0; python_version < '3.14'",
+    "litellm>=1.83.0,<1.92.0; python_version >= '3.14'",
     "tqdm>=4.66.1",
     "cloudpickle>=3.0.0",
     # Python < 3.14
@@ -41,7 +45,7 @@ full = [
 confidence = [
     "llm-structured-confidence>=0.4.5",
     "litellm>=1.64.0; python_version < '3.14'",
-    "litellm>=1.81.0; python_version >= '3.14'",
+    "litellm>=1.81.0,<1.92.0; python_version >= '3.14'",
 ]
 dspy = []
 test = [

--- a/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
+++ b/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
@@ -93,10 +93,12 @@ class BatchEvaluatorWrapper:
         *,
         str_candidate_key: str | None = None,
         raise_on_exception: bool = True,
+        single_instance_mode: bool = False,
     ):
         self._fn = batch_fn
         self._str_candidate_key = str_candidate_key
         self._raise_on_exception = raise_on_exception
+        self._single_instance_mode = single_instance_mode
         sig = inspect.signature(batch_fn)
         has_var_kw = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values())
         self._accepts_opt_states = has_var_kw or "opt_states" in sig.parameters
@@ -108,7 +110,12 @@ class BatchEvaluatorWrapper:
     ) -> list[tuple[float, dict[str, Any]]]:
         call_pairs: list[tuple[Any, Any]] = list(pairs)
         if self._str_candidate_key is not None:
-            call_pairs = [(candidate[self._str_candidate_key], example) for candidate, example in pairs]
+            call_pairs = [(candidate[self._str_candidate_key], example) for candidate, example in call_pairs]
+        if self._single_instance_mode:
+            # Mirror of EvaluatorWrapper's single-instance handling: the
+            # internal placeholder example must never reach user code — the
+            # user-visible example is None in this mode.
+            call_pairs = [(candidate, None) for candidate, _example in call_pairs]
 
         kwargs: dict[str, Any] = {}
         if self._accepts_opt_states and opt_states is not None:
@@ -119,25 +126,41 @@ class BatchEvaluatorWrapper:
         except Exception as e:
             if self._raise_on_exception:
                 raise
-            return [(0.0, {"error": str(e)}) for _ in pairs]
+            # _gepa_transient_failure marks these as synthetic whole-batch
+            # failure results: the adapter will NOT cache them, so one
+            # transient infrastructure error cannot poison the (disk) cache
+            # for every pair across runs.
+            return [(0.0, {"error": str(e), "_gepa_transient_failure": True}) for _ in pairs]
 
         if len(raw_results) != len(pairs):
             raise ValueError(f"batch_evaluator returned {len(raw_results)} results but expected {len(pairs)}")
 
         normalized: list[tuple[float, dict[str, Any]]] = []
-        for r in raw_results:
+        for idx, r in enumerate(raw_results):
             if isinstance(r, list | tuple):
                 r_seq = list(r)
                 if len(r_seq) >= 3:
                     # Legacy (score, output, side_info): the output slot is
                     # ignored — the adapter packages outputs identically to the
                     # sequential path as (score, candidate, side_info).
-                    si = r_seq[2] if isinstance(r_seq[2], dict) else {}
+                    si_raw = r_seq[2]
                 elif len(r_seq) == 2:
-                    si = r_seq[1] if isinstance(r_seq[1], dict) else {}
+                    si_raw = r_seq[1]
                 else:
-                    si = {}
-                normalized.append((float(r_seq[0]), si))
+                    si_raw = {}
+                if si_raw is None:
+                    si_raw = {}
+                if not isinstance(si_raw, dict):
+                    # Mirror the evaluator path's loudness instead of silently
+                    # discarding user diagnostics.
+                    raise TypeError(
+                        f"batch_evaluator result {idx}: side_info must be a dict or None, "
+                        f"got {type(si_raw).__name__}"
+                    )
+                # Defensive copy (mirror of EvaluatorWrapper): the user may
+                # retain and mutate their dict; the cache, best-evals history,
+                # and objective scores must not be corruptible after return.
+                normalized.append((float(r_seq[0]), dict(si_raw)))
             else:
                 normalized.append((float(r), {}))
         return normalized
@@ -326,11 +349,14 @@ class OptimizeAnythingAdapter(GEPAAdapter):
         # Cache miss - call evaluator
         result = self._resolve_pair(candidate, example)
 
-        # Store in cache (thread-safe)
-        with self._eval_cache_lock:
-            self._eval_cache[cache_key] = result
-            if self.cache_mode == "disk":
-                self._save_cache_entry(cache_key, result)
+        # Store in cache (thread-safe); synthetic transient-failure results
+        # from a batch_evaluator exception are never cached.
+        side_info = result[2] if len(result) > 2 and isinstance(result[2], dict) else {}
+        if not side_info.get("_gepa_transient_failure"):
+            with self._eval_cache_lock:
+                self._eval_cache[cache_key] = result
+                if self.cache_mode == "disk":
+                    self._save_cache_entry(cache_key, result)
 
         return result
 
@@ -454,18 +480,40 @@ class OptimizeAnythingAdapter(GEPAAdapter):
                         miss_indices.append(idx)
 
         if miss_indices:
-            miss_pairs = [pairs[idx] for idx in miss_indices]
+            # With caching enabled, duplicate (candidate, example) pairs within
+            # one grouped call resolve to a single user-fn evaluation (the
+            # sequential path gets the same effect through per-pair cache hits).
+            if self.cache_mode != "off":
+                first_by_key: dict[tuple[str, str], int] = {}
+                unique_miss: list[int] = []
+                alias_of: dict[int, int] = {}
+                for idx in miss_indices:
+                    key = self._cache_key(*pairs[idx])
+                    if key in first_by_key:
+                        alias_of[idx] = first_by_key[key]
+                    else:
+                        first_by_key[key] = idx
+                        unique_miss.append(idx)
+            else:
+                unique_miss = list(miss_indices)
+                alias_of = {}
+
+            miss_pairs = [pairs[idx] for idx in unique_miss]
             miss_opt_states = [self._build_opt_state(example) for _, example in miss_pairs]
             miss_results = self._batch_evaluator(miss_pairs, opt_states=miss_opt_states)
-            for idx, res in zip(miss_indices, miss_results, strict=True):
+            for idx, res in zip(unique_miss, miss_results, strict=True):
                 results[idx] = res
-                if self.cache_mode != "off":
-                    score, side_info = res
+                score, side_info = res
+                # Transient whole-batch failures (see BatchEvaluatorWrapper)
+                # are never cached — they must be re-evaluated next time.
+                if self.cache_mode != "off" and not side_info.get("_gepa_transient_failure"):
                     cache_key = self._cache_key(*pairs[idx])
                     with self._eval_cache_lock:
                         self._eval_cache[cache_key] = (score, None, side_info)
                         if self.cache_mode == "disk":
                             self._save_cache_entry(cache_key, (score, None, side_info))
+            for idx, src in alias_of.items():
+                results[idx] = results[src]
 
         raw_by_item: dict[int, list[tuple[float, Any, SideInfo]]] = {}
         for res, item_idx in zip(results, pair_to_item_idx, strict=True):

--- a/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
+++ b/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
@@ -13,6 +13,7 @@ internal engine.  It handles:
 """
 
 import hashlib
+import inspect
 import json
 import logging
 import pickle
@@ -53,6 +54,89 @@ Return ONLY a valid JSON object with the improved parameters (no explanation, no
 """
 
 
+class BatchEvaluatorWrapper:
+    """Wraps a user ``batch_evaluator`` while preserving its single-external-call contract.
+
+    The whole point of ``batch_evaluator`` is that the user receives ALL
+    (candidate, example) pairs in ONE call (e.g. to submit a provider batch job
+    or fan out over their own cluster), so per-call features of the standard
+    evaluator path — ``oa.log()`` capture and stdout/stderr capture — cannot
+    apply here: there is no per-evaluation call to scope them to. Diagnostics
+    belong in each returned ``side_info``.
+
+    What IS restored for parity with the standard evaluator path:
+
+    - ``str_candidate_mode``: candidates are unwrapped to ``str`` before the
+      user function sees them (mirror of ``EvaluatorWrapper``).
+    - ``opt_states`` injection: if the function's signature accepts an
+      ``opt_states`` keyword (or ``**kwargs``), it receives a list of
+      :class:`OptimizationState` aligned with ``pairs`` — the batch analogue of
+      the per-call ``opt_state`` kwarg (warm-starting, #160).
+    - Exception policy: when ``raise_on_exception=False``, a raised batch call
+      is converted to per-pair ``(0.0, {"error": ...})`` results instead of
+      sinking the iteration.
+    - Result normalization: each per-pair result may be ``float``,
+      ``(score, side_info)`` (the mirror of the evaluator protocol), or a
+      legacy ``(score, output, side_info)`` 3-tuple; all normalize to
+      ``(score, side_info)``.
+    """
+
+    def __init__(
+        self,
+        batch_fn: Callable[..., Any],
+        *,
+        str_candidate_key: str | None = None,
+        raise_on_exception: bool = True,
+    ):
+        self._fn = batch_fn
+        self._str_candidate_key = str_candidate_key
+        self._raise_on_exception = raise_on_exception
+        sig = inspect.signature(batch_fn)
+        has_var_kw = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values())
+        self._accepts_opt_states = has_var_kw or "opt_states" in sig.parameters
+
+    def __call__(
+        self,
+        pairs: list[tuple["Candidate", Any]],
+        opt_states: "list[OptimizationState] | None" = None,
+    ) -> list[tuple[float, dict[str, Any]]]:
+        call_pairs: list[tuple[Any, Any]] = list(pairs)
+        if self._str_candidate_key is not None:
+            call_pairs = [(candidate[self._str_candidate_key], example) for candidate, example in pairs]
+
+        kwargs: dict[str, Any] = {}
+        if self._accepts_opt_states and opt_states is not None:
+            kwargs["opt_states"] = opt_states
+
+        try:
+            raw_results = list(self._fn(call_pairs, **kwargs))
+        except Exception as e:
+            if self._raise_on_exception:
+                raise
+            return [(0.0, {"error": str(e)}) for _ in pairs]
+
+        if len(raw_results) != len(pairs):
+            raise ValueError(f"batch_evaluator returned {len(raw_results)} results but expected {len(pairs)}")
+
+        normalized: list[tuple[float, dict[str, Any]]] = []
+        for r in raw_results:
+            if isinstance(r, list | tuple):
+                r_seq = list(r)
+                if len(r_seq) >= 3:
+                    # Legacy (score, output, side_info): the output slot is
+                    # ignored — the adapter packages outputs identically to the
+                    # sequential path as (score, candidate, side_info).
+                    si = r_seq[2] if isinstance(r_seq[2], dict) else {}
+                elif len(r_seq) == 2:
+                    si = r_seq[1] if isinstance(r_seq[1], dict) else {}
+                else:
+                    si = {}
+                normalized.append((float(r_seq[0]), si))
+            else:
+                normalized.append((float(r), {}))
+        return normalized
+
+
 class OptimizeAnythingAdapter(GEPAAdapter):
     """Adapter connecting the ``optimize_anything`` API to GEPA's engine.
 
@@ -76,6 +160,8 @@ class OptimizeAnythingAdapter(GEPAAdapter):
         batch_evaluator: Callable[..., Any] | None = None,
     ):
         self.evaluator = evaluator
+        if batch_evaluator is not None and not isinstance(batch_evaluator, BatchEvaluatorWrapper):
+            batch_evaluator = BatchEvaluatorWrapper(batch_evaluator)
         self._batch_evaluator = batch_evaluator
         self.parallel = parallel
         self.max_workers = max_workers
@@ -291,7 +377,16 @@ class OptimizeAnythingAdapter(GEPAAdapter):
         self,
         items: list[tuple["Candidate", list]],
     ) -> list[EvaluationBatch]:
-        """Flatten all (candidate, example) pairs, call batch_evaluator once, repackage."""
+        """Flatten all (candidate, example) pairs, call batch_evaluator once, repackage.
+
+        The (wrapped) batch_evaluator normalizes every per-pair result to
+        ``(score, side_info)``; packaging then goes through
+        :meth:`_assemble_no_refiner_batch` so the batch path produces byte-identical
+        EvaluationBatches to the sequential path: ``outputs`` are
+        ``(score, candidate, side_info)`` tuples, best-evals history is updated
+        (feeding ``OptimizationState.best_example_evals``), objective scores are
+        extracted, and metric calls are counted the same way.
+        """
         assert self._batch_evaluator is not None
 
         pairs: list[tuple[dict[str, str], Any]] = []
@@ -301,53 +396,17 @@ class OptimizeAnythingAdapter(GEPAAdapter):
                 pairs.append((candidate, example))
                 pair_to_item_idx.append(item_idx)
 
-        raw_results = self._batch_evaluator(pairs)
-        if len(raw_results) != len(pairs):
-            raise ValueError(f"batch_evaluator returned {len(raw_results)} results but expected {len(pairs)}")
+        opt_states = [self._build_opt_state(example) for _, example in pairs]
+        results = self._batch_evaluator(pairs, opt_states=opt_states)
 
-        # Normalize each result to (score, output, side_info)
-        normalized: list[tuple[float, Any, dict[str, Any]]] = []
-        for r in raw_results:
-            r_seq: list[Any] = list(r) if isinstance(r, list | tuple) else [r]
-            if len(r_seq) >= 3:
-                si = r_seq[2] if isinstance(r_seq[2], dict) else {}
-                normalized.append((float(r_seq[0]), r_seq[1], si))
-            elif len(r_seq) == 2:
-                si = r_seq[1] if isinstance(r_seq[1], dict) else {}
-                normalized.append((float(r_seq[0]), (r_seq[0], None, si), si))
-            else:
-                score = float(r_seq[0])
-                normalized.append((score, (score, None, {}), {}))
+        raw_by_item: dict[int, list[tuple[float, Any, SideInfo]]] = {}
+        for (score, side_info), item_idx in zip(results, pair_to_item_idx, strict=True):
+            raw_by_item.setdefault(item_idx, []).append((score, None, side_info))
 
-        # Group by item index and build EvaluationBatch per item
-        results_by_item: dict[int, list[tuple[float, Any, dict[str, Any]]]] = {}
-        for pair_idx, norm in enumerate(normalized):
-            item_idx = pair_to_item_idx[pair_idx]
-            results_by_item.setdefault(item_idx, []).append(norm)
-
-        eval_batches: list[EvaluationBatch] = []
-        for item_idx in range(len(items)):
-            candidate = items[item_idx][0]
-            item_results = results_by_item.get(item_idx, [])
-            scores = [s for s, _, _ in item_results]
-            outputs = [o for _, o, _ in item_results]
-            side_infos: list[dict[str, Any]] = [si for _, _, si in item_results]
-
-            objective_scores: list[dict[str, float]] = [
-                self._extract_objective_scores(candidate, si) for si in side_infos
-            ]
-
-            eval_batches.append(
-                EvaluationBatch(
-                    outputs=outputs,
-                    scores=scores,
-                    trajectories=side_infos,
-                    objective_scores=objective_scores,
-                    num_metric_calls=len(item_results),
-                )
-            )
-
-        return eval_batches
+        return [
+            self._assemble_no_refiner_batch(items[item_idx][0], items[item_idx][1], raw_by_item.get(item_idx, []))
+            for item_idx in range(len(items))
+        ]
 
     def _evaluate_with_refinement(
         self,

--- a/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
+++ b/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
@@ -230,60 +230,35 @@ class OptimizeAnythingAdapter(GEPAAdapter):
         Multi-objective scores from ``side_info["scores"]`` are extracted and
         forwarded as ``objective_scores`` in the returned batch.
         """
-        # Backward compatibility: if refiner_config is None, use old behavior
+        # No-refiner path: evaluate each example (optionally in parallel) and
+        # package. Factored into ``_assemble_no_refiner_batch`` so that
+        # ``batch_evaluate``'s parallel fallback can reuse the exact same
+        # packaging (best-evals update, objective-score extraction, counts).
         if self.refiner_config is None:
-            # Old path: direct evaluation without refinement
             if self.parallel and len(batch) > 1:
                 raw_results = self._evaluate_parallel(batch, candidate)
             else:
                 raw_results = [self._call_evaluator(candidate, example) for example in batch]
-            # Package outputs as (score, candidate, side_info) tuples
-            eval_output = []
-            for score, _, side_info in raw_results:
-                output = (score, candidate, side_info)  # Package as tuple
-                eval_output.append((score, output, side_info))
-        else:
-            # New path: evaluate with refinement
-            # eval_output is list of (score, output, side_info)
-            # where output = (score, best_candidate, side_info)
-            eval_output = self._evaluate_with_refinement(batch, candidate)
+            return self._assemble_no_refiner_batch(candidate, batch, raw_results)
 
-        # Update best evals history for each example
-        # (skip when refiner is on — refiner path already records evals internally)
-        if self.refiner_config is None:
-            for example, (score, _, side_info) in zip(batch, eval_output, strict=True):
-                self._update_best_example_evals(example, score, side_info)
+        # Refiner path: evaluate with refinement. eval_output is a list of
+        # (score, output, side_info) where output = (score, best_candidate, side_info).
+        eval_output = self._evaluate_with_refinement(batch, candidate)
 
         scores = [score for score, _, _ in eval_output]
         side_infos: list[SideInfo] = [info for _, _, info in eval_output]
         # outputs = list of (score, best_candidate, side_info) tuples
         outputs = [out for _, out, _ in eval_output]
+        objective_scores = [self._extract_objective_scores(candidate, si) for si in side_infos]
 
-        objective_scores = []
-        for side_info in side_infos:
-            objective_score = {}
-            if "scores" in side_info:
-                objective_score.update(side_info["scores"])
-
-            for param_name in candidate.keys():
-                if param_name + "_specific_info" in side_info and "scores" in side_info[param_name + "_specific_info"]:
-                    objective_score.update(
-                        {f"{param_name}::{k}": v for k, v in side_info[param_name + "_specific_info"]["scores"].items()}
-                    )
-
-            objective_scores.append(objective_score)
-
-        # Count actual evaluator invocations.
-        # Without refinement: 1 call per example. With refinement: count from
-        # the attempt history already recorded in each side_info.
-        num_metric_calls = len(batch)
-        if self.refiner_config is not None:
-            num_metric_calls = 0
-            for si in side_infos:
-                rp_info = si.get("refiner_prompt_specific_info", {})
-                attempts = rp_info.get("Attempts", [])
-                # Each attempt with "side_info" represents an actual evaluator call
-                num_metric_calls += sum(1 for a in attempts if "side_info" in a)
+        # Count actual evaluator invocations from the attempt history recorded
+        # in each side_info (the refiner path may call the evaluator multiple
+        # times per example).
+        num_metric_calls = 0
+        for si in side_infos:
+            rp_info = si.get("refiner_prompt_specific_info", {})
+            attempts = rp_info.get("Attempts", [])
+            num_metric_calls += sum(1 for a in attempts if "side_info" in a)
 
         return EvaluationBatch(
             outputs=outputs,
@@ -301,11 +276,15 @@ class OptimizeAnythingAdapter(GEPAAdapter):
 
         When a ``batch_evaluator`` was provided at construction time, all
         (candidate, example) pairs are flattened into a single call to the
-        user's batch function.  Otherwise falls back to sequential
-        ``evaluate()`` calls.  Always captures traces.
+        user's batch function.
+
+        Falls back to sequential ``evaluate()`` calls for the refiner path or a
+        single item. Always captures traces.
         """
         if self._batch_evaluator is not None:
             return self._batch_evaluate_via_user_fn(items)
+        if self.parallel and self.refiner_config is None and len(items) > 1:
+            return self._batch_evaluate_parallel_fallback(items)
         return [self.evaluate(batch, candidate, capture_traces=True) for candidate, batch in items]
 
     def _batch_evaluate_via_user_fn(
@@ -464,6 +443,97 @@ class OptimizeAnythingAdapter(GEPAAdapter):
 
         results.sort(key=lambda x: x[0])
         return [result for _, result in results]
+
+    def _run_parallel_pairs(
+        self,
+        pairs: list[tuple["Candidate", Any]],
+    ) -> list[tuple[float, Any, "SideInfo"]]:
+        """Evaluate ``(candidate, example)`` pairs concurrently, preserving input order.
+
+        Unlike :meth:`_run_parallel` (one candidate, many examples), this fans
+        out over pairs whose candidate may differ, so a single thread pool is
+        shared across all candidates in a ``batch_evaluate`` call.
+        """
+        results: list[tuple[int, tuple[float, Any, SideInfo]]] = []
+        with ThreadPoolExecutor(max_workers=self.max_workers or len(pairs)) as executor:
+            future_to_idx = {
+                executor.submit(self._call_evaluator, candidate, example): idx
+                for idx, (candidate, example) in enumerate(pairs)
+            }
+            for future in as_completed(future_to_idx):
+                idx = future_to_idx[future]
+                results.append((idx, future.result()))
+        results.sort(key=lambda x: x[0])
+        return [result for _, result in results]
+
+    def _batch_evaluate_parallel_fallback(
+        self,
+        items: list[tuple["Candidate", list]],
+    ) -> list[EvaluationBatch]:
+        """Fan all ``(candidate, example)`` pairs out across one thread pool, regroup per item.
+
+        No-refiner path only. Saturates ``max_workers`` across candidates and
+        examples, then repackages each item via :meth:`_assemble_no_refiner_batch`
+        so results are identical to per-item ``evaluate()`` calls.
+        """
+        pairs: list[tuple[Candidate, Any]] = []
+        pair_to_item_idx: list[int] = []
+        for item_idx, (candidate, batch) in enumerate(items):
+            for example in batch:
+                pairs.append((candidate, example))
+                pair_to_item_idx.append(item_idx)
+
+        raw_by_pair = self._run_parallel_pairs(pairs) if pairs else []
+
+        raw_per_item: list[list[tuple[float, Any, SideInfo]]] = [[] for _ in items]
+        for pair_idx, raw in enumerate(raw_by_pair):
+            raw_per_item[pair_to_item_idx[pair_idx]].append(raw)
+
+        return [
+            self._assemble_no_refiner_batch(candidate, batch, raw_per_item[item_idx])
+            for item_idx, (candidate, batch) in enumerate(items)
+        ]
+
+    def _extract_objective_scores(self, candidate: "Candidate", side_info: "SideInfo") -> dict[str, float]:
+        """Pull per-objective scores out of a side_info dict (top-level + per-param)."""
+        objective_score: dict[str, float] = {}
+        if "scores" in side_info:
+            objective_score.update(side_info["scores"])
+        for param_name in candidate.keys():
+            specific = side_info.get(param_name + "_specific_info") if isinstance(side_info, dict) else None
+            if isinstance(specific, dict) and "scores" in specific:
+                objective_score.update({f"{param_name}::{k}": v for k, v in specific["scores"].items()})
+        return objective_score
+
+    def _assemble_no_refiner_batch(
+        self,
+        candidate: "Candidate",
+        batch: list[DataInst],
+        raw_results: list[tuple[float, Any, "SideInfo"]],
+    ) -> EvaluationBatch:
+        """Package raw ``(score, _, side_info)`` evaluator results into an EvaluationBatch.
+
+        Shared by :meth:`evaluate` (no-refiner path) and
+        :meth:`_batch_evaluate_parallel_fallback` so both produce identical
+        output, update best-evals history, and count metric calls the same way.
+        """
+        # Package outputs as (score, candidate, side_info) tuples.
+        eval_output = [(score, (score, candidate, side_info), side_info) for score, _, side_info in raw_results]
+        for example, (score, _, side_info) in zip(batch, eval_output, strict=True):
+            self._update_best_example_evals(example, score, side_info)
+
+        scores = [score for score, _, _ in eval_output]
+        side_infos: list[SideInfo] = [info for _, _, info in eval_output]
+        outputs = [out for _, out, _ in eval_output]
+        objective_scores = [self._extract_objective_scores(candidate, si) for si in side_infos]
+
+        return EvaluationBatch(
+            outputs=outputs,
+            scores=scores,
+            trajectories=side_infos,
+            objective_scores=objective_scores,
+            num_metric_calls=len(batch),
+        )
 
     def _evaluate_parallel(self, batch, candidate):
         """Evaluate batch in parallel (no refinement)."""

--- a/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
+++ b/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
@@ -146,7 +146,7 @@ class OptimizeAnythingAdapter(GEPAAdapter):
 
     def __init__(
         self,
-        evaluator: Callable[..., tuple[float, Any, dict[str, Any]]],
+        evaluator: Callable[..., tuple[float, Any, dict[str, Any]]] | None = None,
         reflection_lm: LanguageModel | None = None,
         reflection_prompt_template: str | None = None,
         parallel: bool = True,
@@ -159,6 +159,8 @@ class OptimizeAnythingAdapter(GEPAAdapter):
         cache_dir: str | Path | None = None,
         batch_evaluator: Callable[..., Any] | None = None,
     ):
+        if evaluator is None and batch_evaluator is None:
+            raise ValueError("Provide evaluator=, batch_evaluator=, or both.")
         self.evaluator = evaluator
         if batch_evaluator is not None and not isinstance(batch_evaluator, BatchEvaluatorWrapper):
             batch_evaluator = BatchEvaluatorWrapper(batch_evaluator)
@@ -266,6 +268,27 @@ class OptimizeAnythingAdapter(GEPAAdapter):
 
         return OptimizationState(best_example_evals=self._get_best_example_evals(example))
 
+    def _resolve_pair(self, candidate: "Candidate", example: Any) -> tuple[float, Any, dict]:
+        """Resolve ONE (candidate, example) pair, whichever evaluation transport exists.
+
+        Uses the single-pair evaluator when provided; otherwise routes a
+        singleton batch through ``batch_evaluator``. This is the seam that
+        makes the refiner (and any other per-pair resolution) work identically
+        with or without a single-pair evaluator — including shared caching,
+        since :meth:`_call_evaluator`'s cache wraps this method on both paths.
+        """
+        if self.evaluator is not None:
+            return self.evaluator(
+                candidate,
+                example=example,
+                opt_state=self._build_opt_state(example),
+            )
+        assert self._batch_evaluator is not None
+        ((score, side_info),) = self._batch_evaluator(
+            [(candidate, example)], opt_states=[self._build_opt_state(example)]
+        )
+        return score, None, side_info
+
     def _call_evaluator(
         self,
         candidate: "Candidate",
@@ -274,11 +297,7 @@ class OptimizeAnythingAdapter(GEPAAdapter):
         """Call evaluator with optional caching."""
         # No caching
         if self.cache_mode == "off":
-            return self.evaluator(
-                candidate,
-                example=example,
-                opt_state=self._build_opt_state(example),
-            )
+            return self._resolve_pair(candidate, example)
 
         # Build cache key
         cache_key = self._cache_key(candidate, example)
@@ -289,11 +308,7 @@ class OptimizeAnythingAdapter(GEPAAdapter):
                 return self._eval_cache[cache_key]
 
         # Cache miss - call evaluator
-        result = self.evaluator(
-            candidate,
-            example=example,
-            opt_state=self._build_opt_state(example),
-        )
+        result = self._resolve_pair(candidate, example)
 
         # Store in cache (thread-safe)
         with self._eval_cache_lock:
@@ -321,6 +336,11 @@ class OptimizeAnythingAdapter(GEPAAdapter):
         # ``batch_evaluate``'s parallel fallback can reuse the exact same
         # packaging (best-evals update, objective-score extraction, counts).
         if self.refiner_config is None:
+            if self._batch_evaluator is not None:
+                # batch_evaluator is the preferred transport for any multi-pair
+                # evaluation (valset evals, merge evals, seed evals) — one
+                # external call for the whole batch, cache-aware.
+                return self._batch_evaluate_via_user_fn([(candidate, batch)])[0]
             if self.parallel and len(batch) > 1:
                 raw_results = self._evaluate_parallel(batch, candidate)
             else:
@@ -396,8 +416,36 @@ class OptimizeAnythingAdapter(GEPAAdapter):
                 pairs.append((candidate, example))
                 pair_to_item_idx.append(item_idx)
 
-        opt_states = [self._build_opt_state(example) for _, example in pairs]
-        results = self._batch_evaluator(pairs, opt_states=opt_states)
+        # Cache layer: identical key/value format to _call_evaluator, so
+        # entries are shared across the batch path, the sequential path, and
+        # the refiner's singleton resolutions. Only misses reach the user's
+        # function — still as ONE call.
+        results: list[tuple[float, dict[str, Any]] | None] = [None] * len(pairs)
+        miss_indices = list(range(len(pairs)))
+        if self.cache_mode != "off":
+            miss_indices = []
+            with self._eval_cache_lock:
+                for idx, (cand, example) in enumerate(pairs):
+                    cached = self._eval_cache.get(self._cache_key(cand, example))
+                    if cached is not None:
+                        score, _output, side_info = cached
+                        results[idx] = (score, side_info)
+                    else:
+                        miss_indices.append(idx)
+
+        if miss_indices:
+            miss_pairs = [pairs[idx] for idx in miss_indices]
+            miss_opt_states = [self._build_opt_state(example) for _, example in miss_pairs]
+            miss_results = self._batch_evaluator(miss_pairs, opt_states=miss_opt_states)
+            for idx, res in zip(miss_indices, miss_results, strict=True):
+                results[idx] = res
+                if self.cache_mode != "off":
+                    score, side_info = res
+                    cache_key = self._cache_key(*pairs[idx])
+                    with self._eval_cache_lock:
+                        self._eval_cache[cache_key] = (score, None, side_info)
+                        if self.cache_mode == "disk":
+                            self._save_cache_entry(cache_key, (score, None, side_info))
 
         raw_by_item: dict[int, list[tuple[float, Any, SideInfo]]] = {}
         for (score, side_info), item_idx in zip(results, pair_to_item_idx, strict=True):

--- a/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
+++ b/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
@@ -300,6 +300,9 @@ class OptimizeAnythingAdapter(GEPAAdapter):
         ((score, side_info),) = self._batch_evaluator(
             [(candidate, example)], opt_states=[self._build_opt_state(example)]
         )
+        # Slot 1 is the "output" placeholder, mirroring EvaluatorWrapper's
+        # (score, None, side_info) contract; downstream packaging rebuilds it
+        # from the candidate (_assemble_no_refiner_batch / refiner path).
         return score, None, side_info
 
     def _call_evaluator(
@@ -393,14 +396,18 @@ class OptimizeAnythingAdapter(GEPAAdapter):
     ) -> list[EvaluationBatch]:
         """Evaluate multiple (candidate, batch) pairs.
 
-        When a ``batch_evaluator`` was provided at construction time, all
-        (candidate, example) pairs are flattened into a single call to the
-        user's batch function.
+        When a ``batch_evaluator`` was provided at construction time (and no
+        refiner is configured), all (candidate, example) pairs are flattened
+        into a single call to the user's batch function.
 
         Falls back to sequential ``evaluate()`` calls for the refiner path or a
-        single item. Always captures traces.
+        single item. Always captures traces. With ``refiner_config`` set,
+        evaluation is per-example by construction (each example runs its own
+        evaluate->refine->re-evaluate loop), so grouped calls degrade to
+        singleton batches through ``_resolve_pair`` — refinement is never
+        silently skipped.
         """
-        if self._batch_evaluator is not None:
+        if self._batch_evaluator is not None and self.refiner_config is None:
             return self._batch_evaluate_via_user_fn(items)
         if self.parallel and self.refiner_config is None and len(items) > 1:
             return self._batch_evaluate_parallel_fallback(items)

--- a/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
+++ b/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
@@ -461,7 +461,9 @@ class OptimizeAnythingAdapter(GEPAAdapter):
                             self._save_cache_entry(cache_key, (score, None, side_info))
 
         raw_by_item: dict[int, list[tuple[float, Any, SideInfo]]] = {}
-        for (score, side_info), item_idx in zip(results, pair_to_item_idx, strict=True):
+        for res, item_idx in zip(results, pair_to_item_idx, strict=True):
+            assert res is not None, "unresolved evaluation pair (cache/miss bookkeeping bug)"
+            score, side_info = res
             raw_by_item.setdefault(item_idx, []).append((score, None, side_info))
 
         return [

--- a/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
+++ b/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
@@ -327,17 +327,15 @@ class OptimizeAnythingAdapter(GEPAAdapter):
 
         eval_batches: list[EvaluationBatch] = []
         for item_idx in range(len(items)):
+            candidate = items[item_idx][0]
             item_results = results_by_item.get(item_idx, [])
             scores = [s for s, _, _ in item_results]
             outputs = [o for _, o, _ in item_results]
             side_infos: list[dict[str, Any]] = [si for _, _, si in item_results]
 
-            objective_scores: list[dict[str, float]] = []
-            for si in side_infos:
-                obj: dict[str, float] = {}
-                if isinstance(si, dict) and "scores" in si:
-                    obj.update(si["scores"])
-                objective_scores.append(obj)
+            objective_scores: list[dict[str, float]] = [
+                self._extract_objective_scores(candidate, si) for si in side_infos
+            ]
 
             eval_batches.append(
                 EvaluationBatch(

--- a/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
+++ b/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
@@ -73,8 +73,10 @@ class OptimizeAnythingAdapter(GEPAAdapter):
         background: str | None = None,
         cache_mode: str = "memory",  # "off", "memory", "disk"
         cache_dir: str | Path | None = None,
+        batch_evaluator: Callable[..., Any] | None = None,
     ):
         self.evaluator = evaluator
+        self._batch_evaluator = batch_evaluator
         self.parallel = parallel
         self.max_workers = max_workers
         self.refiner_config = refiner_config
@@ -290,6 +292,85 @@ class OptimizeAnythingAdapter(GEPAAdapter):
             objective_scores=objective_scores,
             num_metric_calls=num_metric_calls,
         )
+
+    def batch_evaluate(
+        self,
+        items: list[tuple["Candidate", list]],
+    ) -> list[EvaluationBatch]:
+        """Evaluate multiple (candidate, batch) pairs.
+
+        When a ``batch_evaluator`` was provided at construction time, all
+        (candidate, example) pairs are flattened into a single call to the
+        user's batch function.  Otherwise falls back to sequential
+        ``evaluate()`` calls.  Always captures traces.
+        """
+        if self._batch_evaluator is not None:
+            return self._batch_evaluate_via_user_fn(items)
+        return [self.evaluate(batch, candidate, capture_traces=True) for candidate, batch in items]
+
+    def _batch_evaluate_via_user_fn(
+        self,
+        items: list[tuple["Candidate", list]],
+    ) -> list[EvaluationBatch]:
+        """Flatten all (candidate, example) pairs, call batch_evaluator once, repackage."""
+        assert self._batch_evaluator is not None
+
+        pairs: list[tuple[dict[str, str], Any]] = []
+        pair_to_item_idx: list[int] = []
+        for item_idx, (candidate, batch) in enumerate(items):
+            for example in batch:
+                pairs.append((candidate, example))
+                pair_to_item_idx.append(item_idx)
+
+        raw_results = self._batch_evaluator(pairs)
+        if len(raw_results) != len(pairs):
+            raise ValueError(f"batch_evaluator returned {len(raw_results)} results but expected {len(pairs)}")
+
+        # Normalize each result to (score, output, side_info)
+        normalized: list[tuple[float, Any, dict[str, Any]]] = []
+        for r in raw_results:
+            r_seq: list[Any] = list(r) if isinstance(r, list | tuple) else [r]
+            if len(r_seq) >= 3:
+                si = r_seq[2] if isinstance(r_seq[2], dict) else {}
+                normalized.append((float(r_seq[0]), r_seq[1], si))
+            elif len(r_seq) == 2:
+                si = r_seq[1] if isinstance(r_seq[1], dict) else {}
+                normalized.append((float(r_seq[0]), (r_seq[0], None, si), si))
+            else:
+                score = float(r_seq[0])
+                normalized.append((score, (score, None, {}), {}))
+
+        # Group by item index and build EvaluationBatch per item
+        results_by_item: dict[int, list[tuple[float, Any, dict[str, Any]]]] = {}
+        for pair_idx, norm in enumerate(normalized):
+            item_idx = pair_to_item_idx[pair_idx]
+            results_by_item.setdefault(item_idx, []).append(norm)
+
+        eval_batches: list[EvaluationBatch] = []
+        for item_idx in range(len(items)):
+            item_results = results_by_item.get(item_idx, [])
+            scores = [s for s, _, _ in item_results]
+            outputs = [o for _, o, _ in item_results]
+            side_infos: list[dict[str, Any]] = [si for _, _, si in item_results]
+
+            objective_scores: list[dict[str, float]] = []
+            for si in side_infos:
+                obj: dict[str, float] = {}
+                if isinstance(si, dict) and "scores" in si:
+                    obj.update(si["scores"])
+                objective_scores.append(obj)
+
+            eval_batches.append(
+                EvaluationBatch(
+                    outputs=outputs,
+                    scores=scores,
+                    trajectories=side_infos,
+                    objective_scores=objective_scores,
+                    num_metric_calls=len(item_results),
+                )
+            )
+
+        return eval_batches
 
     def _evaluate_with_refinement(
         self,

--- a/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
+++ b/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
@@ -79,6 +79,12 @@ class BatchEvaluatorWrapper:
       ``(score, side_info)`` (the mirror of the evaluator protocol), or a
       legacy ``(score, output, side_info)`` 3-tuple; all normalize to
       ``(score, side_info)``.
+
+    Concurrency: grouped evaluations arrive as one call at a time, but when
+    ``refiner_config`` is combined with ``parallel=True`` (and no single-pair
+    evaluator exists), per-example refinement loops run on a thread pool and
+    may call this wrapper concurrently with singleton batches — the wrapped
+    function should be thread-safe in that configuration.
     """
 
     def __init__(
@@ -165,6 +171,13 @@ class OptimizeAnythingAdapter(GEPAAdapter):
         if batch_evaluator is not None and not isinstance(batch_evaluator, BatchEvaluatorWrapper):
             batch_evaluator = BatchEvaluatorWrapper(batch_evaluator)
         self._batch_evaluator = batch_evaluator
+        if batch_evaluator is not None and parallel:
+            logger.info(
+                "batch_evaluator provided: grouped evaluations route through it, so the "
+                "parallel=True thread pool is not used as their transport. If refiner_config "
+                "is set, refinement loops still run on the thread pool and may invoke "
+                "batch_evaluator concurrently with singleton batches — ensure it is thread-safe."
+            )
         self.parallel = parallel
         self.max_workers = max_workers
         self.refiner_config = refiner_config

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -93,6 +93,9 @@ def optimize(
     val_evaluation_policy: EvaluationPolicy[DataId, DataInst] | Literal["full_eval"] | None = None,
     acceptance_criterion: AcceptanceCriterion
     | Literal["strict_improvement", "improvement_or_equal"] = "strict_improvement",
+    # Proposal strategies (default: 1 parent, 1 mutation per iteration)
+    sampling_strategy: Any | None = None,
+    selection_strategy: Any | None = None,
 ) -> GEPAResult[RolloutOutput, DataId]:
     """
     GEPA is an evolutionary optimizer that evolves (multiple) text components of a complex system to optimize them towards a given metric.
@@ -389,6 +392,9 @@ def optimize(
         reflection_prompt_template=reflection_prompt_template,
         custom_candidate_proposer=custom_candidate_proposer,
         callbacks=callbacks,
+        acceptance_criterion=acceptance_criterion_instance,
+        sampling_strategy=sampling_strategy,
+        selection_strategy=selection_strategy,
     )
 
     def evaluator_fn(

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -37,6 +37,8 @@ from gepa.strategies.component_selector import (
     RoundRobinReflectionComponentSelector,
 )
 from gepa.strategies.eval_policy import EvaluationPolicy, FullEvaluationPolicy
+from gepa.strategies.proposal_sampling import SamplingStrategy
+from gepa.strategies.proposal_selection import SelectionStrategy
 from gepa.utils import FileStopper, StopperProtocol
 
 
@@ -94,8 +96,8 @@ def optimize(
     acceptance_criterion: AcceptanceCriterion
     | Literal["strict_improvement", "improvement_or_equal"] = "strict_improvement",
     # Proposal strategies (default: 1 parent, 1 mutation per iteration)
-    sampling_strategy: Any | None = None,
-    selection_strategy: Any | None = None,
+    sampling_strategy: SamplingStrategy | None = None,
+    selection_strategy: SelectionStrategy | None = None,
 ) -> GEPAResult[RolloutOutput, DataId]:
     """
     GEPA is an evolutionary optimizer that evolves (multiple) text components of a complex system to optimize them towards a given metric.

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -229,10 +229,11 @@ def optimize(
         )
 
     if not adapter_has_propose and custom_candidate_proposer is None:
-        assert reflection_lm is not None, (
+        assert reflection_lm is not None or reflection_strategy is not None, (
             f"reflection_lm was not provided. The adapter used '{active_adapter!s}' does not provide a propose_new_texts method, "
             + "and custom_candidate_proposer was not provided. "
-            + "GEPA will use the default proposer, which requires a reflection_lm to be specified."
+            + "GEPA will use the default proposer, which requires a reflection_lm (or a "
+            + "reflection_strategy) to be specified."
         )
 
     # Resolve reflection LM before building stoppers so cost stopper can reference it
@@ -267,7 +268,18 @@ def optimize(
     if max_reflection_cost is not None:
         from gepa.utils import MaxReflectionCostStopper
 
-        stop_callbacks_list.append(MaxReflectionCostStopper(max_reflection_cost, reflection_lm=reflection_lm_callable))
+        if reflection_strategy is not None:
+            if not hasattr(reflection_strategy, "total_cost"):
+                raise ValueError(
+                    "max_reflection_cost is set but reflection_strategy does not expose total_cost — "
+                    "the cost stopper would silently never fire (unbounded reflection spend). Expose a "
+                    "total_cost property on the strategy, or remove max_reflection_cost."
+                )
+            stop_callbacks_list.append(MaxReflectionCostStopper(max_reflection_cost, reflection_lm=reflection_strategy))
+        else:
+            stop_callbacks_list.append(
+                MaxReflectionCostStopper(max_reflection_cost, reflection_lm=reflection_lm_callable)
+            )
 
     if not stop_callbacks_list:
         raise ValueError(

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -23,6 +23,7 @@ from gepa.logging.experiment_tracker import create_experiment_tracker
 from gepa.logging.logger import Logger, LoggerProtocol, StdOutLogger
 from gepa.proposer.merge import MergeProposer
 from gepa.proposer.reflective_mutation.base import CandidateSelector, LanguageModel, ReflectionComponentSelector
+from gepa.proposer.reflective_mutation.reflection_lm import ReflectionLM
 from gepa.proposer.reflective_mutation.reflective_mutation import ReflectiveMutationProposer
 from gepa.strategies.acceptance import AcceptanceCriterion, ImprovementOrEqualAcceptance, StrictImprovementAcceptance
 from gepa.strategies.batch_sampler import BatchSampler, EpochShuffledBatchSampler
@@ -98,6 +99,7 @@ def optimize(
     # Proposal strategies (default: 1 parent, 1 mutation per iteration)
     sampling_strategy: SamplingStrategy | None = None,
     selection_strategy: SelectionStrategy | None = None,
+    reflection_strategy: ReflectionLM | None = None,
 ) -> GEPAResult[RolloutOutput, DataId]:
     """
     GEPA is an evolutionary optimizer that evolves (multiple) text components of a complex system to optimize them towards a given metric.
@@ -144,6 +146,9 @@ def optimize(
 
     # Reflection-based configuration
     - reflection_lm: A `LanguageModel` instance that is used to reflect on the performance of the candidate program.
+    - sampling_strategy: Controls how many (parent, minibatch) proposal tasks are sampled per iteration. One of `SingleMutationSampling` (default; 1 parent, 1 mutation — identical to classic GEPA), `SameParentSampling(n)`, `IndependentSampling(n)`, or `PxNSampling(p, n)`, or any custom `SamplingStrategy`.
+    - selection_strategy: Controls which of an iteration's improving proposals enter the candidate pool. One of `AllImprovements` (default), `BestImprovement`, or `TopKImprovements(k)`, or any custom `SelectionStrategy`.
+    - reflection_strategy: Advanced: a `ReflectionLM` implementation that owns how reflective mutation calls the reflection model (e.g. stateful sessions or aggregating reflectors). Defaults to the stateless single-call reflector built from `reflection_lm`. Implementations may provide `reflect_many` for batched reflection; otherwise `reflect` is called once per task.
     - candidate_selection_strategy: The strategy to use for selecting the candidate to update. Supported strategies: 'pareto', 'current_best', 'epsilon_greedy'. Defaults to 'pareto'.
     - frontier_type: Strategy for tracking Pareto frontiers. 'instance' tracks per validation example, 'objective' tracks per objective metric, 'hybrid' combines both, 'cartesian' tracks per (example, objective) pair. Defaults to 'instance'.
     - skip_perfect_score: Whether to skip updating the candidate if it achieves a perfect score on the minibatch.
@@ -395,6 +400,7 @@ def optimize(
         custom_candidate_proposer=custom_candidate_proposer,
         callbacks=callbacks,
         sampling_strategy=sampling_strategy,
+        reflection_strategy=reflection_strategy,
     )
 
     def evaluator_fn(

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -394,9 +394,7 @@ def optimize(
         reflection_prompt_template=reflection_prompt_template,
         custom_candidate_proposer=custom_candidate_proposer,
         callbacks=callbacks,
-        acceptance_criterion=acceptance_criterion_instance,
         sampling_strategy=sampling_strategy,
-        selection_strategy=selection_strategy,
     )
 
     def evaluator_fn(
@@ -437,6 +435,7 @@ def optimize(
         stop_callback=stop_callback,
         val_evaluation_policy=val_evaluation_policy,
         acceptance_criterion=acceptance_criterion_instance,
+        selection_strategy=selection_strategy,
         use_cloudpickle=use_cloudpickle,
         evaluation_cache=evaluation_cache,
     )

--- a/src/gepa/core/adapter.py
+++ b/src/gepa/core/adapter.py
@@ -35,6 +35,15 @@ class EvaluationBatch(Generic[Trajectory, RolloutOutput]):
     num_metric_calls: int | None = None
 
 
+class BatchEvaluateFn(Protocol):
+    """Protocol for batch evaluation of multiple (candidate, batch) pairs."""
+
+    def __call__(
+        self,
+        items: list[tuple[Candidate, list]],
+    ) -> list["EvaluationBatch"]: ...
+
+
 class ProposalFn(Protocol):
     def __call__(
         self,
@@ -193,3 +202,26 @@ class GEPAAdapter(Protocol[DataInst, Trajectory, RolloutOutput]):
         ...
 
     propose_new_texts: ProposalFn | None = None
+
+    # Optional: adapters can implement batch_evaluate to evaluate multiple
+    # (candidate, batch) pairs in a single call.  When not present, the
+    # proposer falls back to default_batch_evaluate() which calls evaluate()
+    # sequentially.  Unlike evaluate(), batch_evaluate always returns full
+    # results including trajectories.
+    #
+    # def batch_evaluate(
+    #     self, items: list[tuple[Candidate, list[DataInst]]],
+    # ) -> list[EvaluationBatch[Trajectory, RolloutOutput]]: ...
+
+
+def default_batch_evaluate(
+    adapter: GEPAAdapter,
+    items: list[tuple[Candidate, list]],
+) -> list[EvaluationBatch]:
+    """Default sequential batch_evaluate fallback.
+
+    Calls ``adapter.evaluate()`` once per (candidate, batch) pair with
+    ``capture_traces=True``.  Adapters can implement ``batch_evaluate``
+    directly for true batching or parallelism.
+    """
+    return [adapter.evaluate(batch, candidate, capture_traces=True) for candidate, batch in items]

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -6,7 +6,14 @@ import traceback
 from collections.abc import Sequence
 from typing import Any, Generic
 
-from gepa.core.adapter import DataInst, GEPAAdapter, RolloutOutput, Trajectory
+from gepa.core.adapter import (
+    DataInst,
+    EvaluationBatch,
+    GEPAAdapter,
+    RolloutOutput,
+    Trajectory,
+    default_batch_evaluate,
+)
 from gepa.core.callbacks import (
     BudgetUpdatedEvent,
     CandidateAcceptedEvent,
@@ -144,26 +151,85 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         if setter is not None:
             setter(state.adapter_state)
 
-    def _evaluate_on_valset(
+    def _evaluate_programs_on_valset(
         self,
-        program: dict[str, str],
+        programs: list[dict[str, str]],
         state: GEPAState[RolloutOutput, DataId],
-    ) -> ValsetEvaluation[RolloutOutput, DataId]:
+    ) -> list[tuple[ValsetEvaluation[RolloutOutput, DataId], int]]:
+        """Evaluate candidates on the valset, read-only, via ``adapter.batch_evaluate``.
+
+        Cache-miss examples across all candidates go out in one batched call, so
+        parallelism (if any) is the adapter's. Honors the eval cache and
+        ``val_evaluation_policy``. Returns each evaluation with its metric-call
+        count (cache misses); the budget is incremented later in
+        :meth:`_add_evaluated_program`, not here.
+        """
         valset = self.valset
         assert valset is not None
+        cache = state.evaluation_cache
 
-        val_ids = self.val_evaluation_policy.get_eval_batch(valset, state)
+        # 1) Per program: split the requested val examples into cached vs. to-evaluate.
+        cached_per: list[dict[Any, Any]] = []
+        todo_per: list[list[Any]] = []
+        for program in programs:
+            val_ids = list(self.val_evaluation_policy.get_eval_batch(valset, state))
+            if cache is not None:
+                cached, uncached = cache.get_batch(program, val_ids)
+            else:
+                cached, uncached = {}, val_ids
+            cached_per.append(cached)
+            todo_per.append(uncached)
 
-        outputs_by_val_idx, scores_by_val_idx, objective_by_val_idx, num_actual_evals = state.cached_evaluate_full(
-            program, list(val_ids), valset.fetch, self.evaluator
-        )
-        state.increment_evals(num_actual_evals)
+        # 2) One adapter call over every (program, cache-miss examples) pair.
+        eval_idxs = [i for i, todo in enumerate(todo_per) if todo]
+        items = [(programs[i], valset.fetch(todo_per[i])) for i in eval_idxs]
+        fresh = self._batch_evaluate(items) if items else []
+        fresh_by_idx = dict(zip(eval_idxs, fresh, strict=True))
 
-        return ValsetEvaluation(
-            outputs_by_val_id=outputs_by_val_idx,
-            scores_by_val_id=scores_by_val_idx,
-            objective_scores_by_val_id=objective_by_val_idx,
-        )
+        # 3) Merge cached + fresh per program, repopulating the cache.
+        results: list[tuple[ValsetEvaluation[RolloutOutput, DataId], int]] = []
+        for i, program in enumerate(programs):
+            outputs_by: dict[Any, Any] = {}
+            scores_by: dict[Any, float] = {}
+            objective_by: dict[Any, Any] | None = None
+            for eid, entry in cached_per[i].items():
+                outputs_by[eid] = entry.output
+                scores_by[eid] = entry.score
+                if entry.objective_scores is not None:
+                    objective_by = objective_by or {}
+                    objective_by[eid] = entry.objective_scores
+
+            uncached = todo_per[i]
+            if uncached:
+                eb = fresh_by_idx[i]
+                obj = list(eb.objective_scores) if eb.objective_scores else None
+                for j, eid in enumerate(uncached):
+                    outputs_by[eid] = eb.outputs[j]
+                    scores_by[eid] = eb.scores[j]
+                    if obj is not None:
+                        objective_by = objective_by or {}
+                        objective_by[eid] = obj[j]
+                if cache is not None:
+                    cache.put_batch(program, uncached, eb.outputs, eb.scores, obj)
+
+            results.append(
+                (
+                    ValsetEvaluation(
+                        outputs_by_val_id=outputs_by,
+                        scores_by_val_id=scores_by,
+                        objective_scores_by_val_id=objective_by,
+                    ),
+                    len(uncached),
+                )
+            )
+        return results
+
+    def _batch_evaluate(self, items: list[tuple[dict[str, str], list]]) -> list[EvaluationBatch]:
+        """Evaluate (candidate, batch) pairs via the adapter's batch_evaluate or fallback."""
+        batch_fn = getattr(self.adapter, "batch_evaluate", None)
+        if batch_fn is not None:
+            return batch_fn(items)
+        return default_batch_evaluate(self.adapter, items)
 
     def _run_full_eval_and_add(
         self,
@@ -171,8 +237,25 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         state: GEPAState[RolloutOutput, DataId],
         parent_program_idx: list[int],
     ) -> tuple[int, int]:
+        valset_evaluation, num_actual_evals = self._evaluate_programs_on_valset([new_program], state)[0]
+        return self._add_evaluated_program(new_program, state, parent_program_idx, valset_evaluation, num_actual_evals)
+
+    def _add_evaluated_program(
+        self,
+        new_program: dict[str, str],
+        state: GEPAState[RolloutOutput, DataId],
+        parent_program_idx: list[int],
+        valset_evaluation: ValsetEvaluation[RolloutOutput, DataId],
+        num_actual_evals: int,
+    ) -> tuple[int, int]:
+        """Add an already-evaluated candidate to the pool. Must run sequentially.
+
+        Snapshots the discovery budget before incrementing so candidates,
+        processed in order, record the same ``num_metric_calls_by_discovery``
+        as the serial path.
+        """
         num_metric_calls_by_discovery = state.total_num_evals
-        valset_evaluation = self._evaluate_on_valset(new_program, state)
+        state.increment_evals(num_actual_evals)
         state.num_full_ds_evals += 1
 
         # Snapshot Pareto front before update
@@ -277,15 +360,17 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
     # Reflective proposal acceptance (shared by single and parallel paths)
     # ------------------------------------------------------------------
 
-    def _accept_reflective_proposal(
+    def _reflective_acceptance(
         self,
         proposal: CandidateProposal,
         iteration: int,
         state: GEPAState[RolloutOutput, DataId],
     ) -> bool:
-        """Check acceptance, run full eval if accepted, fire callbacks.
+        """Apply the acceptance criterion (on subsample scores) and fire the
+        reject path. Returns True if the proposal should proceed to full eval.
 
-        Returns True if the proposal was accepted.
+        This is the cheap, sequential gate; the expensive full-valset eval and
+        the pool/Pareto mutation happen afterwards in :meth:`_run_reflective_batch`.
         """
         old_sum = sum(proposal.subsample_scores_before or [])
         new_sum = sum(proposal.subsample_scores_after or [])
@@ -319,26 +404,57 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         else:
             accept_msg = f"Iteration {iteration}: Candidate accepted (old_sum={old_sum}, new_sum={new_sum}). Continue to full eval and add to candidate pool."
         self.logger.log(accept_msg)
-
-        new_idx, _ = self._run_full_eval_and_add(
-            new_program=proposal.candidate,
-            state=state,
-            parent_program_idx=proposal.parent_program_ids,
-        )
-
-        self._log_proposal_lm_calls(iteration, proposal, candidate_idx=new_idx)
-
-        notify_callbacks(
-            self.callbacks,
-            "on_candidate_accepted",
-            CandidateAcceptedEvent(
-                iteration=iteration,
-                new_candidate_idx=new_idx,
-                new_score=new_sum,
-                parent_ids=proposal.parent_program_ids,
-            ),
-        )
         return True
+
+    def _run_reflective_batch(
+        self,
+        proposals: list[CandidateProposal],
+        state: GEPAState[RolloutOutput, DataId],
+    ) -> bool:
+        """Gate, full-eval, and add a batch of reflective proposals.
+
+        Gating and pool mutation stay sequential and ordered; the accepted
+        candidates' valset evals are batched into one
+        :meth:`_evaluate_programs_on_valset` call. Returns True if any was accepted.
+        """
+        iteration = state.i + 1
+
+        # 1) Acceptance gate.
+        accepted = [p for p in proposals if self._reflective_acceptance(p, iteration, state)]
+        if not accepted:
+            return False
+
+        # 2) Full-valset eval of all accepted candidates.
+        valset_evals = self._evaluate_programs_on_valset([p.candidate for p in accepted], state)
+
+        # 3) Add each accepted candidate to the pool, in order.
+        any_accepted = False
+        for proposal, (valset_evaluation, num_actual_evals) in zip(accepted, valset_evals, strict=True):
+            new_idx, _ = self._add_evaluated_program(
+                new_program=proposal.candidate,
+                state=state,
+                parent_program_idx=proposal.parent_program_ids,
+                valset_evaluation=valset_evaluation,
+                num_actual_evals=num_actual_evals,
+            )
+            self._log_proposal_lm_calls(iteration, proposal, candidate_idx=new_idx)
+            notify_callbacks(
+                self.callbacks,
+                "on_candidate_accepted",
+                CandidateAcceptedEvent(
+                    iteration=iteration,
+                    new_candidate_idx=new_idx,
+                    new_score=sum(proposal.subsample_scores_after or []),
+                    parent_ids=proposal.parent_program_ids,
+                ),
+            )
+            any_accepted = True
+            if self.merge_proposer is not None:
+                self.merge_proposer.last_iter_found_new_program = True
+                if self.merge_proposer.total_merges_tested < self.merge_proposer.max_merge_invocations:
+                    self.merge_proposer.merges_due += 1
+
+        return any_accepted
 
     # ------------------------------------------------------------------
     # Main optimization loop
@@ -634,14 +750,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                     self.logger.log(f"Iteration {state.i + 1}: Reflective mutation did not propose a new candidate")
                     continue
 
-                for proposal in proposals:
-                    accepted = self._accept_reflective_proposal(proposal, state.i + 1, state)
-                    if accepted:
-                        proposal_accepted = True
-                        if self.merge_proposer is not None:
-                            self.merge_proposer.last_iter_found_new_program = True
-                            if self.merge_proposer.total_merges_tested < self.merge_proposer.max_merge_invocations:
-                                self.merge_proposer.merges_due += 1
+                proposal_accepted = self._run_reflective_batch(proposals, state)
 
             except Exception as e:
                 self.logger.log(f"Iteration {state.i + 1}: Exception during optimization: {e}")

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -4,7 +4,6 @@
 import os
 import traceback
 from collections.abc import Sequence
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Generic
 
 from gepa.core.adapter import DataInst, GEPAAdapter, RolloutOutput, Trajectory
@@ -33,10 +32,7 @@ from gepa.logging.logger import LoggerProtocol
 from gepa.logging.utils import log_detailed_metrics_after_discovering_new_program
 from gepa.proposer.base import CandidateProposal
 from gepa.proposer.merge import MergeProposer
-from gepa.proposer.reflective_mutation.reflective_mutation import (
-    ProposalOutput,
-    ReflectiveMutationProposer,
-)
+from gepa.proposer.reflective_mutation.reflective_mutation import ReflectiveMutationProposer
 from gepa.strategies.acceptance import AcceptanceCriterion, ImprovementOrEqualAcceptance, StrictImprovementAcceptance
 from gepa.strategies.eval_policy import EvaluationPolicy, FullEvaluationPolicy
 from gepa.utils import StopperProtocol
@@ -81,8 +77,6 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         acceptance_criterion: AcceptanceCriterion | None = None,
         # Evaluation caching (stored in state, passed here for initialization)
         evaluation_cache: EvaluationCache[RolloutOutput, DataId] | None = None,
-        # Parallel proposals
-        num_parallel_proposals: int = 1,
     ):
         self.logger = logger
         self.run_dir = run_dir
@@ -126,7 +120,6 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         self.display_progress_bar = display_progress_bar
         self.use_cloudpickle = use_cloudpickle
 
-        self.num_parallel_proposals = num_parallel_proposals
         self.raise_on_exception = raise_on_exception
         self.val_evaluation_policy: EvaluationPolicy[DataId, DataInst] = (
             val_evaluation_policy if val_evaluation_policy is not None else FullEvaluationPolicy()
@@ -346,110 +339,6 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             ),
         )
         return True
-
-    def _process_proposal_output(
-        self,
-        output: ProposalOutput,
-        iteration: int,
-        trace_entry: dict,
-        state: GEPAState[RolloutOutput, DataId],
-    ) -> bool:
-        """Apply deferred state updates from a ProposalOutput and run acceptance.
-
-        Returns True if the proposal was accepted.
-        """
-        self.reflective_proposer.apply_proposal_output(output, state)
-        trace_entry.update(output.trace_data)
-
-        if output.proposal is None:
-            self.logger.log(f"Iteration {iteration}: Reflective mutation did not propose a new candidate")
-            return False
-
-        accepted = self._accept_reflective_proposal(output.proposal, iteration, state)
-
-        if accepted and self.merge_proposer is not None:
-            self.merge_proposer.last_iter_found_new_program = True
-            if self.merge_proposer.total_merges_tested < self.merge_proposer.max_merge_invocations:
-                self.merge_proposer.merges_due += 1
-
-        return accepted
-
-    # ------------------------------------------------------------------
-    # Parallel reflective proposals
-    # ------------------------------------------------------------------
-
-    def _run_parallel_reflective_batch(
-        self,
-        state: GEPAState[RolloutOutput, DataId],
-    ) -> bool:
-        """Run multiple reflective proposals in parallel.
-
-        Pre-samples N contexts sequentially, executes the heavy
-        evaluate-propose-evaluate pipeline in parallel threads, then
-        processes acceptances sequentially.
-        """
-        n = self.num_parallel_proposals
-
-        # Step 1: Pre-sample N contexts (sequential)
-        contexts = []
-        trace_entries: list[dict] = []
-
-        # First context uses the iteration slot already created by the caller
-        trace_entry_0 = state.full_program_trace[-1]
-        ctx_0 = self.reflective_proposer.prepare_proposal(state)
-        trace_entry_0["selected_program_candidate"] = ctx_0.curr_prog_id
-        trace_entry_0["subsample_ids"] = ctx_0.subsample_ids
-        contexts.append(ctx_0)
-        trace_entries.append(trace_entry_0)
-
-        for _ in range(n - 1):
-            if self._should_stop(state):
-                break
-            state.i += 1
-            trace_entry: dict[str, Any] = {"i": state.i}
-            state.full_program_trace.append(trace_entry)
-            ctx = self.reflective_proposer.prepare_proposal(state)
-            trace_entry["selected_program_candidate"] = ctx.curr_prog_id
-            trace_entry["subsample_ids"] = ctx.subsample_ids
-            contexts.append(ctx)
-            trace_entries.append(trace_entry)
-
-        if not contexts:
-            return False
-
-        # Step 2: Execute proposals in parallel (thread-safe heavy compute)
-        outputs: list[ProposalOutput | None] = [None] * len(contexts)
-        with ThreadPoolExecutor(max_workers=len(contexts)) as executor:
-            future_to_idx = {
-                executor.submit(self.reflective_proposer.execute_proposal, ctx, state): idx
-                for idx, ctx in enumerate(contexts)
-            }
-            for future in as_completed(future_to_idx):
-                idx = future_to_idx[future]
-                try:
-                    outputs[idx] = future.result()
-                except Exception as e:
-                    self.logger.log(f"Iteration {contexts[idx].iteration}: Parallel proposal failed: {e}")
-                    self.logger.log(traceback.format_exc())
-                    notify_callbacks(
-                        self.callbacks,
-                        "on_error",
-                        ErrorEvent(
-                            iteration=contexts[idx].iteration,
-                            exception=e,
-                            will_continue=True,
-                        ),
-                    )
-
-        # Step 3: Process acceptances sequentially
-        any_accepted = False
-        for _idx, (ctx, trace_entry, output) in enumerate(zip(contexts, trace_entries, outputs, strict=False)):
-            if output is None:
-                continue
-            if self._process_proposal_output(output, ctx.iteration, trace_entry, state):
-                any_accepted = True
-
-        return any_accepted
 
     # ------------------------------------------------------------------
     # Main optimization loop
@@ -740,13 +629,19 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                     self.merge_proposer.last_iter_found_new_program = False
 
                 # 2) Reflective mutation proposer
-                if self.num_parallel_proposals > 1:
-                    proposal_accepted = self._run_parallel_reflective_batch(state)
-                else:
-                    output = self.reflective_proposer.propose_output(state)
-                    proposal_accepted = self._process_proposal_output(
-                        output, state.i + 1, state.full_program_trace[-1], state
-                    )
+                proposals = self.reflective_proposer.propose(state)
+                if not proposals:
+                    self.logger.log(f"Iteration {state.i + 1}: Reflective mutation did not propose a new candidate")
+                    continue
+
+                for proposal in proposals:
+                    accepted = self._accept_reflective_proposal(proposal, state.i + 1, state)
+                    if accepted:
+                        proposal_accepted = True
+                        if self.merge_proposer is not None:
+                            self.merge_proposer.last_iter_found_new_program = True
+                            if self.merge_proposer.total_merges_tested < self.merge_proposer.max_merge_invocations:
+                                self.merge_proposer.merges_due += 1
 
             except Exception as e:
                 self.logger.log(f"Iteration {state.i + 1}: Exception during optimization: {e}")
@@ -829,11 +724,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         ``"candidates"`` table in WandB / MLflow.
         """
         metadata = proposal.metadata or {}
-        components = {
-            k.split(":", 1)[1]
-            for k in metadata
-            if k.startswith("prompt:") or k.startswith("raw_lm_output:")
-        }
+        components = {k.split(":", 1)[1] for k in metadata if k.startswith("prompt:") or k.startswith("raw_lm_output:")}
         if not components:
             return
 
@@ -847,18 +738,20 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             prompt = metadata.get(f"prompt:{comp}", "")
             raw_output = metadata.get(f"raw_lm_output:{comp}", "")
             proposed_text = proposal.candidate.get(comp, "")
-            rows.append([
-                iteration,
-                comp,
-                status,
-                candidate_idx,
-                parent_ids_str,
-                subsample_before,
-                subsample_after,
-                prompt if isinstance(prompt, str) else str(prompt),
-                raw_output,
-                proposed_text,
-            ])
+            rows.append(
+                [
+                    iteration,
+                    comp,
+                    status,
+                    candidate_idx,
+                    parent_ids_str,
+                    subsample_before,
+                    subsample_after,
+                    prompt if isinstance(prompt, str) else str(prompt),
+                    raw_output,
+                    proposed_text,
+                ]
+            )
 
         self.experiment_tracker.log_table(
             "proposals",

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -374,7 +374,8 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         new_sum = sum(proposal.subsample_scores_after or [])
         custom_reason = getattr(self.acceptance_criterion, "reject_reason", None)
         if custom_reason is not None:
-            reject_msg = f"Iteration {iteration}: {custom_reason(proposal, state)}"
+            reject_reason = custom_reason(proposal, state)
+            reject_msg = f"Iteration {iteration}: {reject_reason}"
         elif isinstance(self.acceptance_criterion, StrictImprovementAcceptance | ImprovementOrEqualAcceptance):
             reject_msg = (
                 f"Iteration {iteration}: New subsample score {new_sum} is not better than old score {old_sum}, skipping"

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -42,6 +42,7 @@ from gepa.proposer.merge import MergeProposer
 from gepa.proposer.reflective_mutation.reflective_mutation import ReflectiveMutationProposer
 from gepa.strategies.acceptance import AcceptanceCriterion, ImprovementOrEqualAcceptance, StrictImprovementAcceptance
 from gepa.strategies.eval_policy import EvaluationPolicy, FullEvaluationPolicy
+from gepa.strategies.proposal_selection import AllImprovements, SelectionStrategy
 from gepa.utils import StopperProtocol
 
 # Import tqdm for progress bar functionality
@@ -80,8 +81,9 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         # Budget and Stop Condition
         stop_callback: StopperProtocol | None = None,
         val_evaluation_policy: EvaluationPolicy[DataId, DataInst] | None = None,
-        # Acceptance criterion for reflective mutation proposals
+        # Acceptance criterion + selection strategy for reflective mutation proposals
         acceptance_criterion: AcceptanceCriterion | None = None,
+        selection_strategy: SelectionStrategy | None = None,
         # Evaluation caching (stored in state, passed here for initialization)
         evaluation_cache: EvaluationCache[RolloutOutput, DataId] | None = None,
     ):
@@ -123,6 +125,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             self.merge_proposer.last_iter_found_new_program = False
 
         self.acceptance_criterion: AcceptanceCriterion = acceptance_criterion or StrictImprovementAcceptance()
+        self.selection_strategy: SelectionStrategy = selection_strategy or AllImprovements()
         self.track_best_outputs = track_best_outputs
         self.display_progress_bar = display_progress_bar
         self.use_cloudpickle = use_cloudpickle
@@ -360,76 +363,76 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
     # Reflective proposal acceptance (shared by single and parallel paths)
     # ------------------------------------------------------------------
 
-    def _reflective_acceptance(
+    def _report_rejected_proposal(
         self,
         proposal: CandidateProposal,
         iteration: int,
         state: GEPAState[RolloutOutput, DataId],
-    ) -> bool:
-        """Apply the acceptance criterion (on subsample scores) and fire the
-        reject path. Returns True if the proposal should proceed to full eval.
-
-        This is the cheap, sequential gate; the expensive full-valset eval and
-        the pool/Pareto mutation happen afterwards in :meth:`_run_reflective_batch`.
-        """
+    ) -> None:
+        """Log and fire ``on_candidate_rejected`` for a proposal that failed acceptance."""
         old_sum = sum(proposal.subsample_scores_before or [])
         new_sum = sum(proposal.subsample_scores_after or [])
-        _uses_builtin_criterion = isinstance(
-            self.acceptance_criterion, StrictImprovementAcceptance | ImprovementOrEqualAcceptance
-        )
-
-        if not self.acceptance_criterion.should_accept(proposal, state):
-            if _uses_builtin_criterion:
-                reject_msg = f"Iteration {iteration}: New subsample score {new_sum} is not better than old score {old_sum}, skipping"
-                reject_reason = f"New subsample score {new_sum} not better than old score {old_sum}"
-            else:
-                reject_msg = f"Iteration {iteration}: Candidate rejected by acceptance criterion (old_sum={old_sum}, new_sum={new_sum}), skipping"
-                reject_reason = f"Candidate rejected by acceptance criterion (old_sum={old_sum}, new_sum={new_sum})"
-            self.logger.log(reject_msg)
-            self._log_proposal_lm_calls(iteration, proposal, candidate_idx=-1)
-            notify_callbacks(
-                self.callbacks,
-                "on_candidate_rejected",
-                CandidateRejectedEvent(
-                    iteration=iteration,
-                    old_score=old_sum,
-                    new_score=new_sum,
-                    reason=reject_reason,
-                ),
+        if isinstance(self.acceptance_criterion, StrictImprovementAcceptance | ImprovementOrEqualAcceptance):
+            reject_msg = (
+                f"Iteration {iteration}: New subsample score {new_sum} is not better than old score {old_sum}, skipping"
             )
-            return False
-
-        if _uses_builtin_criterion:
-            accept_msg = f"Iteration {iteration}: New subsample score {new_sum} is better than old score {old_sum}. Continue to full eval and add to candidate pool."
+            reject_reason = f"New subsample score {new_sum} not better than old score {old_sum}"
         else:
-            accept_msg = f"Iteration {iteration}: Candidate accepted (old_sum={old_sum}, new_sum={new_sum}). Continue to full eval and add to candidate pool."
-        self.logger.log(accept_msg)
-        return True
+            reject_msg = f"Iteration {iteration}: Candidate rejected by acceptance criterion (old_sum={old_sum}, new_sum={new_sum}), skipping"
+            reject_reason = f"Candidate rejected by acceptance criterion (old_sum={old_sum}, new_sum={new_sum})"
+        self.logger.log(reject_msg)
+        self._log_proposal_lm_calls(iteration, proposal, candidate_idx=-1)
+        notify_callbacks(
+            self.callbacks,
+            "on_candidate_rejected",
+            CandidateRejectedEvent(
+                iteration=iteration,
+                old_score=old_sum,
+                new_score=new_sum,
+                reason=reject_reason,
+            ),
+        )
 
     def _run_reflective_batch(
         self,
         proposals: list[CandidateProposal],
         state: GEPAState[RolloutOutput, DataId],
     ) -> bool:
-        """Gate, full-eval, and add a batch of reflective proposals.
+        """Gate, select, full-eval, and add a batch of reflective proposals.
 
-        Gating and pool mutation stay sequential and ordered; the accepted
-        candidates' valset evals are batched into one
-        :meth:`_evaluate_programs_on_valset` call. Returns True if any was accepted.
+        The engine is the single acceptance + selection authority: each proposal
+        is gated by the acceptance criterion (failures fire ``on_candidate_rejected``),
+        the selection strategy picks which of the accepted proposals to keep, and
+        the kept ones are batch-evaluated on the valset (one
+        :meth:`_evaluate_programs_on_valset` call) and added to the pool in order.
+        Returns True if any proposal was accepted.
         """
         iteration = state.i + 1
 
-        # 1) Acceptance gate.
-        accepted = [p for p in proposals if self._reflective_acceptance(p, iteration, state)]
-        if not accepted:
+        # 1) Acceptance gate (on subsample scores); reject the failures.
+        accepted: list[CandidateProposal] = []
+        for proposal in proposals:
+            if self.acceptance_criterion.should_accept(proposal, state):
+                accepted.append(proposal)
+            else:
+                self._report_rejected_proposal(proposal, iteration, state)
+
+        # 2) Selection strategy picks which accepted proposals to add.
+        selected = self.selection_strategy.select(accepted, state, self.acceptance_criterion)
+        if not selected:
             return False
 
-        # 2) Full-valset eval of all accepted candidates.
-        valset_evals = self._evaluate_programs_on_valset([p.candidate for p in accepted], state)
+        # 3) Full-valset eval of the selected candidates (one batched, read-only call).
+        valset_evals = self._evaluate_programs_on_valset([p.candidate for p in selected], state)
 
-        # 3) Add each accepted candidate to the pool, in order.
+        # 4) Add each selected candidate to the pool, in order.
         any_accepted = False
-        for proposal, (valset_evaluation, num_actual_evals) in zip(accepted, valset_evals, strict=True):
+        for proposal, (valset_evaluation, num_actual_evals) in zip(selected, valset_evals, strict=True):
+            new_sum = sum(proposal.subsample_scores_after or [])
+            self.logger.log(
+                f"Iteration {iteration}: Accepted candidate (subsample score "
+                f"{sum(proposal.subsample_scores_before or [])} -> {new_sum}); running full eval."
+            )
             new_idx, _ = self._add_evaluated_program(
                 new_program=proposal.candidate,
                 state=state,
@@ -444,7 +447,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                 CandidateAcceptedEvent(
                     iteration=iteration,
                     new_candidate_idx=new_idx,
-                    new_score=sum(proposal.subsample_scores_after or []),
+                    new_score=new_sum,
                     parent_ids=proposal.parent_program_ids,
                 ),
             )
@@ -498,13 +501,13 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
 
         def valset_evaluator(
             program: dict[str, str],
+            val_ids: list[Any],
         ) -> ValsetEvaluation[RolloutOutput, DataId]:
-            all_ids = list(valset.all_ids())
-            outputs, scores, objective_scores = self.evaluator(valset.fetch(all_ids), program)
-            outputs_dict = dict(zip(all_ids, outputs, strict=False))
-            scores_dict = dict(zip(all_ids, scores, strict=False))
+            outputs, scores, objective_scores = self.evaluator(valset.fetch(val_ids), program)
+            outputs_dict = dict(zip(val_ids, outputs, strict=False))
+            scores_dict = dict(zip(val_ids, scores, strict=False))
             objective_scores_dict = (
-                dict(zip(all_ids, objective_scores, strict=False)) if objective_scores is not None else None
+                dict(zip(val_ids, objective_scores, strict=False)) if objective_scores is not None else None
             )
             return ValsetEvaluation(
                 outputs_by_val_id=outputs_dict,
@@ -528,8 +531,12 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             ),
         )
 
-        # Evaluate seed candidate on valset (after on_optimization_start callback)
-        seed_valset_evaluation = valset_evaluator(self.seed_candidate)
+        # Evaluate seed candidate on valset (after on_optimization_start callback).
+        # Policies may narrow the seed evaluation via the optional get_seed_eval_batch
+        # hook; the state does not exist yet, so get_eval_batch cannot be used here.
+        seed_batch_fn = getattr(self.val_evaluation_policy, "get_seed_eval_batch", None)
+        seed_val_ids = list(seed_batch_fn(valset)) if seed_batch_fn is not None else list(valset.all_ids())
+        seed_valset_evaluation = valset_evaluator(self.seed_candidate, seed_val_ids)
 
         # Initialize state with pre-computed seed evaluation
         state = initialize_gepa_state(

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -368,12 +368,25 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         proposal: CandidateProposal,
         iteration: int,
         state: GEPAState[RolloutOutput, DataId],
+        dropped_by_selection: bool = False,
     ) -> None:
-        """Log and fire ``on_candidate_rejected`` for a proposal that failed acceptance."""
+        """Log and fire ``on_candidate_rejected`` for a non-selected proposal.
+
+        ``dropped_by_selection=True`` means the proposal PASSED the acceptance
+        criterion but was not picked by the selection strategy (e.g.
+        BestImprovement/TopK) — the reason must say so rather than falsely
+        claiming a score regression.
+        """
         old_sum = sum(proposal.subsample_scores_before or [])
         new_sum = sum(proposal.subsample_scores_after or [])
         custom_reason = getattr(self.acceptance_criterion, "reject_reason", None)
-        if custom_reason is not None:
+        if dropped_by_selection:
+            reject_reason = (
+                f"Passed acceptance (score {old_sum} -> {new_sum}) but was not selected "
+                f"by the selection strategy ({type(self.selection_strategy).__name__})"
+            )
+            reject_msg = f"Iteration {iteration}: {reject_reason}, skipping"
+        elif custom_reason is not None:
             reject_reason = custom_reason(proposal, state)
             reject_msg = f"Iteration {iteration}: {reject_reason}"
         elif isinstance(self.acceptance_criterion, StrictImprovementAcceptance | ImprovementOrEqualAcceptance):
@@ -421,11 +434,16 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         #    the acceptance criterion (no engine pre-filter).
         selected = self.selection_strategy.select(list(proposals), state, self.acceptance_criterion)
 
-        # 2) Report everything not selected as rejected.
+        # 2) Report everything not selected as rejected, distinguishing
+        #    acceptance failures from selection drops (re-checking the
+        #    criterion here is cheap and keeps rejection reasons truthful).
         selected_ids = {id(p) for p in selected}
         for proposal in proposals:
             if id(proposal) not in selected_ids:
-                self._report_rejected_proposal(proposal, iteration, state)
+                passed_acceptance = self.acceptance_criterion.should_accept(proposal, state)
+                self._report_rejected_proposal(
+                    proposal, iteration, state, dropped_by_selection=passed_acceptance
+                )
 
         if not selected:
             return False

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -52,6 +52,27 @@ except ImportError:
     tqdm = None
 
 
+class _MemoizedAcceptance:
+    """Wraps an AcceptanceCriterion so each proposal is judged EXACTLY once per
+    engine batch, no matter how many times the selection strategy and the
+    engine's rejection classification consult it. Stateful or stochastic
+    criteria therefore see one call per proposal (the pre-#329 contract) and
+    verdicts stay consistent between selection and rejection reporting."""
+
+    def __init__(self, criterion):
+        self._criterion = criterion
+        self._verdicts: dict[int, bool] = {}
+
+    def should_accept(self, proposal, state) -> bool:
+        key = id(proposal)
+        if key not in self._verdicts:
+            self._verdicts[key] = self._criterion.should_accept(proposal, state)
+        return self._verdicts[key]
+
+    def __getattr__(self, name):
+        return getattr(self._criterion, name)
+
+
 class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
     """Orchestrates the optimization loop using pluggable candidate proposers."""
 
@@ -301,6 +322,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         )
 
         state.full_program_trace[-1]["new_program_idx"] = new_program_idx
+        state.full_program_trace[-1].setdefault("new_program_indices", []).append(new_program_idx)
         state.full_program_trace[-1]["evaluated_val_indices"] = sorted(valset_evaluation.scores_by_val_id.keys())
 
         if is_best_program:
@@ -369,6 +391,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         iteration: int,
         state: GEPAState[RolloutOutput, DataId],
         dropped_by_selection: bool = False,
+        reason_override: str | None = None,
     ) -> None:
         """Log and fire ``on_candidate_rejected`` for a non-selected proposal.
 
@@ -380,7 +403,10 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         old_sum = sum(proposal.subsample_scores_before or [])
         new_sum = sum(proposal.subsample_scores_after or [])
         custom_reason = getattr(self.acceptance_criterion, "reject_reason", None)
-        if dropped_by_selection:
+        if reason_override is not None:
+            reject_reason = reason_override
+            reject_msg = f"Iteration {iteration}: {reject_reason}, skipping"
+        elif dropped_by_selection:
             reject_reason = (
                 f"Passed acceptance (score {old_sum} -> {new_sum}) but was not selected "
                 f"by the selection strategy ({type(self.selection_strategy).__name__})"
@@ -431,19 +457,58 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         iteration = state.i + 1
 
         # 1) Selection is authoritative; it sees every evaluated proposal and
-        #    the acceptance criterion (no engine pre-filter).
-        selected = self.selection_strategy.select(list(proposals), state, self.acceptance_criterion)
+        #    the acceptance criterion (no engine pre-filter). The criterion is
+        #    memoized so each proposal is judged exactly once per batch even
+        #    though both the strategy and the rejection classification below
+        #    consult it — stateful/stochastic criteria stay coherent.
+        criterion = _MemoizedAcceptance(self.acceptance_criterion)
+        selected = self.selection_strategy.select(list(proposals), state, criterion)
+
+        # Defensive: strategies must return proposals FROM the input list.
+        input_ids = {id(p) for p in proposals}
+        foreign = [p for p in selected if id(p) not in input_ids]
+        if foreign:
+            self.logger.log(
+                f"Iteration {iteration}: selection strategy returned {len(foreign)} object(s) not from "
+                "the proposal list; ignoring them (strategies must select from the given proposals)."
+            )
+            selected = [p for p in selected if id(p) in input_ids]
+
+        # Deduplicate: identical child candidates selected in the same
+        # iteration would each get a full valset eval and a pool entry.
+        deduped: list[CandidateProposal] = []
+        seen_candidates: set[tuple] = set()
+        seen_ids: set[int] = set()
+        duplicates: list[CandidateProposal] = []
+        for p in selected:
+            content_key = tuple(sorted(p.candidate.items()))
+            if id(p) in seen_ids or content_key in seen_candidates:
+                duplicates.append(p)
+                continue
+            seen_ids.add(id(p))
+            seen_candidates.add(content_key)
+            deduped.append(p)
+        selected = deduped
 
         # 2) Report everything not selected as rejected, distinguishing
-        #    acceptance failures from selection drops (re-checking the
-        #    criterion here is cheap and keeps rejection reasons truthful).
+        #    acceptance failures from selection drops (memoized verdicts keep
+        #    the reasons truthful at zero extra criterion calls).
         selected_ids = {id(p) for p in selected}
         for proposal in proposals:
-            if id(proposal) not in selected_ids:
-                passed_acceptance = self.acceptance_criterion.should_accept(proposal, state)
+            if id(proposal) in selected_ids:
+                continue
+            if any(proposal is d for d in duplicates):
                 self._report_rejected_proposal(
-                    proposal, iteration, state, dropped_by_selection=passed_acceptance
+                    proposal,
+                    iteration,
+                    state,
+                    reason_override="Duplicate of another candidate selected this iteration",
                 )
+                continue
+            passed_acceptance = criterion.should_accept(proposal, state)
+            self._report_rejected_proposal(
+                proposal, iteration, state, dropped_by_selection=passed_acceptance
+            )
 
         if not selected:
             return False

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -372,7 +372,10 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         """Log and fire ``on_candidate_rejected`` for a proposal that failed acceptance."""
         old_sum = sum(proposal.subsample_scores_before or [])
         new_sum = sum(proposal.subsample_scores_after or [])
-        if isinstance(self.acceptance_criterion, StrictImprovementAcceptance | ImprovementOrEqualAcceptance):
+        custom_reason = getattr(self.acceptance_criterion, "reject_reason", None)
+        if custom_reason is not None:
+            reject_msg = f"Iteration {iteration}: {custom_reason(proposal, state)}"
+        elif isinstance(self.acceptance_criterion, StrictImprovementAcceptance | ImprovementOrEqualAcceptance):
             reject_msg = (
                 f"Iteration {iteration}: New subsample score {new_sum} is not better than old score {old_sum}, skipping"
             )
@@ -400,25 +403,29 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
     ) -> bool:
         """Gate, select, full-eval, and add a batch of reflective proposals.
 
-        The engine is the single acceptance + selection authority: each proposal
-        is gated by the acceptance criterion (failures fire ``on_candidate_rejected``),
-        the selection strategy picks which of the accepted proposals to keep, and
-        the kept ones are batch-evaluated on the valset (one
-        :meth:`_evaluate_programs_on_valset` call) and added to the pool in order.
-        Returns True if any proposal was accepted.
+        The selection strategy is the authority over which proposals proceed:
+        it receives ALL evaluated proposals together with the acceptance
+        criterion. The built-in strategies apply the criterion; a custom
+        strategy may deliberately surface a proposal the criterion would
+        reject (e.g. exploration picks). Everything not selected fires
+        ``on_candidate_rejected`` — including acceptance-passing proposals
+        dropped by Best/TopK selection, which previously vanished without an
+        event. Selected proposals are batch-evaluated on the valset (one
+        :meth:`_evaluate_programs_on_valset` call) and added to the pool in
+        order. Returns True if any proposal was accepted.
         """
         iteration = state.i + 1
 
-        # 1) Acceptance gate (on subsample scores); reject the failures.
-        accepted: list[CandidateProposal] = []
+        # 1) Selection is authoritative; it sees every evaluated proposal and
+        #    the acceptance criterion (no engine pre-filter).
+        selected = self.selection_strategy.select(list(proposals), state, self.acceptance_criterion)
+
+        # 2) Report everything not selected as rejected.
+        selected_ids = {id(p) for p in selected}
         for proposal in proposals:
-            if self.acceptance_criterion.should_accept(proposal, state):
-                accepted.append(proposal)
-            else:
+            if id(proposal) not in selected_ids:
                 self._report_rejected_proposal(proposal, iteration, state)
 
-        # 2) Selection strategy picks which accepted proposals to add.
-        selected = self.selection_strategy.select(accepted, state, self.acceptance_criterion)
         if not selected:
             return False
 

--- a/src/gepa/lm.py
+++ b/src/gepa/lm.py
@@ -235,5 +235,27 @@ class TrackingLM:
 
         return result
 
+    def __getattr__(self, name: str):
+        # Conditionally expose batch_complete: hasattr(tracking_lm,
+        # "batch_complete") must be True exactly when the wrapped callable
+        # provides it, so batched reflection (StatelessReflectionLM) is not
+        # silently downgraded to the per-task path by this wrapper.
+        if name == "batch_complete":
+            inner = getattr(self._fn, "batch_complete", None)
+            if inner is None:
+                raise AttributeError(name)
+
+            def tracked_batch_complete(messages_list):
+                for messages in messages_list:
+                    self._total_tokens_in += self._estimate_tokens(str(messages))
+                results = list(inner(messages_list))
+                for result in results:
+                    if isinstance(result, str):
+                        self._total_tokens_out += self._estimate_tokens(result)
+                return results
+
+            return tracked_batch_complete
+        raise AttributeError(name)
+
     def __repr__(self) -> str:
         return f"TrackingLM({self._fn!r})"

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -1187,7 +1187,10 @@ def optimize_anything(
             steps) use ``evaluator``; with only ``batch_evaluator``, singles
             route through it as singleton batches. Caching (``cache_evaluation``)
             applies identically on both paths, with a shared store: a pair
-            cached by either path is a hit for the other.
+            cached by either path is a hit for the other. Note: with
+            ``refiner_config`` + ``parallel=True`` and no ``evaluator``, your
+            batch function may be called concurrently with singleton batches
+            from the refinement thread pool — make it thread-safe.
         dataset: Examples for multi-task or generalization modes.
             ``None`` = single-task search mode.
         valset: Held-out validation set for generalization mode.

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -1298,6 +1298,13 @@ def optimize_anything(
             "batch_evaluator alone is sufficient: single-pair resolutions "
             "(e.g. refiner steps) are routed through it as singleton batches."
         )
+    if config.engine.capture_stdio and evaluator is None:
+        warnings.warn(
+            "capture_stdio=True has no effect without a single-pair evaluator: the batch_evaluator "
+            "path cannot scope stdio capture to individual evaluations. Return diagnostics in "
+            "side_info instead.",
+            stacklevel=2,
+        )
     wrapped_evaluator = None
     if evaluator is not None:
         wrapped_evaluator = EvaluatorWrapper(
@@ -1347,6 +1354,7 @@ def optimize_anything(
                 batch_evaluator,
                 str_candidate_key=_STR_CANDIDATE_KEY if str_candidate_mode else None,
                 raise_on_exception=config.engine.raise_on_exception,
+                single_instance_mode=single_instance_mode,
             )
             if batch_evaluator is not None
             else None
@@ -1405,6 +1413,14 @@ def optimize_anything(
 
         stop_callbacks_list.append(MaxCandidateProposalsStopper(config.engine.max_candidate_proposals))
 
+    if config.engine.max_reflection_cost is not None and config.reflection.reflection_strategy is not None:
+        strategy = config.reflection.reflection_strategy
+        if not hasattr(strategy, "total_cost"):
+            raise ValueError(
+                "max_reflection_cost is set but reflection_strategy does not expose total_cost — "
+                "the cost stopper would silently never fire (unbounded reflection spend). Expose a "
+                "total_cost property on the strategy, or remove max_reflection_cost."
+            )
     if config.engine.max_reflection_cost is not None:
         from gepa.utils import MaxReflectionCostStopper
 

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -484,16 +484,6 @@ class EngineConfig:
     parallel: bool = True
     max_workers: int | None = field(default_factory=lambda: os.cpu_count() or 32)
 
-    # Number of parallel proposal workers per optimization step.
-    # When > 1, multiple minibatches are sampled and proposed concurrently
-    # (each with its own evaluate-propose-evaluate pipeline), then acceptances
-    # are processed sequentially.
-    # Set to "auto" to compute from max_workers and minibatch_size:
-    #   auto = max(1, max_workers // minibatch_size)
-    # Each proposal evaluates minibatch_size examples at a time, so this
-    # fills the worker pool across concurrent proposals.
-    num_parallel_proposals: int | Literal["auto"] = 1
-
     # Evaluation caching
     cache_evaluation: bool = False
     cache_evaluation_storage: CacheEvaluationStorage = "auto"
@@ -514,6 +504,11 @@ class EngineConfig:
     # internally by libraries. For those, use oa.log() or capture subprocess
     # output manually and pass it to oa.log().
     capture_stdio: bool = False
+
+    # Proposal strategies (default: 1 parent, 1 mutation per iteration).
+    # Swap in a different SamplingStrategy to propose multiple candidates.
+    sampling_strategy: Any | None = None
+    selection_strategy: Any | None = None
 
 
 def _build_reflection_prompt_template(objective: str | None = None, background: str | None = None) -> str:
@@ -1105,21 +1100,11 @@ class EvaluatorWrapper:
         return self._wrapped(candidate, example=example, **kwargs)
 
 
-def _resolve_num_parallel_proposals(
-    value: int | Literal["auto"],
-    max_workers: int,
-    minibatch_size: int,
-) -> int:
-    """Resolve num_parallel_proposals, computing automatically if "auto"."""
-    if isinstance(value, int):
-        return value
-    return max(1, max_workers // minibatch_size)
-
-
 def optimize_anything(
     seed_candidate: str | Candidate | None = None,
     *,
     evaluator: Callable[..., Any],
+    batch_evaluator: Callable[..., Any] | None = None,
     dataset: list[DataInst] | None = None,
     valset: list[DataInst] | None = None,
     objective: str | None = None,
@@ -1311,6 +1296,7 @@ def optimize_anything(
         background=background,
         cache_mode=resolved_cache_mode,
         cache_dir=config.engine.run_dir,
+        batch_evaluator=batch_evaluator,
     )
 
     # Normalize datasets to DataLoader instances
@@ -1571,6 +1557,9 @@ def optimize_anything(
         reflection_prompt_template=config.reflection.reflection_prompt_template,
         custom_candidate_proposer=config.reflection.custom_candidate_proposer,
         callbacks=config.callbacks,
+        acceptance_criterion=acceptance_criterion_instance,
+        sampling_strategy=config.engine.sampling_strategy,
+        selection_strategy=config.engine.selection_strategy,
     )
 
     # Define evaluator function for merge proposer
@@ -1620,14 +1609,9 @@ def optimize_anything(
         acceptance_criterion=acceptance_criterion_instance,
         use_cloudpickle=config.engine.use_cloudpickle,
         evaluation_cache=evaluation_cache,
-        num_parallel_proposals=_resolve_num_parallel_proposals(
-            config.engine.num_parallel_proposals,
-            config.engine.max_workers or (os.cpu_count() or 32),
-            config.reflection.reflection_minibatch_size or 1,
-        ),
     )
 
-    # --- 15. Run optimization ---
+    # --- 16. Run optimization ---
     logger = config.tracking.logger
     with experiment_tracker:
         if isinstance(logger, Logger):

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -1114,7 +1114,7 @@ class EvaluatorWrapper:
 def optimize_anything(
     seed_candidate: str | Candidate | None = None,
     *,
-    evaluator: Callable[..., Any],
+    evaluator: Callable[..., Any] | None = None,
     batch_evaluator: Callable[..., Any] | None = None,
     dataset: list[DataInst] | None = None,
     valset: list[DataInst] | None = None,
@@ -1159,6 +1159,9 @@ def optimize_anything(
               where to begin.
 
         evaluator: Scoring function.  Returns ``(score, side_info)`` or ``score``.
+            Optional when ``batch_evaluator`` is provided (at least one is
+            required): without it, every evaluation — including refiner steps,
+            as singleton batches — routes through ``batch_evaluator``.
             See :class:`Evaluator`.  Diagnostic output via ``oa.log()`` is
             automatically captured as Actionable Side Information (ASI).
             For richer diagnostics, return a ``(score, dict)`` tuple with
@@ -1178,8 +1181,13 @@ def optimize_anything(
             packaging match the sequential path exactly. NOT available on this
             path (structurally per-call features): ``oa.log()`` capture and
             stdout/stderr capture — put diagnostics in each returned
-            ``side_info`` instead. ``evaluator`` is still required and is used
-            by features that evaluate single pairs (e.g. the refiner).
+            ``side_info`` instead. When both are provided,
+            multi-pair evaluations (minibatch stages, valset/seed/merge evals)
+            prefer ``batch_evaluator`` while single-pair resolutions (refiner
+            steps) use ``evaluator``; with only ``batch_evaluator``, singles
+            route through it as singleton batches. Caching (``cache_evaluation``)
+            applies identically on both paths, with a shared store: a pair
+            cached by either path is a hit for the other.
         dataset: Examples for multi-task or generalization modes.
             ``None`` = single-task search mode.
         valset: Held-out validation set for generalization mode.
@@ -1281,13 +1289,21 @@ def optimize_anything(
         effective_dataset = dataset if dataset is not None else [None]  # type: ignore[list-item]
 
     # Wrap the evaluator to handle signature normalization, log/stdout capture, etc.
-    wrapped_evaluator = EvaluatorWrapper(
-        evaluator,
-        single_instance_mode,
-        capture_stdio=config.engine.capture_stdio,
-        str_candidate_mode=str_candidate_mode,
-        raise_on_exception=config.engine.raise_on_exception,
-    )
+    if evaluator is None and batch_evaluator is None:
+        raise ValueError(
+            "Provide evaluator=, batch_evaluator=, or both. "
+            "batch_evaluator alone is sufficient: single-pair resolutions "
+            "(e.g. refiner steps) are routed through it as singleton batches."
+        )
+    wrapped_evaluator = None
+    if evaluator is not None:
+        wrapped_evaluator = EvaluatorWrapper(
+            evaluator,
+            single_instance_mode,
+            capture_stdio=config.engine.capture_stdio,
+            str_candidate_mode=str_candidate_mode,
+            raise_on_exception=config.engine.raise_on_exception,
+        )
 
     # Resolve cache mode: cache_evaluation controls on/off, cache_evaluation_storage controls where
     if not config.engine.cache_evaluation:

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -1175,7 +1175,9 @@ def optimize_anything(
             ``(score, side_info)``. Parity with the standard path: candidates
             are unwrapped in str-candidate mode; if your function accepts an
             ``opt_states`` keyword it receives per-pair
-            :class:`OptimizationState` objects (warm-starting); a raised call
+            :class:`OptimizationState` objects (warm-starting; note they are
+            snapshotted when the grouped call is issued, so pairs within one
+            call do not see each other's fresh results); a raised call
             is converted to per-pair ``(0.0, {"error": ...})`` results when
             ``raise_on_exception=False``; best-evals history and output
             packaging match the sequential path exactly. NOT available on this
@@ -1649,6 +1651,7 @@ def optimize_anything(
             max_merge_invocations=config.merge.max_merge_invocations,
             rng=rng,
             val_overlap_floor=config.merge.merge_val_overlap_floor,
+            callbacks=config.callbacks,
         )
 
     # --- 13. Create evaluation cache if enabled ---

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -121,7 +121,10 @@ from typing import (
     TypeAlias,
 )
 
-from gepa.adapters.optimize_anything_adapter.optimize_anything_adapter import OptimizeAnythingAdapter
+from gepa.adapters.optimize_anything_adapter.optimize_anything_adapter import (
+    BatchEvaluatorWrapper,
+    OptimizeAnythingAdapter,
+)
 from gepa.core.adapter import DataInst, GEPAAdapter, ProposalFn
 from gepa.core.callbacks import GEPACallback
 from gepa.core.data_loader import ensure_loader
@@ -133,6 +136,7 @@ from gepa.logging.experiment_tracker import create_experiment_tracker
 from gepa.logging.logger import Logger, LoggerProtocol, StdOutLogger
 from gepa.proposer.merge import MergeProposer
 from gepa.proposer.reflective_mutation.base import CandidateSelector, LanguageModel, ReflectionComponentSelector
+from gepa.proposer.reflective_mutation.reflection_lm import ReflectionLM
 from gepa.proposer.reflective_mutation.reflective_mutation import ReflectiveMutationProposer
 from gepa.strategies.acceptance import AcceptanceCriterion, ImprovementOrEqualAcceptance, StrictImprovementAcceptance
 from gepa.strategies.batch_sampler import BatchSampler, EpochShuffledBatchSampler
@@ -727,6 +731,11 @@ class ReflectionConfig:
 
     skip_perfect_score: bool = False
     perfect_score: float | None = None
+    # Advanced: a ReflectionLM implementation that owns how reflective mutation
+    # calls the reflection model (sessions, ComBEE-style aggregation, coding
+    # agents). Defaults to the stateless single-call reflector built from
+    # ``reflection_lm``. Mirror of gepa.optimize()'s reflection_strategy=.
+    reflection_strategy: "ReflectionLM | None" = None
     batch_sampler: BatchSampler | Literal["epoch_shuffled"] = "epoch_shuffled"
     reflection_minibatch_size: int | None = None  # Default: 1 for single-instance mode, 3 otherwise
     module_selector: ReflectionComponentSelector | Literal["round_robin", "all"] = "round_robin"
@@ -1155,6 +1164,22 @@ def optimize_anything(
             For richer diagnostics, return a ``(score, dict)`` tuple with
             structured feedback, error messages, or even rendered images
             (via :class:`~gepa.Image`).
+        batch_evaluator: Optional low-level batch evaluation hook. When set,
+            GEPA hands you ALL pending ``(candidate, example)`` pairs in ONE
+            call — e.g. to submit a provider batch job or fan out over your
+            own infrastructure — instead of calling ``evaluator`` per pair.
+            Return one result per pair, each ``score`` or
+            ``(score, side_info)``. Parity with the standard path: candidates
+            are unwrapped in str-candidate mode; if your function accepts an
+            ``opt_states`` keyword it receives per-pair
+            :class:`OptimizationState` objects (warm-starting); a raised call
+            is converted to per-pair ``(0.0, {"error": ...})`` results when
+            ``raise_on_exception=False``; best-evals history and output
+            packaging match the sequential path exactly. NOT available on this
+            path (structurally per-call features): ``oa.log()`` capture and
+            stdout/stderr capture — put diagnostics in each returned
+            ``side_info`` instead. ``evaluator`` is still required and is used
+            by features that evaluate single pairs (e.g. the refiner).
         dataset: Examples for multi-task or generalization modes.
             ``None`` = single-task search mode.
         valset: Held-out validation set for generalization mode.
@@ -1298,7 +1323,15 @@ def optimize_anything(
         background=background,
         cache_mode=resolved_cache_mode,
         cache_dir=config.engine.run_dir,
-        batch_evaluator=batch_evaluator,
+        batch_evaluator=(
+            BatchEvaluatorWrapper(
+                batch_evaluator,
+                str_candidate_key=_STR_CANDIDATE_KEY if str_candidate_mode else None,
+                raise_on_exception=config.engine.raise_on_exception,
+            )
+            if batch_evaluator is not None
+            else None
+        ),
     )
 
     # Normalize datasets to DataLoader instances
@@ -1560,6 +1593,7 @@ def optimize_anything(
         custom_candidate_proposer=config.reflection.custom_candidate_proposer,
         callbacks=config.callbacks,
         sampling_strategy=config.engine.sampling_strategy,
+        reflection_strategy=config.reflection.reflection_strategy,
     )
 
     # Define evaluator function for merge proposer

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -147,6 +147,8 @@ from gepa.strategies.component_selector import (
     RoundRobinReflectionComponentSelector,
 )
 from gepa.strategies.eval_policy import EvaluationPolicy, FullEvaluationPolicy
+from gepa.strategies.proposal_sampling import SamplingStrategy
+from gepa.strategies.proposal_selection import SelectionStrategy
 from gepa.utils import FileStopper, StopperProtocol
 from gepa.utils.stdio_capture import ThreadLocalStreamCapture, stream_manager
 
@@ -507,8 +509,8 @@ class EngineConfig:
 
     # Proposal strategies (default: 1 parent, 1 mutation per iteration).
     # Swap in a different SamplingStrategy to propose multiple candidates.
-    sampling_strategy: Any | None = None
-    selection_strategy: Any | None = None
+    sampling_strategy: SamplingStrategy | None = None
+    selection_strategy: SelectionStrategy | None = None
 
 
 def _build_reflection_prompt_template(objective: str | None = None, background: str | None = None) -> str:

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -1559,9 +1559,7 @@ def optimize_anything(
         reflection_prompt_template=config.reflection.reflection_prompt_template,
         custom_candidate_proposer=config.reflection.custom_candidate_proposer,
         callbacks=config.callbacks,
-        acceptance_criterion=acceptance_criterion_instance,
         sampling_strategy=config.engine.sampling_strategy,
-        selection_strategy=config.engine.selection_strategy,
     )
 
     # Define evaluator function for merge proposer
@@ -1609,6 +1607,7 @@ def optimize_anything(
         stop_callback=stop_callback,
         val_evaluation_policy=config.engine.val_evaluation_policy,
         acceptance_criterion=acceptance_criterion_instance,
+        selection_strategy=config.engine.selection_strategy,
         use_cloudpickle=config.engine.use_cloudpickle,
         evaluation_cache=evaluation_cache,
     )

--- a/src/gepa/proposer/reflective_mutation/reflection_lm.py
+++ b/src/gepa/proposer/reflective_mutation/reflection_lm.py
@@ -72,7 +72,7 @@ class BatchReflectionLM(ReflectionLM, Protocol):
 
 
 class StatelessReflectionLM:
-    """Default reflection LM: one stateless LM call per component.
+    """Default reflection LM: one stateless LM call per component (or one batched call covering all tasks/components when the underlying LM provides ``batch_complete``).
 
     For each component with feedback, render the instruction-proposal prompt
     (honoring a global or per-component template) and parse the new instruction.

--- a/src/gepa/proposer/reflective_mutation/reflection_lm.py
+++ b/src/gepa/proposer/reflective_mutation/reflection_lm.py
@@ -35,6 +35,14 @@ class ReflectionProposal:
     new_texts: dict[str, str]
     prompts: dict[str, str | list[dict[str, Any]]] = field(default_factory=dict)
     raw_lm_outputs: dict[str, str] = field(default_factory=dict)
+    # Free-form diagnostics for multi-call reflection strategies. ``prompts``/
+    # ``raw_lm_outputs`` assume ONE LM call per component; strategies that make
+    # several (e.g. ComBEE's k map calls + 1 reduce call per component) should
+    # record per-call intermediates here (namespaced keys, e.g.
+    # "combee:level1_prompts"). Merged into CandidateProposal.metadata, so it
+    # reaches on_proposal_end consumers, experiment trackers, and the run
+    # manifest without a future protocol break.
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @runtime_checkable

--- a/src/gepa/proposer/reflective_mutation/reflection_lm.py
+++ b/src/gepa/proposer/reflective_mutation/reflection_lm.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""Reflection LM abstraction (#329 Phase 1).
+
+A ``ReflectionLM`` proposes new component texts and returns the (possibly
+extended) reflection LM to use next.  The stateless default
+(:class:`StatelessReflectionLM`) returns itself, so behavior is identical to
+GEPA's historical single-callable reflection.  Sessions, agents, and ComBEE
+become additional implementations in later phases.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from gepa.proposer.reflective_mutation.base import LanguageModel
+from gepa.strategies.instruction_proposal import InstructionProposalSignature
+
+
+@dataclass
+class ReflectionProposal:
+    """Output of one :meth:`ReflectionLM.reflect` call.
+
+    ``new_texts`` maps component name -> proposed text.  ``prompts`` and
+    ``raw_lm_outputs`` are optional per-component diagnostics for callbacks and
+    experiment trackers.
+    """
+
+    new_texts: dict[str, str]
+    prompts: dict[str, str | list[dict[str, Any]]] = field(default_factory=dict)
+    raw_lm_outputs: dict[str, str] = field(default_factory=dict)
+
+
+@runtime_checkable
+class ReflectionLM(Protocol):
+    """Proposes new component texts.
+
+    ``reflect`` returns ``(proposal, next_lm)``: the reflection LM to use next.
+    Stateless implementations return ``self``; stateful ones return an extended
+    copy, leaving the original reusable/forkable.  See #329.
+    """
+
+    def reflect(
+        self,
+        candidate: dict[str, str],
+        reflective_dataset: Mapping[str, Sequence[Mapping[str, Any]]],
+        components_to_update: list[str],
+    ) -> tuple[ReflectionProposal, ReflectionLM]: ...
+
+
+class StatelessReflectionLM:
+    """Default reflection LM: one stateless LM call per component.
+
+    For each component with feedback, render the instruction-proposal prompt
+    (honoring a global or per-component template) and parse the new instruction.
+    ``reflect`` returns ``self`` — there is no carried state.
+    """
+
+    def __init__(
+        self,
+        lm: LanguageModel,
+        reflection_prompt_template: str | dict[str, str] | None = None,
+        logger: Any | None = None,
+    ):
+        self.lm = lm
+        self.reflection_prompt_template = reflection_prompt_template
+        self.logger = logger
+        # Components already warned about a missing per-component template (warn once).
+        self._missing_template_warnings: set[str] = set()
+
+    def _log(self, message: str) -> None:
+        if self.logger is not None:
+            self.logger.log(message)
+
+    def _resolve_template(self, name: str) -> str | None:
+        if isinstance(self.reflection_prompt_template, dict):
+            template = self.reflection_prompt_template.get(name)
+            if template is None and name not in self._missing_template_warnings:
+                self._log(f"No reflection_prompt_template found for parameter '{name}'. Using default template.")
+                self._missing_template_warnings.add(name)
+            return template
+        return self.reflection_prompt_template
+
+    def reflect(
+        self,
+        candidate: dict[str, str],
+        reflective_dataset: Mapping[str, Sequence[Mapping[str, Any]]],
+        components_to_update: list[str],
+    ) -> tuple[ReflectionProposal, StatelessReflectionLM]:
+        new_texts: dict[str, str] = {}
+        prompts: dict[str, str | list[dict[str, Any]]] = {}
+        raw_lm_outputs: dict[str, str] = {}
+        for name in components_to_update:
+            # Gracefully handle a selected component with no data in the reflective dataset.
+            if name not in reflective_dataset or not reflective_dataset.get(name):
+                self._log(f"Component '{name}' is not in reflective dataset. Skipping.")
+                continue
+
+            result, prompt, raw_output = InstructionProposalSignature.run_with_metadata(
+                lm=self.lm,
+                input_dict={
+                    "current_instruction_doc": candidate[name],
+                    "dataset_with_feedback": reflective_dataset[name],
+                    "prompt_template": self._resolve_template(name),
+                },
+            )
+            new_texts[name] = result["new_instruction"]
+            prompts[name] = prompt
+            raw_lm_outputs[name] = raw_output
+
+        # Stateless: the next LM is this same object (no carried context).
+        return ReflectionProposal(new_texts=new_texts, prompts=prompts, raw_lm_outputs=raw_lm_outputs), self

--- a/src/gepa/proposer/reflective_mutation/reflection_lm.py
+++ b/src/gepa/proposer/reflective_mutation/reflection_lm.py
@@ -19,6 +19,9 @@ from typing import Any, Protocol, runtime_checkable
 from gepa.proposer.reflective_mutation.base import LanguageModel
 from gepa.strategies.instruction_proposal import InstructionProposalSignature
 
+# One reflection job = (candidate, reflective_dataset, components_to_update).
+ReflectionJob = tuple[dict[str, str], "Mapping[str, Sequence[Mapping[str, Any]]]", list[str]]
+
 
 @dataclass
 class ReflectionProposal:
@@ -49,6 +52,23 @@ class ReflectionLM(Protocol):
         reflective_dataset: Mapping[str, Sequence[Mapping[str, Any]]],
         components_to_update: list[str],
     ) -> tuple[ReflectionProposal, ReflectionLM]: ...
+
+
+@runtime_checkable
+class BatchReflectionLM(ReflectionLM, Protocol):
+    """A :class:`ReflectionLM` that can reflect on many jobs in one batched call.
+
+    ``reflect_many`` is the vectorized form of ``reflect``: given N independent
+    jobs (one per candidate proposed this iteration), it returns N
+    ``(proposal, next_lm)`` results in order.  Implementations issue the
+    underlying LLM calls as a single batched/concurrent request (e.g.
+    ``litellm.batch_completion``), so per-iteration proposal throughput comes
+    from one batched call at the reflection edge rather than engine threads.
+
+    ``reflect`` is just the N=1 case and must stay consistent with it.
+    """
+
+    def reflect_many(self, jobs: list[ReflectionJob]) -> list[tuple[ReflectionProposal, ReflectionLM]]: ...
 
 
 class StatelessReflectionLM:
@@ -84,32 +104,67 @@ class StatelessReflectionLM:
             return template
         return self.reflection_prompt_template
 
+    def _render(self, current_instruction_doc: str, dataset_with_feedback: Any, prompt_template: str | None):
+        """Render a reflection prompt and its chat-messages form."""
+        prompt = InstructionProposalSignature.prompt_renderer(
+            {
+                "current_instruction_doc": current_instruction_doc,
+                "dataset_with_feedback": dataset_with_feedback,
+                "prompt_template": prompt_template,
+            }
+        )
+        # Normalize to a chat-messages list (matches gepa.lm.LM.__call__).
+        messages = [{"role": "user", "content": prompt}] if isinstance(prompt, str) else prompt
+        return prompt, messages
+
+    def _batch_complete(self, prompts: list[Any], messages_list: list[list[dict[str, Any]]]) -> list[str]:
+        """Issue the reflection completions, batched when possible.
+
+        A single prompt uses the plain completion path, so N=1 is byte-identical
+        to the historical single reflection.  When the LM exposes
+        ``batch_complete`` (``litellm.batch_completion``), all prompts go out as
+        one concurrent request; a custom callable without it runs sequentially.
+        """
+        if not prompts:
+            return []
+        if len(prompts) == 1:
+            return [self.lm(prompts[0])]
+        batch_complete = getattr(self.lm, "batch_complete", None)
+        if batch_complete is not None:
+            return list(batch_complete(messages_list))
+        return [self.lm(prompt) for prompt in prompts]
+
     def reflect(
         self,
         candidate: dict[str, str],
         reflective_dataset: Mapping[str, Sequence[Mapping[str, Any]]],
         components_to_update: list[str],
     ) -> tuple[ReflectionProposal, StatelessReflectionLM]:
-        new_texts: dict[str, str] = {}
-        prompts: dict[str, str | list[dict[str, Any]]] = {}
-        raw_lm_outputs: dict[str, str] = {}
-        for name in components_to_update:
-            # Gracefully handle a selected component with no data in the reflective dataset.
-            if name not in reflective_dataset or not reflective_dataset.get(name):
-                self._log(f"Component '{name}' is not in reflective dataset. Skipping.")
-                continue
+        # N=1 case of reflect_many — same code path, so behavior is identical.
+        return self.reflect_many([(candidate, reflective_dataset, components_to_update)])[0]
 
-            result, prompt, raw_output = InstructionProposalSignature.run_with_metadata(
-                lm=self.lm,
-                input_dict={
-                    "current_instruction_doc": candidate[name],
-                    "dataset_with_feedback": reflective_dataset[name],
-                    "prompt_template": self._resolve_template(name),
-                },
-            )
-            new_texts[name] = result["new_instruction"]
-            prompts[name] = prompt
-            raw_lm_outputs[name] = raw_output
+    def reflect_many(self, jobs: list[ReflectionJob]) -> list[tuple[ReflectionProposal, StatelessReflectionLM]]:
+        # Flatten every (job, component) with feedback into one list of rendered
+        # prompts, issue them as a single batched completion, then scatter the
+        # parsed results back into one ReflectionProposal per job.
+        rendered: list[tuple[int, str, Any, list[dict[str, Any]]]] = []
+        for job_idx, (candidate, reflective_dataset, components_to_update) in enumerate(jobs):
+            for name in components_to_update:
+                # Gracefully handle a selected component with no data in the reflective dataset.
+                if name not in reflective_dataset or not reflective_dataset.get(name):
+                    self._log(f"Component '{name}' is not in reflective dataset. Skipping.")
+                    continue
+                prompt, messages = self._render(candidate[name], reflective_dataset[name], self._resolve_template(name))
+                rendered.append((job_idx, name, prompt, messages))
+
+        raw_outputs = self._batch_complete([r[2] for r in rendered], [r[3] for r in rendered])
+
+        proposals = [ReflectionProposal(new_texts={}, prompts={}, raw_lm_outputs={}) for _ in jobs]
+        for (job_idx, name, prompt, _messages), raw_output in zip(rendered, raw_outputs, strict=True):
+            new_instruction = InstructionProposalSignature.output_extractor(raw_output.strip())["new_instruction"]
+            proposals[job_idx].new_texts[name] = new_instruction
+            proposals[job_idx].prompts[name] = prompt
+            proposals[job_idx].raw_lm_outputs[name] = raw_output
 
         # Stateless: the next LM is this same object (no carried context).
-        return ReflectionProposal(new_texts=new_texts, prompts=prompts, raw_lm_outputs=raw_lm_outputs), self
+        return [(proposal, self) for proposal in proposals]

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -34,7 +34,7 @@ from gepa.proposer.reflective_mutation.base import (
     LanguageModel,
     ReflectionComponentSelector,
 )
-from gepa.proposer.reflective_mutation.reflection_lm import StatelessReflectionLM
+from gepa.proposer.reflective_mutation.reflection_lm import ReflectionLM, StatelessReflectionLM
 from gepa.strategies.batch_sampler import BatchSampler
 from gepa.strategies.instruction_proposal import InstructionProposalSignature
 from gepa.strategies.proposal_sampling import ProposalTask, SamplingStrategy, SingleMutationSampling
@@ -71,6 +71,7 @@ class ReflectiveMutationProposer:
         custom_candidate_proposer: ProposalFn | None = None,
         callbacks: list[GEPACallback] | None = None,
         sampling_strategy: SamplingStrategy | None = None,
+        reflection_strategy: ReflectionLM | None = None,
     ):
         self.logger = logger
         self.trainset = ensure_loader(trainset)
@@ -94,8 +95,12 @@ class ReflectiveMutationProposer:
         else:
             InstructionProposalSignature.validate_prompt_template(reflection_prompt_template)
 
-        # Reflection LM (#329 Phase 1); None when an adapter/custom proposer owns reflection.
-        self._reflection_lm: StatelessReflectionLM | None = (
+        # Reflection LM (#329 Phase 1); None when an adapter/custom proposer owns
+        # reflection. An injected reflection_strategy — any ReflectionLM
+        # implementation, e.g. session-based or ComBEE-style aggregating
+        # reflectors (#329 Phase 2/3) — takes precedence over the stateless
+        # default built from the raw reflection_lm callable.
+        self._reflection_lm: ReflectionLM | None = reflection_strategy or (
             StatelessReflectionLM(reflection_lm, reflection_prompt_template, logger)
             if reflection_lm is not None
             else None
@@ -139,10 +144,12 @@ class ReflectiveMutationProposer:
     ) -> list[tuple[dict[str, str], dict[str, str | list[dict[str, Any]]], dict[str, str]]]:
         """Propose new texts for many tasks, batching the reflection LM calls.
 
-        Only the built-in stateless reflection path can be batched (one
-        ``litellm.batch_completion`` covering every task/component). When an
-        adapter proposer or custom proposer owns the call, fall back to one
-        invocation per task — their batching, if any, is their concern.
+        ReflectionLM implementations that provide ``reflect_many`` (e.g. the
+        stateless default, which issues one ``litellm.batch_completion``
+        covering every task/component) are batched; implementations that only
+        provide ``reflect()`` are called once per task. When an adapter
+        proposer or custom proposer owns the call, fall back to one invocation
+        per task — their batching, if any, is their concern.
         """
         if (
             self.adapter.propose_new_texts is not None
@@ -151,7 +158,11 @@ class ReflectiveMutationProposer:
         ):
             return [self.propose_new_texts(cand, refds, comps) for cand, refds, comps in jobs]
 
-        results = self._reflection_lm.reflect_many(jobs)
+        reflect_many = getattr(self._reflection_lm, "reflect_many", None)
+        if reflect_many is not None:
+            results = reflect_many(jobs)
+        else:
+            results = [self._reflection_lm.reflect(cand, refds, comps) for cand, refds, comps in jobs]
         return [(proposal.new_texts, proposal.prompts, proposal.raw_lm_outputs) for proposal, _next_lm in results]
 
     def _propose_texts_batch_safe(

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -139,6 +139,50 @@ class ReflectiveMutationProposer:
         proposal, _next_lm = self._reflection_lm.reflect(candidate, reflective_dataset, components_to_update)
         return proposal.new_texts, proposal.prompts, proposal.raw_lm_outputs
 
+    def _propose_texts_batch(
+        self, jobs: list[tuple[dict[str, str], Mapping[str, Sequence[Mapping[str, Any]]], list[str]]]
+    ) -> list[tuple[dict[str, str], dict[str, str | list[dict[str, Any]]], dict[str, str]]]:
+        """Propose new texts for many tasks, batching the reflection LM calls.
+
+        Only the built-in stateless reflection path can be batched (one
+        ``litellm.batch_completion`` covering every task/component). When an
+        adapter proposer or custom proposer owns the call, fall back to one
+        invocation per task — their batching, if any, is their concern.
+        """
+        if (
+            self.adapter.propose_new_texts is not None
+            or self.custom_candidate_proposer is not None
+            or self._reflection_lm is None
+        ):
+            return [self.propose_new_texts(cand, refds, comps) for cand, refds, comps in jobs]
+
+        results = self._reflection_lm.reflect_many(jobs)
+        return [(proposal.new_texts, proposal.prompts, proposal.raw_lm_outputs) for proposal, _next_lm in results]
+
+    def _propose_texts_batch_safe(
+        self, jobs: list[tuple[dict[str, str], Mapping[str, Sequence[Mapping[str, Any]]], list[str]]]
+    ) -> list[tuple[dict[str, str], dict[str, str | list[dict[str, Any]]], dict[str, str]] | None]:
+        """Like :meth:`_propose_texts_batch`, but isolates per-task failures.
+
+        Returns ``None`` in the slot of any task whose reflection raised, so one
+        bad task (or a failed batch) does not sink the whole iteration.
+        """
+        if not jobs:
+            return []
+        try:
+            return list(self._propose_texts_batch(jobs))
+        except Exception as e:
+            self.logger.log(f"Batched reflection failed ({e}); retrying per task.")
+            self.logger.log(traceback.format_exc())
+            out: list[tuple[dict[str, str], dict[str, str | list[dict[str, Any]]], dict[str, str]] | None] = []
+            for cand, refds, comps in jobs:
+                try:
+                    out.append(self.propose_new_texts(cand, refds, comps))
+                except Exception as e2:
+                    self.logger.log(f"Per-task reflection failed: {e2}")
+                    out.append(None)
+            return out
+
     # ------------------------------------------------------------------
     # Batch evaluate helper
     # ------------------------------------------------------------------
@@ -276,14 +320,16 @@ class ReflectiveMutationProposer:
             step=i,
         )
 
-        # Stage 3: Reflect + propose (per task)
-        children: list[tuple[ProposalTask, dict[str, str], EvaluationBatch, dict[str, Any]] | None] = []
+        # Stage 3a: Build reflective datasets + fire pre-reflection callbacks (per task).
+        # ``prepared`` holds one slot per task (None = skipped); ``jobs`` is the
+        # subset that will reflect, in order, so the reflection LM can batch them.
+        prepared: list[tuple[ProposalTask, EvaluationBatch, list[str], Any] | None] = []
         for task, key in zip(tasks, task_to_key, strict=True):
             eval_curr = key_to_eval[key]
 
             if not eval_curr.trajectories:
                 self.logger.log(f"Iteration {i}: No trajectories for parent {task.parent_idx}. Skipping.")
-                children.append(None)
+                prepared.append(None)
                 continue
 
             if (
@@ -292,7 +338,7 @@ class ReflectiveMutationProposer:
                 and all(s is not None and s >= self.perfect_score for s in eval_curr.scores)
             ):
                 self.logger.log(f"Iteration {i}: All subsample scores perfect for parent {task.parent_idx}. Skipping.")
-                children.append(None)
+                prepared.append(None)
                 continue
 
             predictor_names = self.module_selector(
@@ -326,40 +372,57 @@ class ReflectiveMutationProposer:
                         reflective_dataset=reflective_dataset_concrete,
                     ),
                 )
-
-                new_texts, prompts, raw_outputs = self.propose_new_texts(
-                    task.parent_candidate, reflective_dataset, predictor_names
-                )
-
-                notify_callbacks(
-                    self.callbacks,
-                    "on_proposal_end",
-                    ProposalEndEvent(
-                        iteration=i,
-                        new_instructions=new_texts,
-                        prompts=prompts,
-                        raw_lm_outputs=raw_outputs,
-                    ),
-                )
-
-                _lm_metadata: dict[str, Any] = {}
-                for comp in new_texts:
-                    _lm_metadata[f"prompt:{comp}"] = prompts.get(comp, "")
-                    _lm_metadata[f"raw_lm_output:{comp}"] = raw_outputs.get(comp, "")
-
-                for pname, text in new_texts.items():
-                    self.logger.log(f"Iteration {i}: Proposed new text for {pname}: {text}")
-
-                new_candidate = task.parent_candidate.copy()
-                for name, text in new_texts.items():
-                    assert name in new_candidate, f"{name} missing in candidate"
-                    new_candidate[name] = text
-
-                children.append((task, new_candidate, eval_curr, _lm_metadata))
             except Exception as e:
-                self.logger.log(f"Iteration {i}: Exception during reflection/proposal: {e}")
+                self.logger.log(f"Iteration {i}: Exception building reflective dataset: {e}")
                 self.logger.log(traceback.format_exc())
+                prepared.append(None)
+                continue
+
+            prepared.append((task, eval_curr, predictor_names, reflective_dataset))
+
+        # Stage 3b: Reflect across all prepared tasks — one batched LM call when the
+        # reflection LM supports it (litellm.batch_completion), else per task.
+        jobs = [(p[0].parent_candidate, p[3], p[2]) for p in prepared if p is not None]
+        batch_texts = iter(self._propose_texts_batch_safe(jobs))
+
+        # Stage 3c: Build each child candidate from its proposed texts.
+        children: list[tuple[ProposalTask, dict[str, str], EvaluationBatch, dict[str, Any]] | None] = []
+        for p in prepared:
+            if p is None:
                 children.append(None)
+                continue
+            task, eval_curr, _predictor_names, _reflective_dataset = p
+            texts = next(batch_texts)
+            if texts is None:
+                children.append(None)
+                continue
+            new_texts, prompts, raw_outputs = texts
+
+            notify_callbacks(
+                self.callbacks,
+                "on_proposal_end",
+                ProposalEndEvent(
+                    iteration=i,
+                    new_instructions=new_texts,
+                    prompts=prompts,
+                    raw_lm_outputs=raw_outputs,
+                ),
+            )
+
+            _lm_metadata: dict[str, Any] = {}
+            for comp in new_texts:
+                _lm_metadata[f"prompt:{comp}"] = prompts.get(comp, "")
+                _lm_metadata[f"raw_lm_output:{comp}"] = raw_outputs.get(comp, "")
+
+            for pname, text in new_texts.items():
+                self.logger.log(f"Iteration {i}: Proposed new text for {pname}: {text}")
+
+            new_candidate = task.parent_candidate.copy()
+            for name, text in new_texts.items():
+                assert name in new_candidate, f"{name} missing in candidate"
+                new_candidate[name] = text
+
+            children.append((task, new_candidate, eval_curr, _lm_metadata))
 
         # Stage 4: Batch evaluate children
         valid_children = [(idx, c) for idx, c in enumerate(children) if c is not None]

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -97,6 +97,19 @@ class ReflectiveMutationProposer:
         else:
             InstructionProposalSignature.validate_prompt_template(reflection_prompt_template)
 
+        if reflection_strategy is not None and (
+            adapter.propose_new_texts is not None or custom_candidate_proposer is not None
+        ):
+            owner = (
+                "adapter.propose_new_texts"
+                if adapter.propose_new_texts is not None
+                else "custom_candidate_proposer"
+            )
+            raise ValueError(
+                f"reflection_strategy was provided, but {owner} owns proposal generation "
+                "and the reflection strategy would be silently ignored. Remove one of the two."
+            )
+
         # Reflection LM (#329 Phase 1); None when an adapter/custom proposer owns
         # reflection. An injected reflection_strategy — any ReflectionLM
         # implementation, e.g. session-based or ComBEE-style aggregating
@@ -119,19 +132,22 @@ class ReflectiveMutationProposer:
         candidate: dict[str, str],
         reflective_dataset: Mapping[str, Sequence[Mapping[str, Any]]],
         components_to_update: list[str],
-    ) -> tuple[dict[str, str], dict[str, str | list[dict[str, Any]]], dict[str, str]]:
+    ) -> tuple[dict[str, str], dict[str, str | list[dict[str, Any]]], dict[str, str], dict[str, Any]]:
         """Propose new instruction texts for the given components.
 
         Returns:
-            A tuple of (new_texts, prompts, raw_lm_outputs) where each is a
-            dict keyed by component name.
+            A tuple of (new_texts, prompts, raw_lm_outputs, reflection_metadata)
+            where the first three are dicts keyed by component name and
+            ``reflection_metadata`` is the ReflectionLM's free-form diagnostics
+            (empty for single-call reflectors; multi-call strategies such as
+            ComBEE record per-call intermediates here).
         """
         empty: dict[str, str | list[dict[str, Any]]] = {}
         if self.adapter.propose_new_texts is not None:
-            return self.adapter.propose_new_texts(candidate, reflective_dataset, components_to_update), empty, {}
+            return self.adapter.propose_new_texts(candidate, reflective_dataset, components_to_update), empty, {}, {}
 
         if self.custom_candidate_proposer is not None:
-            return self.custom_candidate_proposer(candidate, reflective_dataset, components_to_update), empty, {}
+            return self.custom_candidate_proposer(candidate, reflective_dataset, components_to_update), empty, {}, {}
 
         if self._reflection_lm is None:
             raise ValueError("reflection_lm must be provided when adapter.propose_new_texts is None.")
@@ -139,11 +155,11 @@ class ReflectiveMutationProposer:
         # Delegate to the ReflectionLM (#329 Phase 1). The stateless default
         # returns itself as next_lm, so we ignore it; a later phase pools it.
         proposal, _next_lm = self._reflection_lm.reflect(candidate, reflective_dataset, components_to_update)
-        return proposal.new_texts, proposal.prompts, proposal.raw_lm_outputs
+        return proposal.new_texts, proposal.prompts, proposal.raw_lm_outputs, proposal.metadata
 
     def _propose_texts_batch(
         self, jobs: list[tuple[dict[str, str], Mapping[str, Sequence[Mapping[str, Any]]], list[str]]]
-    ) -> list[tuple[dict[str, str], dict[str, str | list[dict[str, Any]]], dict[str, str]]]:
+    ) -> list[tuple[dict[str, str], dict[str, str | list[dict[str, Any]]], dict[str, str], dict[str, Any]]]:
         """Propose new texts for many tasks, batching the reflection LM calls.
 
         ReflectionLM implementations that provide ``reflect_many`` (e.g. the
@@ -165,11 +181,14 @@ class ReflectiveMutationProposer:
             results = reflect_many(jobs)
         else:
             results = [self._reflection_lm.reflect(cand, refds, comps) for cand, refds, comps in jobs]
-        return [(proposal.new_texts, proposal.prompts, proposal.raw_lm_outputs) for proposal, _next_lm in results]
+        return [
+            (proposal.new_texts, proposal.prompts, proposal.raw_lm_outputs, proposal.metadata)
+            for proposal, _next_lm in results
+        ]
 
     def _propose_texts_batch_safe(
         self, jobs: list[tuple[dict[str, str], Mapping[str, Sequence[Mapping[str, Any]]], list[str]]]
-    ) -> list[tuple[dict[str, str], dict[str, str | list[dict[str, Any]]], dict[str, str]] | None]:
+    ) -> list[tuple[dict[str, str], dict[str, str | list[dict[str, Any]]], dict[str, str], dict[str, Any]] | None]:
         """Like :meth:`_propose_texts_batch`, but isolates per-task failures.
 
         Returns ``None`` in the slot of any task whose reflection raised, so one
@@ -182,7 +201,7 @@ class ReflectiveMutationProposer:
         except Exception as e:
             self.logger.log(f"Batched reflection failed ({e}); retrying per task.")
             self.logger.log(traceback.format_exc())
-            out: list[tuple[dict[str, str], dict[str, str | list[dict[str, Any]]], dict[str, str]] | None] = []
+            out: list[tuple[dict[str, str], dict[str, str | list[dict[str, Any]]], dict[str, str], dict[str, Any]] | None] = []
             for cand, refds, comps in jobs:
                 try:
                     out.append(self.propose_new_texts(cand, refds, comps))
@@ -311,10 +330,17 @@ class ReflectiveMutationProposer:
                     objective_scores_list,
                 )
 
-        # Log first task's selection (for trace compatibility)
+        # Trace: legacy first-task keys (pre-#329 tooling compatibility) plus
+        # full per-task records — multi-task iterations record every task, not
+        # just the first. Tasks that get skipped later simply never receive
+        # score keys.
         first_task = tasks[0]
         state.full_program_trace[-1]["selected_program_candidate"] = first_task.parent_idx
         state.full_program_trace[-1]["subsample_ids"] = first_task.minibatch_ids
+        state.full_program_trace[-1]["n_tasks"] = len(tasks)
+        state.full_program_trace[-1]["tasks"] = [
+            {"parent_idx": task.parent_idx, "subsample_ids": list(task.minibatch_ids)} for task in tasks
+        ]
         self.logger.log(
             f"Iteration {i}: Selected program {first_task.parent_idx} "
             f"score: {state.program_full_scores_val_set[first_task.parent_idx]}"
@@ -427,7 +453,7 @@ class ReflectiveMutationProposer:
             if texts is None:
                 children.append(None)
                 continue
-            new_texts, prompts, raw_outputs = texts
+            new_texts, prompts, raw_outputs, reflection_metadata = texts
 
             if not new_texts:
                 # Reflection produced no text updates (e.g. every requested
@@ -456,6 +482,11 @@ class ReflectiveMutationProposer:
             for comp in new_texts:
                 _lm_metadata[f"prompt:{comp}"] = prompts.get(comp, "")
                 _lm_metadata[f"raw_lm_output:{comp}"] = raw_outputs.get(comp, "")
+            # Multi-call reflection diagnostics (e.g. ComBEE per-call
+            # intermediates) flow into the proposal metadata for callbacks,
+            # trackers, and the run manifest.
+            if reflection_metadata:
+                _lm_metadata.update(reflection_metadata)
 
             for pname, text in new_texts.items():
                 self.logger.log(f"Iteration {i}: Proposed new text for {pname}: {text}")
@@ -526,6 +557,13 @@ class ReflectiveMutationProposer:
                 state.evaluation_cache.put_batch(
                     new_candidate, task.minibatch_ids, child_eval.outputs, child_eval.scores, new_obj_scores
                 )
+
+        # Trace: per-task before/after scores (children is index-aligned with tasks)
+        trace_tasks = state.full_program_trace[-1].get("tasks")
+        if trace_tasks is not None:
+            for (child_idx, (_task, _nc, eval_curr, _md)), child_eval in zip(valid_children, child_evals, strict=True):
+                trace_tasks[child_idx]["subsample_scores"] = list(eval_curr.scores)
+                trace_tasks[child_idx]["new_subsample_scores"] = list(child_eval.scores)
 
         # Log subsample scores for first task (trace compatibility)
         if valid_children:

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -27,6 +27,7 @@ from gepa.proposer.reflective_mutation.base import (
     LanguageModel,
     ReflectionComponentSelector,
 )
+from gepa.proposer.reflective_mutation.reflection_lm import StatelessReflectionLM
 from gepa.strategies.batch_sampler import BatchSampler
 from gepa.strategies.instruction_proposal import InstructionProposalSignature
 
@@ -102,14 +103,19 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
         self._lock = threading.Lock()
 
         self.reflection_prompt_template = reflection_prompt_template
-        # Track parameters for which we've already logged missing template warnings
-        self._missing_template_warnings: set[str] = set()
 
         if isinstance(reflection_prompt_template, dict):
             for _param_name, template in reflection_prompt_template.items():
                 InstructionProposalSignature.validate_prompt_template(template)
         else:
             InstructionProposalSignature.validate_prompt_template(reflection_prompt_template)
+
+        # Reflection LM (#329 Phase 1); None when an adapter/custom proposer owns reflection.
+        self._reflection_lm: StatelessReflectionLM | None = (
+            StatelessReflectionLM(reflection_lm, reflection_prompt_template, logger)
+            if reflection_lm is not None
+            else None
+        )
 
         if self.skip_perfect_score and self.perfect_score is None:
             raise ValueError(
@@ -137,47 +143,13 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
         if self.custom_candidate_proposer is not None:
             return self.custom_candidate_proposer(candidate, reflective_dataset, components_to_update), empty, {}
 
-        if self.reflection_lm is None:
+        if self._reflection_lm is None:
             raise ValueError("reflection_lm must be provided when adapter.propose_new_texts is None.")
 
-        new_texts: dict[str, str] = {}
-        prompts: dict[str, str | list[dict[str, Any]]] = {}
-        raw_lm_outputs: dict[str, str] = {}
-        for name in components_to_update:
-            # Gracefully handle cases where a selected component has no data in reflective_dataset
-            if name not in reflective_dataset or not reflective_dataset.get(name):
-                self.logger.log(f"Component '{name}' is not in reflective dataset. Skipping.")
-                continue
-
-            base_instruction = candidate[name]
-            dataset_with_feedback = reflective_dataset[name]
-
-            # Determine which prompt template to use for this parameter
-            prompt_template = None
-            if isinstance(self.reflection_prompt_template, dict):
-                # Use parameter-specific template if available
-                prompt_template = self.reflection_prompt_template.get(name)
-                if prompt_template is None and name not in self._missing_template_warnings:
-                    self.logger.log(
-                        f"No reflection_prompt_template found for parameter '{name}'. Using default template."
-                    )
-                    self._missing_template_warnings.add(name)
-            else:
-                # Use the single template for all parameters
-                prompt_template = self.reflection_prompt_template
-
-            result, prompt, raw_output = InstructionProposalSignature.run_with_metadata(
-                lm=self.reflection_lm,
-                input_dict={
-                    "current_instruction_doc": base_instruction,
-                    "dataset_with_feedback": dataset_with_feedback,
-                    "prompt_template": prompt_template,
-                },
-            )
-            new_texts[name] = result["new_instruction"]
-            prompts[name] = prompt
-            raw_lm_outputs[name] = raw_output
-        return new_texts, prompts, raw_lm_outputs
+        # Delegate to the ReflectionLM (#329 Phase 1). The stateless default
+        # returns itself as next_lm, so we ignore it; a later phase pools it.
+        proposal, _next_lm = self._reflection_lm.reflect(candidate, reflective_dataset, components_to_update)
+        return proposal.new_texts, proposal.prompts, proposal.raw_lm_outputs
 
     def prepare_proposal(self, state: GEPAState) -> ProposalContext:
         """Select parent candidate and sample minibatch. Must be called sequentially.
@@ -338,7 +310,9 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
 
         # 3) Build reflective dataset and propose new content
         try:
-            reflective_dataset = self.adapter.make_reflective_dataset(ctx.curr_prog, eval_curr, predictor_names_to_update)
+            reflective_dataset = self.adapter.make_reflective_dataset(
+                ctx.curr_prog, eval_curr, predictor_names_to_update
+            )
 
             reflective_dataset_concrete: dict[str, list[dict[str, Any]]] = {
                 k: [dict(item) for item in v] for k, v in reflective_dataset.items()
@@ -420,7 +394,9 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
         eval_after = self.adapter.evaluate(ctx.minibatch, new_candidate, capture_traces=True)
         new_scores = eval_after.scores
         new_outputs = eval_after.outputs
-        total_evals += eval_after.num_metric_calls if eval_after.num_metric_calls is not None else len(ctx.subsample_ids)
+        total_evals += (
+            eval_after.num_metric_calls if eval_after.num_metric_calls is not None else len(ctx.subsample_ids)
+        )
 
         notify_callbacks(
             self.callbacks,
@@ -440,9 +416,7 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
 
         trace_data["new_subsample_scores"] = new_scores
         new_sum = sum(new_scores)
-        self.experiment_tracker.log_metrics(
-            {"new_subsample_score": new_sum, "total_metric_calls": total_evals}, step=i
-        )
+        self.experiment_tracker.log_metrics({"new_subsample_score": new_sum, "total_metric_calls": total_evals}, step=i)
 
         proposal = CandidateProposal(
             candidate=new_candidate,
@@ -465,7 +439,9 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
             tag="reflective_mutation",
             metadata=_lm_metadata,
         )
-        return ProposalOutput(proposal=proposal, total_evals=total_evals, trace_data=trace_data, cache_entry=cache_entry)
+        return ProposalOutput(
+            proposal=proposal, total_evals=total_evals, trace_data=trace_data, cache_entry=cache_entry
+        )
 
     def apply_proposal_output(self, output: ProposalOutput, state: GEPAState) -> None:
         """Apply deferred state updates from a proposal. Must be called sequentially."""
@@ -481,10 +457,12 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
         :meth:`apply_proposal_output`.
         """
         ctx = self.prepare_proposal(state)
-        state.full_program_trace[-1].update({
-            "selected_program_candidate": ctx.curr_prog_id,
-            "subsample_ids": ctx.subsample_ids,
-        })
+        state.full_program_trace[-1].update(
+            {
+                "selected_program_candidate": ctx.curr_prog_id,
+                "subsample_ids": ctx.subsample_ids,
+            }
+        )
         return self.execute_proposal(ctx, state)
 
     def propose(self, state: GEPAState) -> CandidateProposal | None:

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -49,7 +49,9 @@ class ReflectiveMutationProposer:
     2. Batch-evaluates all parents (deduplicated)
     3. For each task: builds a reflective dataset and proposes new texts
     4. Batch-evaluates all children
-    5. Filters proposals via ``selection_strategy`` + ``acceptance_criterion``
+    5. Returns ALL evaluated proposals as :class:`CandidateProposal` objects —
+       acceptance and selection are applied by the engine, which is the single
+       accept+select authority
 
     With the default ``SingleMutationSampling``, this produces exactly one
     task per iteration — matching GEPA's original sequential behavior.
@@ -426,6 +428,18 @@ class ReflectiveMutationProposer:
                 children.append(None)
                 continue
             new_texts, prompts, raw_outputs = texts
+
+            if not new_texts:
+                # Reflection produced no text updates (e.g. every requested
+                # component was missing from the reflective dataset). A child
+                # would be byte-identical to its parent: don't burn minibatch
+                # metric calls evaluating it or emit proposal/rejection events
+                # for a proposal that never happened.
+                self.logger.log(
+                    f"Iteration {i}: Reflection returned no text updates; skipping proposal for this task."
+                )
+                children.append(None)
+                continue
 
             notify_callbacks(
                 self.callbacks,

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -493,6 +493,10 @@ class ReflectiveMutationProposer:
             )
 
             _lm_metadata: dict[str, Any] = {}
+            # Stable per-proposal identifier (iteration-taskindex): downstream
+            # consumers (run manifests, #346's per-proposal state anchors) can
+            # key on this instead of positional inference.
+            _lm_metadata["proposal_id"] = f"{i}-{len(children)}"
             for comp in new_texts:
                 _lm_metadata[f"prompt:{comp}"] = prompts.get(comp, "")
                 _lm_metadata[f"raw_lm_output:{comp}"] = raw_outputs.get(comp, "")

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -1,16 +1,22 @@
 # Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
 # https://github.com/gepa-ai/gepa
 
-import threading
+import traceback
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
 from typing import Any
 
-from gepa.core.adapter import DataInst, GEPAAdapter, ProposalFn, RolloutOutput, Trajectory
+from gepa.core.adapter import (
+    DataInst,
+    EvaluationBatch,
+    GEPAAdapter,
+    ProposalFn,
+    RolloutOutput,
+    Trajectory,
+    default_batch_evaluate,
+)
 from gepa.core.callbacks import (
     CandidateSelectedEvent,
     EvaluationEndEvent,
-    EvaluationSkippedEvent,
     EvaluationStartEvent,
     GEPACallback,
     MinibatchSampledEvent,
@@ -20,56 +26,34 @@ from gepa.core.callbacks import (
     notify_callbacks,
 )
 from gepa.core.data_loader import DataId, DataLoader, ensure_loader
-from gepa.core.state import GEPAState
-from gepa.proposer.base import CandidateProposal, ProposeNewCandidate, SubsampleEvaluation
+from gepa.core.state import GEPAState, _candidate_hash
+from gepa.proposer.base import CandidateProposal, SubsampleEvaluation
 from gepa.proposer.reflective_mutation.base import (
     CandidateSelector,
     LanguageModel,
     ReflectionComponentSelector,
 )
 from gepa.proposer.reflective_mutation.reflection_lm import StatelessReflectionLM
+from gepa.strategies.acceptance import AcceptanceCriterion, StrictImprovementAcceptance
 from gepa.strategies.batch_sampler import BatchSampler
 from gepa.strategies.instruction_proposal import InstructionProposalSignature
+from gepa.strategies.proposal_sampling import ProposalTask, SamplingStrategy, SingleMutationSampling
+from gepa.strategies.proposal_selection import AllImprovements, SelectionStrategy
 
 
-@dataclass
-class ProposalContext:
-    """Pre-sampled context for a single proposal worker.
-
-    Created by :meth:`ReflectiveMutationProposer.prepare_proposal` (sequential),
-    then consumed by :meth:`ReflectiveMutationProposer.execute_proposal` (parallel-safe).
-    """
-
-    iteration: int
-    curr_prog_id: int
-    curr_prog: dict[str, str]
-    curr_prog_score: float
-    subsample_ids: list
-    minibatch: list
-    parent_ids: list[int]
-    is_seed_candidate: bool
-
-
-@dataclass
-class ProposalOutput:
-    """Result from :meth:`ReflectiveMutationProposer.execute_proposal`.
-
-    Contains the proposal plus deferred state updates that must be applied
-    sequentially via :meth:`ReflectiveMutationProposer.apply_proposal_output`.
-    """
-
-    proposal: CandidateProposal | None
-    total_evals: int
-    trace_data: dict[str, Any] = field(default_factory=dict)
-    cache_entry: tuple | None = None
-
-
-class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
+class ReflectiveMutationProposer:
     """Implements the reflective mutation flow.
 
-    Supports parallel execution: call :meth:`prepare_proposal` sequentially,
-    then :meth:`execute_proposal` from multiple threads, then
-    :meth:`apply_proposal_output` sequentially.
+    Each iteration, the proposer:
+
+    1. Samples one or more (parent, minibatch) tasks via ``sampling_strategy``
+    2. Batch-evaluates all parents (deduplicated)
+    3. For each task: builds a reflective dataset and proposes new texts
+    4. Batch-evaluates all children
+    5. Filters proposals via ``selection_strategy`` + ``acceptance_criterion``
+
+    With the default ``SingleMutationSampling``, this produces exactly one
+    task per iteration — matching GEPA's original sequential behavior.
     """
 
     def __init__(
@@ -87,6 +71,9 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
         reflection_prompt_template: str | dict[str, str] | None = None,
         custom_candidate_proposer: ProposalFn | None = None,
         callbacks: list[GEPACallback] | None = None,
+        acceptance_criterion: AcceptanceCriterion | None = None,
+        sampling_strategy: SamplingStrategy | None = None,
+        selection_strategy: SelectionStrategy | None = None,
     ):
         self.logger = logger
         self.trainset = ensure_loader(trainset)
@@ -100,7 +87,9 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
         self.reflection_lm = reflection_lm
         self.custom_candidate_proposer = custom_candidate_proposer
         self.callbacks = callbacks
-        self._lock = threading.Lock()
+        self.acceptance_criterion: AcceptanceCriterion = acceptance_criterion or StrictImprovementAcceptance()
+        self.sampling_strategy: SamplingStrategy = sampling_strategy or SingleMutationSampling()
+        self.selection_strategy: SelectionStrategy = selection_strategy or AllImprovements()
 
         self.reflection_prompt_template = reflection_prompt_template
 
@@ -133,8 +122,7 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
 
         Returns:
             A tuple of (new_texts, prompts, raw_lm_outputs) where each is a
-            dict keyed by component name.  When the adapter or a custom proposer
-            handles the call, prompts and raw_lm_outputs are empty dicts.
+            dict keyed by component name.
         """
         empty: dict[str, str | list[dict[str, Any]]] = {}
         if self.adapter.propose_new_texts is not None:
@@ -151,327 +139,295 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
         proposal, _next_lm = self._reflection_lm.reflect(candidate, reflective_dataset, components_to_update)
         return proposal.new_texts, proposal.prompts, proposal.raw_lm_outputs
 
-    def prepare_proposal(self, state: GEPAState) -> ProposalContext:
-        """Select parent candidate and sample minibatch. Must be called sequentially.
+    # ------------------------------------------------------------------
+    # Batch evaluate helper
+    # ------------------------------------------------------------------
 
-        Performs the state-dependent, non-parallelizable parts of a proposal:
-        candidate selection, minibatch sampling, and callback notifications
-        that should fire in order.
+    def _batch_evaluate(self, items: list[tuple[dict[str, str], list]]) -> list[EvaluationBatch]:
+        """Evaluate (candidate, batch) pairs via the adapter's batch_evaluate or fallback."""
+        batch_fn = getattr(self.adapter, "batch_evaluate", None)
+        if batch_fn is not None:
+            return batch_fn(items)
+        return default_batch_evaluate(self.adapter, items)
+
+    # ------------------------------------------------------------------
+    # Main proposal method
+    # ------------------------------------------------------------------
+
+    def propose(self, state: GEPAState) -> list[CandidateProposal]:
+        """Run the reflective mutation pipeline and return accepted proposals.
+
+        With the default ``SingleMutationSampling`` + ``AllImprovements``,
+        this returns 0 or 1 proposals — identical to the original sequential
+        behavior.
         """
         i = state.i + 1
 
-        curr_prog_id = self.candidate_selector.select_candidate_idx(state)
-        curr_prog = state.program_candidates[curr_prog_id]
-        curr_prog_score = state.program_full_scores_val_set[curr_prog_id]
-        self.logger.log(f"Iteration {i}: Selected program {curr_prog_id} score: {curr_prog_score}")
+        # Stage 1: Sample (parent, minibatch) tasks
+        tasks = self.sampling_strategy.sample_tasks(state, self.candidate_selector, self.batch_sampler, self.trainset)
+        if not tasks:
+            return []
 
-        notify_callbacks(
-            self.callbacks,
-            "on_candidate_selected",
-            CandidateSelectedEvent(
-                iteration=i,
-                candidate_idx=curr_prog_id,
-                candidate=curr_prog,
-                score=curr_prog_score,
-            ),
+        # Fire callbacks for each sampled task
+        for task in tasks:
+            notify_callbacks(
+                self.callbacks,
+                "on_candidate_selected",
+                CandidateSelectedEvent(
+                    iteration=i,
+                    candidate_idx=task.parent_idx,
+                    candidate=task.parent_candidate,
+                    score=state.program_full_scores_val_set[task.parent_idx],
+                ),
+            )
+            notify_callbacks(
+                self.callbacks,
+                "on_minibatch_sampled",
+                MinibatchSampledEvent(
+                    iteration=i,
+                    minibatch_ids=task.minibatch_ids,
+                    trainset_size=len(self.trainset),
+                ),
+            )
+
+        # Stage 2: Batch evaluate parents (deduplicated)
+        unique_keys: dict[tuple[str, tuple], tuple[dict[str, str], list[Any]]] = {}
+        task_to_key: list[tuple[str, tuple]] = []
+        for task in tasks:
+            key = (_candidate_hash(task.parent_candidate), tuple(task.minibatch_ids))
+            unique_keys.setdefault(key, (task.parent_candidate, task.minibatch))
+            task_to_key.append(key)
+
+        key_list = list(unique_keys.keys())
+        items = [unique_keys[k] for k in key_list]
+
+        # Fire evaluation start callbacks for each task
+        for task in tasks:
+            notify_callbacks(
+                self.callbacks,
+                "on_evaluation_start",
+                EvaluationStartEvent(
+                    iteration=i,
+                    candidate_idx=task.parent_idx,
+                    batch_size=len(task.minibatch),
+                    capture_traces=True,
+                    parent_ids=[p for p in state.parent_program_for_candidate[task.parent_idx] if p is not None],
+                    inputs=task.minibatch,
+                    is_seed_candidate=task.parent_idx == 0,
+                ),
+            )
+
+        parent_evals = self._batch_evaluate(items)
+        key_to_eval: dict[tuple[str, tuple], EvaluationBatch] = dict(zip(key_list, parent_evals, strict=True))
+
+        # Fire evaluation end callbacks for each task
+        for task, key in zip(tasks, task_to_key, strict=True):
+            eval_curr = key_to_eval[key]
+            notify_callbacks(
+                self.callbacks,
+                "on_evaluation_end",
+                EvaluationEndEvent(
+                    iteration=i,
+                    candidate_idx=task.parent_idx,
+                    scores=eval_curr.scores,
+                    has_trajectories=bool(eval_curr.trajectories),
+                    parent_ids=[p for p in state.parent_program_for_candidate[task.parent_idx] if p is not None],
+                    outputs=eval_curr.outputs,
+                    trajectories=eval_curr.trajectories,
+                    objective_scores=eval_curr.objective_scores,
+                    is_seed_candidate=task.parent_idx == 0,
+                ),
+            )
+
+        total_parent_evals = sum(
+            e.num_metric_calls if e.num_metric_calls is not None else len(items[idx][1])
+            for idx, e in enumerate(parent_evals)
+        )
+        state.increment_evals(total_parent_evals)
+
+        # Update evaluation cache for parents
+        if state.evaluation_cache is not None:
+            for task, key in zip(tasks, task_to_key, strict=True):
+                eval_curr = key_to_eval[key]
+                objective_scores_list = list(eval_curr.objective_scores) if eval_curr.objective_scores else None
+                state.evaluation_cache.put_batch(
+                    task.parent_candidate,
+                    task.minibatch_ids,
+                    eval_curr.outputs,
+                    eval_curr.scores,
+                    objective_scores_list,
+                )
+
+        # Log first task's selection (for trace compatibility)
+        first_task = tasks[0]
+        state.full_program_trace[-1]["selected_program_candidate"] = first_task.parent_idx
+        state.full_program_trace[-1]["subsample_ids"] = first_task.minibatch_ids
+        self.logger.log(
+            f"Iteration {i}: Selected program {first_task.parent_idx} "
+            f"score: {state.program_full_scores_val_set[first_task.parent_idx]}"
         )
 
         self.experiment_tracker.log_metrics(
-            {"iteration": i, "selected_program_candidate": curr_prog_id, "total_metric_calls": state.total_num_evals},
+            {
+                "iteration": i,
+                "selected_program_candidate": first_task.parent_idx,
+                "total_metric_calls": state.total_num_evals,
+            },
             step=i,
         )
 
-        subsample_ids = self.batch_sampler.next_minibatch_ids(self.trainset, state)
-        minibatch = self.trainset.fetch(subsample_ids)
+        # Stage 3: Reflect + propose (per task)
+        children: list[tuple[ProposalTask, dict[str, str], EvaluationBatch, dict[str, Any]] | None] = []
+        for task, key in zip(tasks, task_to_key, strict=True):
+            eval_curr = key_to_eval[key]
 
-        notify_callbacks(
-            self.callbacks,
-            "on_minibatch_sampled",
-            MinibatchSampledEvent(
-                iteration=i,
-                minibatch_ids=subsample_ids,
-                trainset_size=len(self.trainset),
-            ),
-        )
+            if not eval_curr.trajectories:
+                self.logger.log(f"Iteration {i}: No trajectories for parent {task.parent_idx}. Skipping.")
+                children.append(None)
+                continue
 
-        curr_parent_ids = [p for p in state.parent_program_for_candidate[curr_prog_id] if p is not None]
-        is_seed_candidate = curr_prog_id == 0
+            if (
+                self.skip_perfect_score
+                and self.perfect_score is not None
+                and all(s is not None and s >= self.perfect_score for s in eval_curr.scores)
+            ):
+                self.logger.log(f"Iteration {i}: All subsample scores perfect for parent {task.parent_idx}. Skipping.")
+                children.append(None)
+                continue
 
-        return ProposalContext(
-            iteration=i,
-            curr_prog_id=curr_prog_id,
-            curr_prog=curr_prog,
-            curr_prog_score=curr_prog_score,
-            subsample_ids=subsample_ids,
-            minibatch=minibatch,
-            parent_ids=curr_parent_ids,
-            is_seed_candidate=is_seed_candidate,
-        )
-
-    def execute_proposal(self, ctx: ProposalContext, state: GEPAState) -> ProposalOutput:
-        """Run the evaluation + proposal pipeline. Safe for parallel execution.
-
-        The only state mutation is the module_selector (e.g. RoundRobin counter),
-        which is protected by a lock. All other state updates are deferred to
-        :meth:`apply_proposal_output`.
-        """
-        i = ctx.iteration
-        trace_data: dict[str, Any] = {
-            "selected_program_candidate": ctx.curr_prog_id,
-            "subsample_ids": ctx.subsample_ids,
-        }
-        total_evals = 0
-        cache_entry = None
-
-        # 1) Evaluate current program with traces
-        notify_callbacks(
-            self.callbacks,
-            "on_evaluation_start",
-            EvaluationStartEvent(
-                iteration=i,
-                candidate_idx=ctx.curr_prog_id,
-                batch_size=len(ctx.minibatch),
-                capture_traces=True,
-                parent_ids=ctx.parent_ids,
-                inputs=ctx.minibatch,
-                is_seed_candidate=ctx.is_seed_candidate,
-            ),
-        )
-        eval_curr = self.adapter.evaluate(ctx.minibatch, ctx.curr_prog, capture_traces=True)
-        total_evals += eval_curr.num_metric_calls if eval_curr.num_metric_calls is not None else len(ctx.subsample_ids)
-        trace_data["subsample_scores"] = eval_curr.scores
-        notify_callbacks(
-            self.callbacks,
-            "on_evaluation_end",
-            EvaluationEndEvent(
-                iteration=i,
-                candidate_idx=ctx.curr_prog_id,
-                scores=eval_curr.scores,
-                has_trajectories=bool(eval_curr.trajectories),
-                parent_ids=ctx.parent_ids,
-                outputs=eval_curr.outputs,
-                trajectories=eval_curr.trajectories,
-                objective_scores=eval_curr.objective_scores,
-                is_seed_candidate=ctx.is_seed_candidate,
-            ),
-        )
-
-        # Prepare cache entry for parent evaluation
-        objective_scores_list = list(eval_curr.objective_scores) if eval_curr.objective_scores else None
-        cache_entry = (ctx.curr_prog, ctx.subsample_ids, eval_curr.outputs, eval_curr.scores, objective_scores_list)
-
-        if not eval_curr.trajectories or len(eval_curr.trajectories) == 0:
-            self.logger.log(f"Iteration {i}: No trajectories captured. Skipping.")
-            notify_callbacks(
-                self.callbacks,
-                "on_evaluation_skipped",
-                EvaluationSkippedEvent(
-                    iteration=i,
-                    candidate_idx=ctx.curr_prog_id,
-                    reason="no_trajectories",
-                    scores=eval_curr.scores,
-                    is_seed_candidate=ctx.is_seed_candidate,
-                ),
-            )
-            return ProposalOutput(
-                proposal=None, total_evals=total_evals, trace_data=trace_data, cache_entry=cache_entry
+            predictor_names = self.module_selector(
+                state, eval_curr.trajectories, eval_curr.scores, task.parent_idx, task.parent_candidate
             )
 
-        if (
-            self.skip_perfect_score
-            and self.perfect_score is not None
-            and all(s is not None and s >= self.perfect_score for s in eval_curr.scores)
+            try:
+                reflective_dataset = self.adapter.make_reflective_dataset(
+                    task.parent_candidate, eval_curr, predictor_names
+                )
+                reflective_dataset_concrete: dict[str, list[dict[str, Any]]] = {
+                    k: [dict(item) for item in v] for k, v in reflective_dataset.items()
+                }
+                notify_callbacks(
+                    self.callbacks,
+                    "on_reflective_dataset_built",
+                    ReflectiveDatasetBuiltEvent(
+                        iteration=i,
+                        candidate_idx=task.parent_idx,
+                        components=predictor_names,
+                        dataset=reflective_dataset_concrete,
+                    ),
+                )
+                notify_callbacks(
+                    self.callbacks,
+                    "on_proposal_start",
+                    ProposalStartEvent(
+                        iteration=i,
+                        parent_candidate=task.parent_candidate,
+                        components=predictor_names,
+                        reflective_dataset=reflective_dataset_concrete,
+                    ),
+                )
+
+                new_texts, prompts, raw_outputs = self.propose_new_texts(
+                    task.parent_candidate, reflective_dataset, predictor_names
+                )
+
+                notify_callbacks(
+                    self.callbacks,
+                    "on_proposal_end",
+                    ProposalEndEvent(
+                        iteration=i,
+                        new_instructions=new_texts,
+                        prompts=prompts,
+                        raw_lm_outputs=raw_outputs,
+                    ),
+                )
+
+                _lm_metadata: dict[str, Any] = {}
+                for comp in new_texts:
+                    _lm_metadata[f"prompt:{comp}"] = prompts.get(comp, "")
+                    _lm_metadata[f"raw_lm_output:{comp}"] = raw_outputs.get(comp, "")
+
+                for pname, text in new_texts.items():
+                    self.logger.log(f"Iteration {i}: Proposed new text for {pname}: {text}")
+
+                new_candidate = task.parent_candidate.copy()
+                for name, text in new_texts.items():
+                    assert name in new_candidate, f"{name} missing in candidate"
+                    new_candidate[name] = text
+
+                children.append((task, new_candidate, eval_curr, _lm_metadata))
+            except Exception as e:
+                self.logger.log(f"Iteration {i}: Exception during reflection/proposal: {e}")
+                self.logger.log(traceback.format_exc())
+                children.append(None)
+
+        # Stage 4: Batch evaluate children
+        valid_children = [(idx, c) for idx, c in enumerate(children) if c is not None]
+        if not valid_children:
+            return []
+
+        child_items = [(c[1], c[0].minibatch) for _, c in valid_children]
+        child_evals = self._batch_evaluate(child_items)
+
+        total_child_evals = sum(
+            e.num_metric_calls if e.num_metric_calls is not None else len(child_items[idx][1])
+            for idx, e in enumerate(child_evals)
+        )
+        state.increment_evals(total_child_evals)
+
+        # Update evaluation cache for children
+        if state.evaluation_cache is not None:
+            for (_, (task, new_candidate, _, _)), child_eval in zip(valid_children, child_evals, strict=True):
+                new_obj_scores = list(child_eval.objective_scores) if child_eval.objective_scores else None
+                state.evaluation_cache.put_batch(
+                    new_candidate, task.minibatch_ids, child_eval.outputs, child_eval.scores, new_obj_scores
+                )
+
+        # Log subsample scores for first task (trace compatibility)
+        if valid_children:
+            first_child_idx = valid_children[0][0]
+            first_child = children[first_child_idx]
+            if first_child is not None:
+                state.full_program_trace[-1]["subsample_scores"] = key_to_eval[task_to_key[first_child_idx]].scores
+                state.full_program_trace[-1]["new_subsample_scores"] = child_evals[0].scores
+
+                subsample_before = sum(key_to_eval[task_to_key[first_child_idx]].scores)
+                subsample_after = sum(child_evals[0].scores)
+                self.experiment_tracker.log_metrics(
+                    {
+                        "subsample/before": subsample_before,
+                        "subsample/after": subsample_after,
+                        "total_metric_calls": state.total_num_evals,
+                    },
+                    step=i,
+                )
+
+        # Stage 5: Build proposals and filter
+        proposals: list[CandidateProposal] = []
+        for (_, (task, new_candidate, eval_curr, _lm_metadata)), child_eval in zip(
+            valid_children, child_evals, strict=True
         ):
-            self.logger.log(f"Iteration {i}: All subsample scores perfect. Skipping.")
-            notify_callbacks(
-                self.callbacks,
-                "on_evaluation_skipped",
-                EvaluationSkippedEvent(
-                    iteration=i,
-                    candidate_idx=ctx.curr_prog_id,
-                    reason="all_scores_perfect",
+            proposal = CandidateProposal(
+                candidate=new_candidate,
+                parent_program_ids=[task.parent_idx],
+                subsample_indices=task.minibatch_ids,
+                subsample_scores_before=eval_curr.scores,
+                subsample_scores_after=child_eval.scores,
+                eval_before=SubsampleEvaluation(
                     scores=eval_curr.scores,
-                    is_seed_candidate=ctx.is_seed_candidate,
+                    outputs=eval_curr.outputs,
+                    objective_scores=list(eval_curr.objective_scores) if eval_curr.objective_scores else None,
+                    trajectories=eval_curr.trajectories,
                 ),
-            )
-            return ProposalOutput(
-                proposal=None, total_evals=total_evals, trace_data=trace_data, cache_entry=cache_entry
-            )
-
-        self.experiment_tracker.log_metrics(
-            {"subsample_score": sum(eval_curr.scores), "total_metric_calls": total_evals}, step=i
-        )
-
-        # 2) Decide which components to update (lock protects RoundRobin state mutation)
-        with self._lock:
-            predictor_names_to_update = self.module_selector(
-                state, eval_curr.trajectories, eval_curr.scores, ctx.curr_prog_id, ctx.curr_prog
-            )
-
-        # 3) Build reflective dataset and propose new content
-        try:
-            reflective_dataset = self.adapter.make_reflective_dataset(
-                ctx.curr_prog, eval_curr, predictor_names_to_update
-            )
-
-            reflective_dataset_concrete: dict[str, list[dict[str, Any]]] = {
-                k: [dict(item) for item in v] for k, v in reflective_dataset.items()
-            }
-
-            notify_callbacks(
-                self.callbacks,
-                "on_reflective_dataset_built",
-                ReflectiveDatasetBuiltEvent(
-                    iteration=i,
-                    candidate_idx=ctx.curr_prog_id,
-                    components=predictor_names_to_update,
-                    dataset=reflective_dataset_concrete,
+                eval_after=SubsampleEvaluation(
+                    scores=child_eval.scores,
+                    outputs=child_eval.outputs,
+                    objective_scores=list(child_eval.objective_scores) if child_eval.objective_scores else None,
+                    trajectories=child_eval.trajectories,
                 ),
+                tag="reflective_mutation",
+                metadata=_lm_metadata,
             )
+            proposals.append(proposal)
 
-            notify_callbacks(
-                self.callbacks,
-                "on_proposal_start",
-                ProposalStartEvent(
-                    iteration=i,
-                    parent_candidate=ctx.curr_prog,
-                    components=predictor_names_to_update,
-                    reflective_dataset=reflective_dataset_concrete,
-                ),
-            )
-
-            new_texts, prompts, raw_lm_outputs = self.propose_new_texts(
-                ctx.curr_prog, reflective_dataset, predictor_names_to_update
-            )
-
-            notify_callbacks(
-                self.callbacks,
-                "on_proposal_end",
-                ProposalEndEvent(
-                    iteration=i,
-                    new_instructions=new_texts,
-                    prompts=prompts,
-                    raw_lm_outputs=raw_lm_outputs,
-                ),
-            )
-
-            _lm_metadata: dict[str, Any] = {}
-            for comp in new_texts:
-                _lm_metadata[f"prompt:{comp}"] = prompts.get(comp, "")
-                _lm_metadata[f"raw_lm_output:{comp}"] = raw_lm_outputs.get(comp, "")
-
-            for pname, text in new_texts.items():
-                self.logger.log(f"Iteration {i}: Proposed new text for {pname}: {text}")
-        except Exception as e:
-            self.logger.log(f"Iteration {i}: Exception during reflection/proposal: {e}")
-            import traceback
-
-            self.logger.log(traceback.format_exc())
-            return ProposalOutput(
-                proposal=None, total_evals=total_evals, trace_data=trace_data, cache_entry=cache_entry
-            )
-
-        # 4) Create candidate, evaluate on same minibatch
-        new_candidate = ctx.curr_prog.copy()
-        for pname, text in new_texts.items():
-            assert pname in new_candidate, f"{pname} missing in candidate"
-            new_candidate[pname] = text
-
-        notify_callbacks(
-            self.callbacks,
-            "on_evaluation_start",
-            EvaluationStartEvent(
-                iteration=i,
-                candidate_idx=None,
-                batch_size=len(ctx.minibatch),
-                capture_traces=True,
-                parent_ids=[ctx.curr_prog_id],
-                inputs=ctx.minibatch,
-                is_seed_candidate=False,
-            ),
-        )
-
-        eval_after = self.adapter.evaluate(ctx.minibatch, new_candidate, capture_traces=True)
-        new_scores = eval_after.scores
-        new_outputs = eval_after.outputs
-        total_evals += (
-            eval_after.num_metric_calls if eval_after.num_metric_calls is not None else len(ctx.subsample_ids)
-        )
-
-        notify_callbacks(
-            self.callbacks,
-            "on_evaluation_end",
-            EvaluationEndEvent(
-                iteration=i,
-                candidate_idx=None,
-                scores=new_scores,
-                has_trajectories=bool(eval_after.trajectories),
-                parent_ids=[ctx.curr_prog_id],
-                outputs=new_outputs,
-                trajectories=eval_after.trajectories,
-                objective_scores=eval_after.objective_scores,
-                is_seed_candidate=False,
-            ),
-        )
-
-        trace_data["new_subsample_scores"] = new_scores
-        new_sum = sum(new_scores)
-        self.experiment_tracker.log_metrics({"new_subsample_score": new_sum, "total_metric_calls": total_evals}, step=i)
-
-        proposal = CandidateProposal(
-            candidate=new_candidate,
-            parent_program_ids=[ctx.curr_prog_id],
-            subsample_indices=ctx.subsample_ids,
-            subsample_scores_before=eval_curr.scores,
-            subsample_scores_after=new_scores,
-            eval_before=SubsampleEvaluation(
-                scores=eval_curr.scores,
-                outputs=eval_curr.outputs,
-                objective_scores=list(eval_curr.objective_scores) if eval_curr.objective_scores else None,
-                trajectories=eval_curr.trajectories,
-            ),
-            eval_after=SubsampleEvaluation(
-                scores=new_scores,
-                outputs=new_outputs,
-                objective_scores=list(eval_after.objective_scores) if eval_after.objective_scores else None,
-                trajectories=eval_after.trajectories,
-            ),
-            tag="reflective_mutation",
-            metadata=_lm_metadata,
-        )
-        return ProposalOutput(
-            proposal=proposal, total_evals=total_evals, trace_data=trace_data, cache_entry=cache_entry
-        )
-
-    def apply_proposal_output(self, output: ProposalOutput, state: GEPAState) -> None:
-        """Apply deferred state updates from a proposal. Must be called sequentially."""
-        state.increment_evals(output.total_evals)
-        if output.cache_entry is not None and state.evaluation_cache is not None:
-            candidate, ids, outputs, scores, obj_scores = output.cache_entry
-            state.evaluation_cache.put_batch(candidate, ids, outputs, scores, obj_scores)
-
-    def propose_output(self, state: GEPAState) -> ProposalOutput:
-        """Run a single reflective mutation iteration, returning a :class:`ProposalOutput`.
-
-        The caller is responsible for passing the output to
-        :meth:`apply_proposal_output`.
-        """
-        ctx = self.prepare_proposal(state)
-        state.full_program_trace[-1].update(
-            {
-                "selected_program_candidate": ctx.curr_prog_id,
-                "subsample_ids": ctx.subsample_ids,
-            }
-        )
-        return self.execute_proposal(ctx, state)
-
-    def propose(self, state: GEPAState) -> CandidateProposal | None:
-        """Run a single reflective mutation iteration.
-
-        Convenience method equivalent to :meth:`propose_output` followed by
-        :meth:`apply_proposal_output`.
-        """
-        output = self.propose_output(state)
-        self.apply_proposal_output(output, state)
-        state.full_program_trace[-1].update(output.trace_data)
-        return output.proposal
+        return self.selection_strategy.select(proposals, state, self.acceptance_criterion)

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -152,9 +152,12 @@ class ReflectiveMutationProposer:
         if self._reflection_lm is None:
             raise ValueError("reflection_lm must be provided when adapter.propose_new_texts is None.")
 
-        # Delegate to the ReflectionLM (#329 Phase 1). The stateless default
-        # returns itself as next_lm, so we ignore it; a later phase pools it.
-        proposal, _next_lm = self._reflection_lm.reflect(candidate, reflective_dataset, components_to_update)
+        # Delegate to the ReflectionLM (#329 Phase 1). Stateful implementations
+        # return a successor carrying accumulated context; chain it so session
+        # state actually persists (stateless implementations return self,
+        # making this a no-op).
+        proposal, next_lm = self._reflection_lm.reflect(candidate, reflective_dataset, components_to_update)
+        self._reflection_lm = next_lm
         return proposal.new_texts, proposal.prompts, proposal.raw_lm_outputs, proposal.metadata
 
     def _propose_texts_batch(
@@ -178,9 +181,20 @@ class ReflectiveMutationProposer:
 
         reflect_many = getattr(self._reflection_lm, "reflect_many", None)
         if reflect_many is not None:
-            results = reflect_many(jobs)
+            results = list(reflect_many(jobs))
+            if len(results) != len(jobs):
+                raise ValueError(
+                    f"ReflectionLM.reflect_many returned {len(results)} results for {len(jobs)} jobs"
+                )
         else:
-            results = [self._reflection_lm.reflect(cand, refds, comps) for cand, refds, comps in jobs]
+            results = []
+            for cand, refds, comps in jobs:
+                proposal, next_lm = self._reflection_lm.reflect(cand, refds, comps)
+                self._reflection_lm = next_lm  # chain stateful reflectors
+                results.append((proposal, next_lm))
+        if results:
+            # For batched reflection, chain to the final returned successor.
+            self._reflection_lm = results[-1][1]
         return [
             (proposal.new_texts, proposal.prompts, proposal.raw_lm_outputs, proposal.metadata)
             for proposal, _next_lm in results
@@ -484,9 +498,14 @@ class ReflectiveMutationProposer:
                 _lm_metadata[f"raw_lm_output:{comp}"] = raw_outputs.get(comp, "")
             # Multi-call reflection diagnostics (e.g. ComBEE per-call
             # intermediates) flow into the proposal metadata for callbacks,
-            # trackers, and the run manifest.
-            if reflection_metadata:
-                _lm_metadata.update(reflection_metadata)
+            # trackers, and the run manifest. Keys that would collide with the
+            # reserved prompt:/raw_lm_output: namespaces are remapped so a
+            # reflector cannot inject phantom components into proposal tables.
+            for meta_key, meta_val in (reflection_metadata or {}).items():
+                if meta_key.startswith(("prompt:", "raw_lm_output:")):
+                    _lm_metadata[f"reflection_meta:{meta_key}"] = meta_val
+                else:
+                    _lm_metadata[meta_key] = meta_val
 
             for pname, text in new_texts.items():
                 self.logger.log(f"Iteration {i}: Proposed new text for {pname}: {text}")
@@ -577,6 +596,9 @@ class ReflectiveMutationProposer:
                 subsample_after = sum(child_evals[0].scores)
                 self.experiment_tracker.log_metrics(
                     {
+                        # pre-#329 key names, kept for existing dashboards
+                        "subsample_score": subsample_before,
+                        "new_subsample_score": subsample_after,
                         "subsample/before": subsample_before,
                         "subsample/after": subsample_after,
                         "total_metric_calls": state.total_num_evals,

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -17,6 +17,7 @@ from gepa.core.adapter import (
 from gepa.core.callbacks import (
     CandidateSelectedEvent,
     EvaluationEndEvent,
+    EvaluationSkippedEvent,
     EvaluationStartEvent,
     GEPACallback,
     MinibatchSampledEvent,
@@ -329,6 +330,17 @@ class ReflectiveMutationProposer:
 
             if not eval_curr.trajectories:
                 self.logger.log(f"Iteration {i}: No trajectories for parent {task.parent_idx}. Skipping.")
+                notify_callbacks(
+                    self.callbacks,
+                    "on_evaluation_skipped",
+                    EvaluationSkippedEvent(
+                        iteration=i,
+                        candidate_idx=task.parent_idx,
+                        reason="no_trajectories",
+                        scores=eval_curr.scores,
+                        is_seed_candidate=task.parent_idx == 0,
+                    ),
+                )
                 prepared.append(None)
                 continue
 
@@ -338,6 +350,17 @@ class ReflectiveMutationProposer:
                 and all(s is not None and s >= self.perfect_score for s in eval_curr.scores)
             ):
                 self.logger.log(f"Iteration {i}: All subsample scores perfect for parent {task.parent_idx}. Skipping.")
+                notify_callbacks(
+                    self.callbacks,
+                    "on_evaluation_skipped",
+                    EvaluationSkippedEvent(
+                        iteration=i,
+                        candidate_idx=task.parent_idx,
+                        reason="all_scores_perfect",
+                        scores=eval_curr.scores,
+                        is_seed_candidate=task.parent_idx == 0,
+                    ),
+                )
                 prepared.append(None)
                 continue
 

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -35,11 +35,9 @@ from gepa.proposer.reflective_mutation.base import (
     ReflectionComponentSelector,
 )
 from gepa.proposer.reflective_mutation.reflection_lm import StatelessReflectionLM
-from gepa.strategies.acceptance import AcceptanceCriterion, StrictImprovementAcceptance
 from gepa.strategies.batch_sampler import BatchSampler
 from gepa.strategies.instruction_proposal import InstructionProposalSignature
 from gepa.strategies.proposal_sampling import ProposalTask, SamplingStrategy, SingleMutationSampling
-from gepa.strategies.proposal_selection import AllImprovements, SelectionStrategy
 
 
 class ReflectiveMutationProposer:
@@ -72,9 +70,7 @@ class ReflectiveMutationProposer:
         reflection_prompt_template: str | dict[str, str] | None = None,
         custom_candidate_proposer: ProposalFn | None = None,
         callbacks: list[GEPACallback] | None = None,
-        acceptance_criterion: AcceptanceCriterion | None = None,
         sampling_strategy: SamplingStrategy | None = None,
-        selection_strategy: SelectionStrategy | None = None,
     ):
         self.logger = logger
         self.trainset = ensure_loader(trainset)
@@ -88,9 +84,7 @@ class ReflectiveMutationProposer:
         self.reflection_lm = reflection_lm
         self.custom_candidate_proposer = custom_candidate_proposer
         self.callbacks = callbacks
-        self.acceptance_criterion: AcceptanceCriterion = acceptance_criterion or StrictImprovementAcceptance()
         self.sampling_strategy: SamplingStrategy = sampling_strategy or SingleMutationSampling()
-        self.selection_strategy: SelectionStrategy = selection_strategy or AllImprovements()
 
         self.reflection_prompt_template = reflection_prompt_template
 
@@ -200,11 +194,12 @@ class ReflectiveMutationProposer:
     # ------------------------------------------------------------------
 
     def propose(self, state: GEPAState) -> list[CandidateProposal]:
-        """Run the reflective mutation pipeline and return accepted proposals.
+        """Run the reflective mutation pipeline and return all evaluated proposals.
 
-        With the default ``SingleMutationSampling`` + ``AllImprovements``,
-        this returns 0 or 1 proposals — identical to the original sequential
-        behavior.
+        The proposer generates and minibatch-evaluates candidates; acceptance and
+        selection (which to keep) are the engine's job. With the default
+        ``SingleMutationSampling`` this returns at most one proposal — identical to
+        the original sequential behavior.
         """
         i = state.i + 1
 
@@ -516,4 +511,4 @@ class ReflectiveMutationProposer:
             )
             proposals.append(proposal)
 
-        return self.selection_strategy.select(proposals, state, self.acceptance_criterion)
+        return proposals

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -448,7 +448,45 @@ class ReflectiveMutationProposer:
             return []
 
         child_items = [(c[1], c[0].minibatch) for _, c in valid_children]
+
+        # Fire evaluation start callbacks for each child candidate (parity with
+        # the pre-batch sequential path, which emitted these around the new
+        # candidate's minibatch evaluation; candidate_idx is None because the
+        # child is not in the candidate pool yet)
+        for _, (task, _new_candidate, _eval_curr, _meta) in valid_children:
+            notify_callbacks(
+                self.callbacks,
+                "on_evaluation_start",
+                EvaluationStartEvent(
+                    iteration=i,
+                    candidate_idx=None,
+                    batch_size=len(task.minibatch),
+                    capture_traces=True,
+                    parent_ids=[task.parent_idx],
+                    inputs=task.minibatch,
+                    is_seed_candidate=False,
+                ),
+            )
+
         child_evals = self._batch_evaluate(child_items)
+
+        # Fire evaluation end callbacks for each child candidate
+        for (_, (task, _new_candidate, _eval_curr, _meta)), child_eval in zip(valid_children, child_evals, strict=True):
+            notify_callbacks(
+                self.callbacks,
+                "on_evaluation_end",
+                EvaluationEndEvent(
+                    iteration=i,
+                    candidate_idx=None,
+                    scores=child_eval.scores,
+                    has_trajectories=bool(child_eval.trajectories),
+                    parent_ids=[task.parent_idx],
+                    outputs=child_eval.outputs,
+                    trajectories=child_eval.trajectories,
+                    objective_scores=child_eval.objective_scores,
+                    is_seed_candidate=False,
+                ),
+            )
 
         total_child_evals = sum(
             e.num_metric_calls if e.num_metric_calls is not None else len(child_items[idx][1])

--- a/src/gepa/strategies/acceptance.py
+++ b/src/gepa/strategies/acceptance.py
@@ -22,6 +22,11 @@ class AcceptanceCriterion(Protocol):
       - ``parent_program_ids``: indices of parent candidates.
       - ``metadata``: free-form dict with LM prompts and raw outputs.
 
+    Implementations may additionally define an optional
+    ``reject_reason(proposal, state) -> str`` method; when present, the engine
+    uses it to produce an informative log message for rejected proposals
+    instead of the generic fallback.
+
     - ``state``: the full ``GEPAState``, giving access to all existing candidates,
       validation scores, the Pareto frontier, iteration count, etc.
     """

--- a/src/gepa/strategies/batch_sampler.py
+++ b/src/gepa/strategies/batch_sampler.py
@@ -11,6 +11,15 @@ from gepa.core.state import GEPAState
 
 
 class BatchSampler(Protocol[DataId, DataInst]):
+    """Yields the minibatch of trainset ids to propose from.
+
+    Multi-proposal sampling strategies call ``next_minibatch_ids`` once per
+    task within a single iteration (``state.i`` unchanged between calls).
+    Implementations should return a *different* minibatch on each repeated
+    call within an iteration, so parallel proposal tasks don't all share one
+    minibatch.
+    """
+
     def next_minibatch_ids(self, loader: DataLoader[DataId, DataInst], state: GEPAState) -> list[DataId]: ...
 
 
@@ -28,6 +37,8 @@ class EpochShuffledBatchSampler(BatchSampler[DataId, DataInst]):
         self.epoch = -1
         self.id_freqs = Counter()
         self.last_trainset_size = 0
+        self._current_iteration: int | None = None
+        self._calls_in_iteration = 0
         if rng is None:
             self.rng = random.Random(0)
         else:
@@ -60,6 +71,18 @@ class EpochShuffledBatchSampler(BatchSampler[DataId, DataInst]):
         if trainset_size == 0:
             raise ValueError("Cannot sample a minibatch from an empty loader.")
 
+        # Repeated calls within one iteration (multi-proposal sampling
+        # strategies request one minibatch per task) advance one chunk each,
+        # so tasks in the same iteration get distinct minibatches. The first
+        # call of an iteration is unchanged from the classic behavior. Chunks
+        # wrap around, so distinctness holds only while the iteration's call
+        # count stays within len(shuffled_ids) / minibatch_size.
+        if state.i == self._current_iteration:
+            self._calls_in_iteration += 1
+        else:
+            self._current_iteration = state.i
+            self._calls_in_iteration = 0
+
         base_idx = state.i * self.minibatch_size
         curr_epoch = 0 if self.epoch == -1 else base_idx // max(len(self.shuffled_ids), 1)
 
@@ -71,7 +94,10 @@ class EpochShuffledBatchSampler(BatchSampler[DataId, DataInst]):
         assert len(self.shuffled_ids) >= self.minibatch_size
         assert len(self.shuffled_ids) % self.minibatch_size == 0
 
-        base_idx = base_idx % len(self.shuffled_ids)
+        # The epoch bookkeeping above uses the un-offset base_idx (constant
+        # within an iteration), so repeat calls never trigger a reshuffle and
+        # the shuffle sequence stays identical to the single-call path.
+        base_idx = (base_idx + self._calls_in_iteration * self.minibatch_size) % len(self.shuffled_ids)
         end_idx = base_idx + self.minibatch_size
         assert end_idx <= len(self.shuffled_ids)
         return self.shuffled_ids[base_idx:end_idx]

--- a/src/gepa/strategies/proposal_sampling.py
+++ b/src/gepa/strategies/proposal_sampling.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""Sampling strategies for selecting (parent, minibatch) pairs each iteration."""
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from gepa.core.data_loader import DataLoader
+from gepa.core.state import GEPAState
+from gepa.proposer.reflective_mutation.base import CandidateSelector
+from gepa.strategies.batch_sampler import BatchSampler
+
+
+@dataclass
+class ProposalTask:
+    """One (parent, minibatch) pair to propose from."""
+
+    parent_idx: int
+    parent_candidate: dict[str, str]
+    minibatch_ids: list
+    minibatch: list
+
+
+class SamplingStrategy(Protocol):
+    """Generates one or more (parent, minibatch) tasks per iteration.
+
+    The default (``SingleMutationSampling``) produces exactly one task,
+    matching GEPA's original sequential behavior.  Swap in a different
+    strategy to propose multiple candidates per iteration.
+    """
+
+    def sample_tasks(
+        self,
+        state: GEPAState,
+        candidate_selector: CandidateSelector,
+        batch_sampler: BatchSampler,
+        trainset: DataLoader,
+    ) -> list[ProposalTask]: ...
+
+
+class SingleMutationSampling:
+    """1 parent, 1 mutation — default GEPA behavior."""
+
+    def sample_tasks(
+        self,
+        state: GEPAState,
+        candidate_selector: CandidateSelector,
+        batch_sampler: BatchSampler,
+        trainset: DataLoader,
+    ) -> list[ProposalTask]:
+        parent_idx = candidate_selector.select_candidate_idx(state)
+        mb_ids = batch_sampler.next_minibatch_ids(trainset, state)
+        return [ProposalTask(parent_idx, state.program_candidates[parent_idx], mb_ids, trainset.fetch(mb_ids))]
+
+
+class SameParentSampling:
+    """Best-of-N on the same parent with different minibatches."""
+
+    def __init__(self, n: int):
+        self.n = n
+
+    def sample_tasks(
+        self,
+        state: GEPAState,
+        candidate_selector: CandidateSelector,
+        batch_sampler: BatchSampler,
+        trainset: DataLoader,
+    ) -> list[ProposalTask]:
+        parent_idx = candidate_selector.select_candidate_idx(state)
+        parent = state.program_candidates[parent_idx]
+        tasks = []
+        for _ in range(self.n):
+            mb_ids = batch_sampler.next_minibatch_ids(trainset, state)
+            tasks.append(ProposalTask(parent_idx, parent, mb_ids, trainset.fetch(mb_ids)))
+        return tasks
+
+
+class IndependentSampling:
+    """N different parents, each with their own minibatch."""
+
+    def __init__(self, n: int):
+        self.n = n
+
+    def sample_tasks(
+        self,
+        state: GEPAState,
+        candidate_selector: CandidateSelector,
+        batch_sampler: BatchSampler,
+        trainset: DataLoader,
+    ) -> list[ProposalTask]:
+        tasks = []
+        for _ in range(self.n):
+            parent_idx = candidate_selector.select_candidate_idx(state)
+            mb_ids = batch_sampler.next_minibatch_ids(trainset, state)
+            tasks.append(ProposalTask(parent_idx, state.program_candidates[parent_idx], mb_ids, trainset.fetch(mb_ids)))
+        return tasks
+
+
+class PxNSampling:
+    """P parents x N mutations each = P*N total tasks."""
+
+    def __init__(self, p: int, n: int):
+        self.p = p
+        self.n = n
+
+    def sample_tasks(
+        self,
+        state: GEPAState,
+        candidate_selector: CandidateSelector,
+        batch_sampler: BatchSampler,
+        trainset: DataLoader,
+    ) -> list[ProposalTask]:
+        tasks = []
+        for _ in range(self.p):
+            parent_idx = candidate_selector.select_candidate_idx(state)
+            parent = state.program_candidates[parent_idx]
+            for _ in range(self.n):
+                mb_ids = batch_sampler.next_minibatch_ids(trainset, state)
+                tasks.append(ProposalTask(parent_idx, parent, mb_ids, trainset.fetch(mb_ids)))
+        return tasks

--- a/src/gepa/strategies/proposal_sampling.py
+++ b/src/gepa/strategies/proposal_sampling.py
@@ -4,22 +4,22 @@
 """Sampling strategies for selecting (parent, minibatch) pairs each iteration."""
 
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Generic, Protocol
 
-from gepa.core.data_loader import DataLoader
+from gepa.core.data_loader import DataId, DataInst, DataLoader
 from gepa.core.state import GEPAState
 from gepa.proposer.reflective_mutation.base import CandidateSelector
 from gepa.strategies.batch_sampler import BatchSampler
 
 
 @dataclass
-class ProposalTask:
+class ProposalTask(Generic[DataId, DataInst]):
     """One (parent, minibatch) pair to propose from."""
 
     parent_idx: int
     parent_candidate: dict[str, str]
-    minibatch_ids: list
-    minibatch: list
+    minibatch_ids: list[DataId]
+    minibatch: list[DataInst]
 
 
 class SamplingStrategy(Protocol):
@@ -28,6 +28,13 @@ class SamplingStrategy(Protocol):
     The default (``SingleMutationSampling``) produces exactly one task,
     matching GEPA's original sequential behavior.  Swap in a different
     strategy to propose multiple candidates per iteration.
+
+    Note on trainset size: multi-task strategies draw ``n`` minibatches from
+    the epoch-shuffled sampler per iteration. When
+    ``n * minibatch_size > len(trainset)`` the sampler wraps around within the
+    iteration, so some tasks will receive repeated minibatches. This is safe
+    but reduces the diversity benefit — prefer ``n <= len(trainset) //
+    minibatch_size``.
     """
 
     def sample_tasks(

--- a/src/gepa/strategies/proposal_sampling.py
+++ b/src/gepa/strategies/proposal_sampling.py
@@ -39,7 +39,7 @@ class SamplingStrategy(Protocol):
     ) -> list[ProposalTask]: ...
 
 
-class SingleMutationSampling:
+class SingleMutationSampling(SamplingStrategy):
     """1 parent, 1 mutation — default GEPA behavior."""
 
     def sample_tasks(
@@ -54,7 +54,7 @@ class SingleMutationSampling:
         return [ProposalTask(parent_idx, state.program_candidates[parent_idx], mb_ids, trainset.fetch(mb_ids))]
 
 
-class SameParentSampling:
+class SameParentSampling(SamplingStrategy):
     """Best-of-N on the same parent with different minibatches."""
 
     def __init__(self, n: int):
@@ -76,7 +76,7 @@ class SameParentSampling:
         return tasks
 
 
-class IndependentSampling:
+class IndependentSampling(SamplingStrategy):
     """N different parents, each with their own minibatch."""
 
     def __init__(self, n: int):
@@ -97,7 +97,7 @@ class IndependentSampling:
         return tasks
 
 
-class PxNSampling:
+class PxNSampling(SamplingStrategy):
     """P parents x N mutations each = P*N total tasks."""
 
     def __init__(self, p: int, n: int):

--- a/src/gepa/strategies/proposal_sampling.py
+++ b/src/gepa/strategies/proposal_sampling.py
@@ -22,7 +22,7 @@ class ProposalTask(Generic[DataId, DataInst]):
     minibatch: list[DataInst]
 
 
-class SamplingStrategy(Protocol):
+class SamplingStrategy(Protocol[DataId, DataInst]):
     """Generates one or more (parent, minibatch) tasks per iteration.
 
     The default (``SingleMutationSampling``) produces exactly one task,
@@ -41,9 +41,9 @@ class SamplingStrategy(Protocol):
         self,
         state: GEPAState,
         candidate_selector: CandidateSelector,
-        batch_sampler: BatchSampler,
-        trainset: DataLoader,
-    ) -> list[ProposalTask]: ...
+        batch_sampler: BatchSampler[DataId, DataInst],
+        trainset: DataLoader[DataId, DataInst],
+    ) -> list[ProposalTask[DataId, DataInst]]: ...
 
 
 class SingleMutationSampling(SamplingStrategy):

--- a/src/gepa/strategies/proposal_selection.py
+++ b/src/gepa/strategies/proposal_selection.py
@@ -15,7 +15,7 @@ class SelectionStrategy(Protocol):
 
     The default (``AllImprovements``) accepts every proposal that passes
     the acceptance criterion, matching GEPA's original behavior.
-    
+
     Contract: ``select`` must return proposals FROM the given list (the same
     objects, not copies) — the engine ignores foreign objects, deduplicates
     identical candidates, and reports everything unselected as rejected. The

--- a/src/gepa/strategies/proposal_selection.py
+++ b/src/gepa/strategies/proposal_selection.py
@@ -25,7 +25,7 @@ class SelectionStrategy(Protocol):
     ) -> list[CandidateProposal]: ...
 
 
-class AllImprovements:
+class AllImprovements(SelectionStrategy):
     """Accept all proposals that pass the acceptance criterion."""
 
     def select(
@@ -37,7 +37,7 @@ class AllImprovements:
         return [p for p in proposals if acceptance_criterion.should_accept(p, state)]
 
 
-class BestImprovement:
+class BestImprovement(SelectionStrategy):
     """Accept only the single best-improving proposal."""
 
     def select(
@@ -57,7 +57,7 @@ class BestImprovement:
         return [best] if best else []
 
 
-class TopKImprovements:
+class TopKImprovements(SelectionStrategy):
     """Accept top-K proposals by improvement margin."""
 
     def __init__(self, k: int):

--- a/src/gepa/strategies/proposal_selection.py
+++ b/src/gepa/strategies/proposal_selection.py
@@ -15,6 +15,12 @@ class SelectionStrategy(Protocol):
 
     The default (``AllImprovements``) accepts every proposal that passes
     the acceptance criterion, matching GEPA's original behavior.
+    
+    Contract: ``select`` must return proposals FROM the given list (the same
+    objects, not copies) — the engine ignores foreign objects, deduplicates
+    identical candidates, and reports everything unselected as rejected. The
+    acceptance criterion passed in is memoized per batch: consulting it any
+    number of times costs exactly one underlying judgement per proposal.
     """
 
     def select(

--- a/src/gepa/strategies/proposal_selection.py
+++ b/src/gepa/strategies/proposal_selection.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""Selection strategies for filtering proposals after evaluation."""
+
+from typing import Protocol
+
+from gepa.core.state import GEPAState
+from gepa.proposer.base import CandidateProposal
+from gepa.strategies.acceptance import AcceptanceCriterion
+
+
+class SelectionStrategy(Protocol):
+    """Filters proposals after subsample evaluation.
+
+    The default (``AllImprovements``) accepts every proposal that passes
+    the acceptance criterion, matching GEPA's original behavior.
+    """
+
+    def select(
+        self,
+        proposals: list[CandidateProposal],
+        state: GEPAState,
+        acceptance_criterion: AcceptanceCriterion,
+    ) -> list[CandidateProposal]: ...
+
+
+class AllImprovements:
+    """Accept all proposals that pass the acceptance criterion."""
+
+    def select(
+        self,
+        proposals: list[CandidateProposal],
+        state: GEPAState,
+        acceptance_criterion: AcceptanceCriterion,
+    ) -> list[CandidateProposal]:
+        return [p for p in proposals if acceptance_criterion.should_accept(p, state)]
+
+
+class BestImprovement:
+    """Accept only the single best-improving proposal."""
+
+    def select(
+        self,
+        proposals: list[CandidateProposal],
+        state: GEPAState,
+        acceptance_criterion: AcceptanceCriterion,
+    ) -> list[CandidateProposal]:
+        best: CandidateProposal | None = None
+        best_imp = float("-inf")
+        for p in proposals:
+            if not acceptance_criterion.should_accept(p, state):
+                continue
+            imp = sum(p.subsample_scores_after or []) - sum(p.subsample_scores_before or [])
+            if imp > best_imp:
+                best, best_imp = p, imp
+        return [best] if best else []
+
+
+class TopKImprovements:
+    """Accept top-K proposals by improvement margin."""
+
+    def __init__(self, k: int):
+        self.k = k
+
+    def select(
+        self,
+        proposals: list[CandidateProposal],
+        state: GEPAState,
+        acceptance_criterion: AcceptanceCriterion,
+    ) -> list[CandidateProposal]:
+        passing = [
+            (sum(p.subsample_scores_after or []) - sum(p.subsample_scores_before or []), p)
+            for p in proposals
+            if acceptance_criterion.should_accept(p, state)
+        ]
+        passing.sort(key=lambda x: x[0], reverse=True)
+        return [p for _, p in passing[: self.k]]

--- a/tests/test_batch_evaluator_user_fn.py
+++ b/tests/test_batch_evaluator_user_fn.py
@@ -248,3 +248,29 @@ def test_optimize_anything_requires_a_transport():
 
     with pytest.raises(ValueError, match="batch_evaluator"):
         optimize_anything(seed_candidate="x")
+
+
+def test_batch_evaluate_with_refiner_and_batch_fn_still_refines_per_example():
+    """N1 regression: refiner_config + batch_evaluator must NOT silently skip
+    refinement on the grouped batch_evaluate path. Evaluation degrades to
+    per-example loops whose evals reach the batch fn as singleton batches —
+    the fn must never see a grouped (>1 pair) call in this configuration."""
+    from gepa.optimize_anything import RefinerConfig
+
+    calls: list[int] = []
+
+    def fn(pairs):
+        calls.append(len(pairs))
+        return [(1.0, {}) for _ in pairs]
+
+    adapter = OptimizeAnythingAdapter(
+        evaluator=None,
+        batch_evaluator=fn,
+        refiner_config=RefinerConfig(refiner_lm=lambda prompt: "no-op refinement", max_refinements=1),
+        parallel=False,
+        cache_mode="off",
+    )
+    adapter.batch_evaluate([({"refiner_prompt": "seed"}, [1, 2])])
+    assert calls, "batch_evaluator was never called"
+    assert all(n == 1 for n in calls), f"grouped call leaked past the refiner guard: {calls}"
+    assert len(calls) >= 2  # at least one original eval per example

--- a/tests/test_batch_evaluator_user_fn.py
+++ b/tests/test_batch_evaluator_user_fn.py
@@ -61,7 +61,7 @@ def test_wrapper_exception_policy_convert():
         raise RuntimeError("cluster down")
 
     out = BatchEvaluatorWrapper(boom, raise_on_exception=False)(PAIRS)
-    assert out == [(0.0, {"error": "cluster down"})] * 2
+    assert out == [(0.0, {"error": "cluster down", "_gepa_transient_failure": True})] * 2
 
 
 def test_wrapper_str_candidate_unwrapping():
@@ -274,3 +274,81 @@ def test_batch_evaluate_with_refiner_and_batch_fn_still_refines_per_example():
     assert calls, "batch_evaluator was never called"
     assert all(n == 1 for n in calls), f"grouped call leaked past the refiner guard: {calls}"
     assert len(calls) >= 2  # at least one original eval per example
+
+
+# ---------------------------------------------------------------------------
+# Adversarial-review fixes: sentinel mirror, copies, failure caching, dedup
+# ---------------------------------------------------------------------------
+
+
+def test_single_instance_mode_examples_are_none():
+    seen = []
+
+    def fn(pairs):
+        seen.extend(ex for _, ex in pairs)
+        return [0.0 for _ in pairs]
+
+    wrapper = BatchEvaluatorWrapper(fn, single_instance_mode=True)
+    wrapper([({"t": "x"}, object()), ({"t": "y"}, object())])
+    assert seen == [None, None], f"internal sentinel leaked to user fn: {seen}"
+
+
+def test_side_info_is_defensively_copied():
+    retained = {"note": "original"}
+    wrapper = BatchEvaluatorWrapper(lambda pairs: [(1.0, retained) for _ in pairs])
+    out = wrapper(PAIRS)
+    retained["note"] = "MUTATED"
+    assert all(si["note"] == "original" for _, si in out)
+
+
+def test_non_dict_side_info_raises_loudly():
+    wrapper = BatchEvaluatorWrapper(lambda pairs: [(1.0, "not-a-dict") for _ in pairs])
+    with pytest.raises(TypeError, match="side_info must be a dict"):
+        wrapper(PAIRS)
+
+
+def test_transient_batch_failure_is_never_cached():
+    state = {"fail": True}
+
+    def flaky(pairs):
+        if state["fail"]:
+            raise RuntimeError("transient outage")
+        return [(1.0, {}) for _ in pairs]
+
+    adapter = OptimizeAnythingAdapter(evaluator=None, parallel=False, cache_mode="memory", batch_evaluator=flaky)
+    # NOTE: raise_on_exception lives on the wrapper; rebuild with it disabled.
+    adapter._batch_evaluator = BatchEvaluatorWrapper(flaky, raise_on_exception=False)
+
+    first = adapter.batch_evaluate([({"bias": "0"}, [1, 2])])
+    assert first[0].scores == [0.0, 0.0]
+    assert all(t.get("_gepa_transient_failure") for t in first[0].trajectories)
+
+    state["fail"] = False
+    second = adapter.batch_evaluate([({"bias": "0"}, [1, 2])])
+    assert second[0].scores == [1.0, 1.0], "failure results were cached and never re-evaluated"
+
+
+def test_duplicate_pairs_deduplicated_within_grouped_call_when_cached():
+    fn = _CountingBatchFn()
+    adapter = OptimizeAnythingAdapter(evaluator=None, parallel=False, cache_mode="memory", batch_evaluator=fn)
+    # Same (candidate, example) pair appears twice across items.
+    adapter.batch_evaluate([({"bias": "0"}, [1, 2]), ({"bias": "0"}, [2, 3])])
+    assert sum(len(c) for c in fn.calls) == 3, f"duplicate pair not deduped: {fn.calls}"
+
+
+def test_capture_stdio_without_evaluator_warns():
+    import warnings as _warnings
+
+    from gepa.optimize_anything import EngineConfig, GEPAConfig, optimize_anything
+
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        try:
+            optimize_anything(
+                seed_candidate="x",
+                batch_evaluator=lambda pairs: [0.0 for _ in pairs],
+                config=GEPAConfig(engine=EngineConfig(capture_stdio=True, max_metric_calls=1)),
+            )
+        except Exception:  # only the warning matters here
+            pass
+        assert any("capture_stdio" in str(w.message) for w in caught)

--- a/tests/test_batch_evaluator_user_fn.py
+++ b/tests/test_batch_evaluator_user_fn.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""Tests for the user-facing ``batch_evaluator`` path (BatchEvaluatorWrapper +
+OptimizeAnythingAdapter._batch_evaluate_via_user_fn).
+
+Contract under test: the batch path preserves evaluator-path parity for
+everything that survives a single external batch call — str-candidate
+unwrapping, per-pair ``opt_states`` injection, exception policy, best-evals
+(warm-start) history, and output packaging — while the user keeps exactly one
+call for all pairs.
+"""
+
+import pytest
+
+from gepa.adapters.optimize_anything_adapter.optimize_anything_adapter import (
+    BatchEvaluatorWrapper,
+    OptimizeAnythingAdapter,
+)
+
+# ---------------------------------------------------------------------------
+# BatchEvaluatorWrapper unit tests
+# ---------------------------------------------------------------------------
+
+
+PAIRS = [({"text": "a"}, 1), ({"text": "b"}, 2)]
+
+
+def test_wrapper_normalizes_all_result_shapes():
+    def fn(pairs):
+        return [0.5, (0.7, {"note": "two"}), (0.9, "ignored-output", {"note": "three"})][: len(pairs)]
+
+    wrapper = BatchEvaluatorWrapper(fn)
+    out = wrapper([({"t": "x"}, i) for i in range(3)])
+    assert out == [(0.5, {}), (0.7, {"note": "two"}), (0.9, {"note": "three"})]
+
+
+def test_wrapper_two_tuple_side_info_is_not_dropped():
+    """(score, side_info) — the natural mirror of the Evaluator protocol."""
+    wrapper = BatchEvaluatorWrapper(lambda pairs: [(1.0, {"bias": "0"}) for _ in pairs])
+    out = wrapper(PAIRS)
+    assert all(si == {"bias": "0"} for _, si in out)
+
+
+def test_wrapper_length_mismatch_raises():
+    wrapper = BatchEvaluatorWrapper(lambda pairs: [1.0])
+    with pytest.raises(ValueError, match="returned 1 results but expected 2"):
+        wrapper(PAIRS)
+
+
+def test_wrapper_exception_policy_raise():
+    def boom(pairs):
+        raise RuntimeError("cluster down")
+
+    with pytest.raises(RuntimeError):
+        BatchEvaluatorWrapper(boom, raise_on_exception=True)(PAIRS)
+
+
+def test_wrapper_exception_policy_convert():
+    def boom(pairs):
+        raise RuntimeError("cluster down")
+
+    out = BatchEvaluatorWrapper(boom, raise_on_exception=False)(PAIRS)
+    assert out == [(0.0, {"error": "cluster down"})] * 2
+
+
+def test_wrapper_str_candidate_unwrapping():
+    seen = []
+
+    def fn(pairs):
+        seen.extend(c for c, _ in pairs)
+        return [0.0 for _ in pairs]
+
+    BatchEvaluatorWrapper(fn, str_candidate_key="text")(PAIRS)
+    assert seen == ["a", "b"]
+
+
+def test_wrapper_injects_opt_states_when_signature_accepts():
+    received = {}
+
+    def fn(pairs, opt_states):
+        received["opt_states"] = opt_states
+        return [0.0 for _ in pairs]
+
+    states = ["s1", "s2"]
+    BatchEvaluatorWrapper(fn)(PAIRS, opt_states=states)
+    assert received["opt_states"] is states
+
+
+def test_wrapper_omits_opt_states_when_signature_does_not_accept():
+    def fn(pairs):
+        return [0.0 for _ in pairs]
+
+    # Must not raise TypeError for the unexpected kwarg.
+    out = BatchEvaluatorWrapper(fn)(PAIRS, opt_states=["s1", "s2"])
+    assert len(out) == 2
+
+
+# ---------------------------------------------------------------------------
+# Adapter-level parity tests
+# ---------------------------------------------------------------------------
+
+
+def _sequential_evaluator(candidate, example=None, **kwargs):
+    score = float(example) + float(candidate["bias"])
+    return score, None, {"example": example, "bias": candidate["bias"]}
+
+
+def _make_adapter(batch_evaluator=None):
+    return OptimizeAnythingAdapter(
+        evaluator=_sequential_evaluator,
+        parallel=False,
+        cache_mode="off",
+        batch_evaluator=batch_evaluator,
+    )
+
+
+ITEMS = [
+    ({"bias": "0"}, [1, 2, 3]),
+    ({"bias": "100"}, [5]),
+]
+
+
+def _user_batch_fn(pairs):
+    return [(float(ex) + float(c["bias"]), {"example": ex, "bias": c["bias"]}) for c, ex in pairs]
+
+
+def test_batch_path_packaging_matches_sequential_path():
+    """outputs must be (score, candidate, side_info) on BOTH paths (H4/B1)."""
+    sequential = _make_adapter().batch_evaluate(ITEMS)
+    batched = _make_adapter(batch_evaluator=_user_batch_fn).batch_evaluate(ITEMS)
+
+    for seq_batch, usr_batch in zip(sequential, batched, strict=True):
+        assert usr_batch.scores == seq_batch.scores
+        assert usr_batch.num_metric_calls == seq_batch.num_metric_calls
+        assert usr_batch.objective_scores == seq_batch.objective_scores
+        for seq_out, usr_out in zip(seq_batch.outputs, usr_batch.outputs, strict=True):
+            # (score, candidate, side_info) triple parity
+            assert usr_out[0] == seq_out[0]
+            assert usr_out[1] == seq_out[1]
+            assert usr_out[2]["bias"] == seq_out[2]["bias"]
+    # And specifically: slot 1 is the candidate, never None (H4 regression).
+    assert all(out[1] == {"bias": "0"} for out in batched[0].outputs)
+    assert batched[1].outputs[0][1] == {"bias": "100"}
+
+
+def test_batch_path_updates_best_evals_for_warm_start():
+    """B1: the top-K best-eval buffer must be populated on the batch path."""
+    adapter = _make_adapter(batch_evaluator=_user_batch_fn)
+    adapter.batch_evaluate(ITEMS)
+    opt_state = adapter._build_opt_state(1)
+    assert opt_state.best_example_evals, "best_example_evals not populated by batch path"
+
+
+def test_batch_path_receives_per_pair_opt_states():
+    received = []
+
+    def fn(pairs, opt_states):
+        received.append(list(opt_states))
+        return [(0.0, {}) for _ in pairs]
+
+    adapter = _make_adapter(batch_evaluator=fn)
+    adapter.batch_evaluate(ITEMS)
+    assert len(received) == 1
+    assert len(received[0]) == 4  # one OptimizationState per flattened pair

--- a/tests/test_batch_evaluator_user_fn.py
+++ b/tests/test_batch_evaluator_user_fn.py
@@ -163,3 +163,88 @@ def test_batch_path_receives_per_pair_opt_states():
     adapter.batch_evaluate(ITEMS)
     assert len(received) == 1
     assert len(received[0]) == 4  # one OptimizationState per flattened pair
+
+
+# ---------------------------------------------------------------------------
+# Unification: optional evaluator, shared caching, routing preferences
+# ---------------------------------------------------------------------------
+
+
+class _CountingBatchFn:
+    def __init__(self):
+        self.calls: list[list] = []
+
+    def __call__(self, pairs):
+        self.calls.append(list(pairs))
+        return [(float(ex) + float(c["bias"]), {"example": ex}) for c, ex in pairs]
+
+
+def test_ctor_requires_at_least_one_transport():
+    with pytest.raises(ValueError, match="evaluator"):
+        OptimizeAnythingAdapter(evaluator=None, batch_evaluator=None)
+
+
+def test_batch_only_adapter_evaluate_routes_whole_batch():
+    fn = _CountingBatchFn()
+    adapter = OptimizeAnythingAdapter(evaluator=None, parallel=False, cache_mode="off", batch_evaluator=fn)
+    result = adapter.evaluate([1, 2, 3], {"bias": "0"})
+    assert result.scores == [1.0, 2.0, 3.0]
+    assert len(fn.calls) == 1 and len(fn.calls[0]) == 3  # one grouped call
+    # Packaging parity: outputs are (score, candidate, side_info) triples.
+    assert all(out[1] == {"bias": "0"} for out in result.outputs)
+
+
+def test_batch_only_singleton_resolution_for_refiner_seam():
+    """_call_evaluator (the refiner's seam) routes singles through the batch fn."""
+    fn = _CountingBatchFn()
+    adapter = OptimizeAnythingAdapter(evaluator=None, parallel=False, cache_mode="off", batch_evaluator=fn)
+    score, _output, _side_info = adapter._call_evaluator({"bias": "10"}, 5)
+    assert score == 15.0
+    assert len(fn.calls) == 1 and len(fn.calls[0]) == 1  # singleton batch
+
+
+def test_cache_shared_between_batch_and_singleton_paths():
+    fn = _CountingBatchFn()
+    adapter = OptimizeAnythingAdapter(evaluator=None, parallel=False, cache_mode="memory", batch_evaluator=fn)
+    adapter.batch_evaluate(ITEMS)  # fills the cache (4 pairs)
+    assert sum(len(c) for c in fn.calls) == 4
+
+    # Second grouped call: all hits, user fn NOT called again.
+    adapter.batch_evaluate(ITEMS)
+    assert sum(len(c) for c in fn.calls) == 4
+
+    # Singleton resolution (refiner seam) hits the same cache.
+    score, _, _ = adapter._call_evaluator({"bias": "0"}, 1)
+    assert score == 1.0
+    assert sum(len(c) for c in fn.calls) == 4
+
+    # A genuinely new pair triggers exactly one miss-only call.
+    adapter.batch_evaluate([({"bias": "0"}, [1, 2, 99])])
+    assert sum(len(c) for c in fn.calls) == 5
+    assert len(fn.calls[-1]) == 1  # only the miss (99) reached the user fn
+
+
+def test_both_transports_grouped_prefers_batch_fn():
+    fn = _CountingBatchFn()
+    seen_by_evaluator = []
+
+    def evaluator(candidate, example=None, **kwargs):
+        seen_by_evaluator.append(example)
+        return float(example), None, {}
+
+    adapter = OptimizeAnythingAdapter(evaluator=evaluator, parallel=False, cache_mode="off", batch_evaluator=fn)
+    adapter.evaluate([1, 2], {"bias": "0"})
+    assert len(fn.calls) == 1  # grouped work went to the batch fn
+    assert seen_by_evaluator == []
+
+    # Single-pair resolution (refiner seam) prefers the single-pair evaluator.
+    adapter._call_evaluator({"bias": "0"}, 7)
+    assert seen_by_evaluator == [7]
+    assert len(fn.calls) == 1
+
+
+def test_optimize_anything_requires_a_transport():
+    from gepa.optimize_anything import optimize_anything
+
+    with pytest.raises(ValueError, match="batch_evaluator"):
+        optimize_anything(seed_candidate="x")

--- a/tests/test_batch_sampler.py
+++ b/tests/test_batch_sampler.py
@@ -34,3 +34,34 @@ def test_epoch_sampler_errors_when_loader_empty():
 
     with pytest.raises(ValueError):
         sampler.next_minibatch_ids(loader, state)
+
+
+def test_repeated_calls_within_iteration_return_distinct_minibatches():
+    # Multi-proposal sampling strategies call the sampler once per task within
+    # a single iteration; each call must yield a different minibatch.
+    loader = ListDataLoader(["a", "b", "c", "d", "e", "f"])
+    sampler = EpochShuffledBatchSampler(minibatch_size=2, rng=random.Random(0))
+    state = SimpleNamespace(i=0)
+
+    batches = [tuple(sampler.next_minibatch_ids(loader, state)) for _ in range(3)]
+    assert len(set(batches)) == 3
+    assert {i for batch in batches for i in batch} == {0, 1, 2, 3, 4, 5}
+
+    # A fourth call exceeds the number of chunks and wraps around.
+    assert tuple(sampler.next_minibatch_ids(loader, state)) == batches[0]
+
+
+def test_extra_calls_do_not_perturb_later_iterations():
+    # The first call of each iteration must be byte-identical whether or not
+    # earlier iterations made extra (multi-proposal) calls.
+    items = list("abcdefgh")
+    single = EpochShuffledBatchSampler(minibatch_size=3, rng=random.Random(0))
+    multi = EpochShuffledBatchSampler(minibatch_size=3, rng=random.Random(0))
+
+    for i in range(10):
+        loader_single, loader_multi = ListDataLoader(items), ListDataLoader(items)
+        state = SimpleNamespace(i=i)
+        expected = single.next_minibatch_ids(loader_single, state)
+        assert multi.next_minibatch_ids(loader_multi, state) == expected
+        for _ in range(4):
+            multi.next_minibatch_ids(loader_multi, state)

--- a/tests/test_multi_proposal_invariants.py
+++ b/tests/test_multi_proposal_invariants.py
@@ -1,0 +1,313 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""End-to-end invariants for the multi-proposal machinery (#369) on a fully
+deterministic synthetic task — no network, no recorded cache, so it can drive
+the NEW paths (PxN/SameParent/Independent sampling, Best/TopK selection, the
+adapter batch_evaluate seam, evaluation caching) that the replay-based tests
+cannot reach.
+
+Invariants:
+  I1 budget ledger == independently instrumented evaluator truth == result field
+  I2 candidate count == 1 + accepted events; lineage indices sane
+  I3 selection is margin-correct: accepted == min(K, improving); no dropped
+     margin above the selection cutoff; rejection reasons truthful per class
+  I4 evaluation event pairs balanced; one child-eval pair per proposal
+  I5 trace records every task with scores; save/load round-trips; state consistent
+  I6 batched adapters receive grouped calls
+  I7 determinism: identical config -> identical outcome
+"""
+
+import re
+from collections import defaultdict
+from itertools import pairwise
+
+import pytest
+
+import gepa
+from gepa.core.adapter import EvaluationBatch
+from gepa.core.state import GEPAState
+from gepa.strategies.proposal_sampling import (
+    IndependentSampling,
+    PxNSampling,
+    SameParentSampling,
+    SingleMutationSampling,
+)
+from gepa.strategies.proposal_selection import AllImprovements, BestImprovement, TopKImprovements
+
+TRAIN = [{"k": i} for i in range(10)]
+
+
+def _level_of(candidate):
+    return int(re.search(r"LEVEL=(\d+)", candidate["system_prompt"]).group(1))
+
+
+class SyntheticAdapter:
+    """score(candidate, example k) = 1.0 iff LEVEL >= k. Deterministic."""
+
+    propose_new_texts = None
+
+    def __init__(self):
+        self.metric_calls = 0
+        self.grouped_calls: list[int] = []
+
+    def evaluate(self, batch, candidate, capture_traces=False):
+        level = _level_of(candidate)
+        self.metric_calls += len(batch)
+        return EvaluationBatch(
+            outputs=[f"out-l{level}-k{ex['k']}" for ex in batch],
+            scores=[1.0 if level >= ex["k"] else 0.0 for ex in batch],
+            trajectories=(
+                [{"k": ex["k"], "feedback": f"level={level} needed k={ex['k']}"} for ex in batch]
+                if capture_traces
+                else None
+            ),
+            objective_scores=None,
+            num_metric_calls=len(batch),
+        )
+
+    def make_reflective_dataset(self, candidate, eval_batch, components):
+        return {c: [{"Feedback": t["feedback"]} for t in (eval_batch.trajectories or [])] for c in components}
+
+
+class BatchedSyntheticAdapter(SyntheticAdapter):
+    def batch_evaluate(self, items):
+        self.grouped_calls.append(len(items))
+        return [self.evaluate(batch, candidate, capture_traces=True) for candidate, batch in items]
+
+
+class SyntheticReflectionLM:
+    """child level = parent + (calls % 4): delta 0 children never improve, so
+    acceptance and selection both do real work."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self, prompt):
+        m = re.findall(r"LEVEL=(\d+)", prompt)
+        parent_level = int(m[-1]) if m else 0
+        delta = self.calls % 4
+        self.calls += 1
+        return f"```\nLEVEL={parent_level + delta}\n```"
+
+
+class _EventLog:
+    def __init__(self):
+        self.by = defaultdict(list)
+
+    def __getattr__(self, name):
+        if name.startswith("on_"):
+
+            def rec(e, n=name):
+                self.by[n].append(dict(e))
+
+            return rec
+        raise AttributeError(name)
+
+
+def _run(sampling, selection, adapter_cls, cache, run_dir):
+    adapter = adapter_cls()
+    log = _EventLog()
+    result = gepa.optimize(
+        seed_candidate={"system_prompt": "LEVEL=0"},
+        trainset=TRAIN,
+        valset=TRAIN,
+        adapter=adapter,
+        reflection_lm=SyntheticReflectionLM(),
+        max_metric_calls=400,
+        sampling_strategy=sampling,
+        selection_strategy=selection,
+        cache_evaluation=cache,
+        callbacks=[log],
+        run_dir=str(run_dir),
+        seed=0,
+        display_progress_bar=False,
+    )
+    return result, adapter, log.by
+
+
+def state_trace_entries(run_dir):
+    state = GEPAState.load(str(run_dir))
+    assert state.is_consistent()
+    return [t for t in state.full_program_trace if "n_tasks" in t]
+
+
+def _assert_invariants(result, adapter, by, run_dir, expect_tasks, topk):
+    # I1 — budget truth
+    budget = by["on_budget_updated"]
+    assert budget, "no budget events"
+    assert budget[-1]["metric_calls_used"] == adapter.metric_calls
+    assert result.total_metric_calls == adapter.metric_calls
+    for prev, cur in pairwise(budget):
+        assert cur["metric_calls_used"] == prev["metric_calls_used"] + cur["metric_calls_delta"]
+    assert budget[0]["metric_calls_used"] - budget[0]["metric_calls_delta"] == len(TRAIN)
+
+    # I2 — candidates and lineage
+    accepted = by["on_candidate_accepted"]
+    assert len(result.candidates) == 1 + len(accepted)
+    for e in accepted:
+        assert all(0 <= pid < e["new_candidate_idx"] for pid in e["parent_ids"])
+
+    # I2b — every accepted program index appears in the trace (no overwrite)
+    traced = [idx for t in state_trace_entries(run_dir) for idx in t.get("new_program_indices", [])]
+    assert sorted(traced) == list(range(1, len(result.candidates)))
+
+    # I4 — event pairing
+    n_prop = len(by["on_proposal_end"])
+    assert len(by["on_evaluation_start"]) == len(by["on_evaluation_end"])
+    assert len([e for e in by["on_evaluation_end"] if e.get("candidate_idx") is None]) == n_prop
+
+    # I5 — trace + save/load
+    entries = state_trace_entries(run_dir)
+    assert entries, "no trace entries with task records"
+    assert all(t["n_tasks"] == expect_tasks and len(t["tasks"]) == expect_tasks for t in entries)
+    assert sum(1 for t in entries for task in t["tasks"] if "new_subsample_scores" in task) == n_prop
+    assert all(t["selected_program_candidate"] == t["tasks"][0]["parent_idx"] for t in entries if t["tasks"])
+
+    # I3 — margin-correct selection + truthful rejection classes
+    rejected = by["on_candidate_rejected"]
+    sel_dropped = [e for e in rejected if "not selected by the selection strategy" in e["reason"]]
+    duplicates = [e for e in rejected if "Duplicate of another candidate" in e["reason"]]
+    crit_rejected = [e for e in rejected if e not in sel_dropped and e not in duplicates]
+    for e in sel_dropped:
+        assert e["new_score"] > e["old_score"], "selection-dropped reason on a non-improving proposal"
+    for e in crit_rejected:
+        assert not e["new_score"] > e["old_score"], "criterion-rejection reason on an improving proposal"
+    if topk is not None:
+        acc_by_iter = defaultdict(int)
+        for e in accepted:
+            acc_by_iter[e["iteration"]] += 1
+        margins_by_iter = {}
+        it = 0
+        for t in entries:
+            it += 1
+            margins_by_iter[it] = sorted(
+                (
+                    sum(task["new_subsample_scores"]) - sum(task["subsample_scores"])
+                    for task in t["tasks"]
+                    if "new_subsample_scores" in task
+                ),
+                reverse=True,
+            )
+        dup_by_iter = defaultdict(int)
+        for e in duplicates:
+            dup_by_iter[e["iteration"]] += 1
+        for it, margins in margins_by_iter.items():
+            improving = [m for m in margins if m > 0]
+            expected = min(topk, len(improving))
+            got = acc_by_iter.get(it, 0)
+            # Identical selected children are deduplicated, so accepted may
+            # fall below the naive expectation by exactly the duplicates removed.
+            assert expected - dup_by_iter.get(it, 0) <= got <= expected
+            drop_margins = [e["new_score"] - e["old_score"] for e in sel_dropped if e["iteration"] == it]
+            if drop_margins and len(improving) >= topk:
+                assert max(drop_margins) <= improving[topk - 1]
+
+    # I6 — batched adapters get grouped calls in multi-task iterations
+    if isinstance(adapter, BatchedSyntheticAdapter) and expect_tasks > 1:
+        assert any(n > 1 for n in adapter.grouped_calls)
+
+
+CONFIGS = [
+    ("single-all-plain", SingleMutationSampling, AllImprovements, SyntheticAdapter, False, 1, None),
+    ("pxn4x4-top2-plain", lambda: PxNSampling(p=4, n=4), lambda: TopKImprovements(k=2), SyntheticAdapter, False, 16, 2),
+    ("pxn4x4-best-batched-cache", lambda: PxNSampling(p=4, n=4), BestImprovement, BatchedSyntheticAdapter, True, 16, 1),
+    ("same4-all-batched", lambda: SameParentSampling(n=4), AllImprovements, BatchedSyntheticAdapter, False, 4, None),
+    ("indep4-top2-cache", lambda: IndependentSampling(n=4), lambda: TopKImprovements(k=2), SyntheticAdapter, True, 4, 2),
+]
+
+
+@pytest.mark.parametrize("name,sampling,selection,adapter_cls,cache,expect_tasks,topk", CONFIGS, ids=[c[0] for c in CONFIGS])
+def test_multi_proposal_invariants(tmp_path, name, sampling, selection, adapter_cls, cache, expect_tasks, topk):
+    result, adapter, by = _run(sampling(), selection(), adapter_cls, cache, tmp_path / name)
+    _assert_invariants(result, adapter, by, tmp_path / name, expect_tasks, topk)
+
+
+def test_multi_proposal_determinism(tmp_path):
+    r1, _a1, _ = _run(PxNSampling(p=4, n=4), TopKImprovements(k=2), SyntheticAdapter, False, tmp_path / "d1")
+    r2, _a2, _ = _run(PxNSampling(p=4, n=4), TopKImprovements(k=2), SyntheticAdapter, False, tmp_path / "d2")
+    assert r1.best_candidate == r2.best_candidate
+    assert r1.total_metric_calls == r2.total_metric_calls
+    assert len(r1.candidates) == len(r2.candidates)
+
+
+class ConstantReflectionLM:
+    """Always proposes the same improved text — every task in an iteration
+    yields an identical child."""
+
+    def __call__(self, prompt):
+        return "```\nLEVEL=9\n```"
+
+
+def test_identical_children_are_deduplicated(tmp_path):
+    """Two tasks proposing byte-identical children must yield ONE pool entry,
+    one valset eval, and a truthful duplicate-rejection for the other."""
+    adapter = SyntheticAdapter()
+    log = _EventLog()
+    result = gepa.optimize(
+        seed_candidate={"system_prompt": "LEVEL=0"},
+        trainset=TRAIN,
+        valset=TRAIN,
+        adapter=adapter,
+        reflection_lm=ConstantReflectionLM(),
+        max_metric_calls=80,
+        sampling_strategy=SameParentSampling(n=2),
+        callbacks=[log],
+        run_dir=str(tmp_path / "dedup"),
+        seed=0,
+        display_progress_bar=False,
+    )
+    candidates = [c["system_prompt"] for c in result.candidates]
+    assert len(candidates) == len(set(candidates)), f"duplicate pool entries: {candidates}"
+    dup_rejections = [
+        e for e in log.by["on_candidate_rejected"] if "Duplicate of another candidate" in e["reason"]
+    ]
+    assert dup_rejections, "expected duplicate-rejection events for identical children"
+
+
+class EveryOtherCallCriterion:
+    """Stateful acceptance: alternates verdicts BY CALL. If the engine judges
+    any proposal more than once, verdicts flip and selection/classification
+    disagree — the pre-#329 contract is one judgement per proposal."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def should_accept(self, proposal, state):
+        self.calls += 1
+        return self.calls % 2 == 1
+
+    def reject_reason(self, proposal, state):
+        return "rejected by every-other-call criterion"
+
+
+def test_stateful_acceptance_criterion_judged_once_per_proposal(tmp_path):
+    criterion = EveryOtherCallCriterion()
+    log = _EventLog()
+    _result = gepa.optimize(
+        seed_candidate={"system_prompt": "LEVEL=0"},
+        trainset=TRAIN,
+        valset=TRAIN,
+        adapter=SyntheticAdapter(),
+        reflection_lm=SyntheticReflectionLM(),
+        max_metric_calls=200,
+        sampling_strategy=SameParentSampling(n=2),
+        acceptance_criterion=criterion,
+        callbacks=[log],
+        run_dir=str(tmp_path / "stateful"),
+        seed=0,
+        display_progress_bar=False,
+    )
+    n_proposals = len(log.by["on_proposal_end"])
+    assert criterion.calls == n_proposals, (
+        f"criterion judged {criterion.calls} times for {n_proposals} proposals — must be exactly once each"
+    )
+    # Every-other acceptance with proposals present must accept roughly half.
+    assert len(log.by["on_candidate_accepted"]) > 0
+    # The custom reject_reason hook must be honored for criterion rejections.
+    crit_rejects = [
+        e
+        for e in log.by["on_candidate_rejected"]
+        if "not selected" not in e["reason"] and "Duplicate" not in e["reason"]
+    ]
+    assert all("every-other-call criterion" in e["reason"] for e in crit_rejects)

--- a/tests/test_optimize_anything_batch_eval.py
+++ b/tests/test_optimize_anything_batch_eval.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""Tests for OptimizeAnythingAdapter.batch_evaluate's batch-aware parallel fallback.
+
+When the engine hands multiple (candidate, batch) items to ``batch_evaluate``
+(parallel proposals / multi-accept iterations), the no-refiner path should fan
+*all* (candidate, example) pairs out across a single thread pool — saturating
+``max_workers`` across candidates — rather than running one underfilled pool per
+candidate.
+"""
+
+import threading
+
+import pytest
+
+from gepa.adapters.optimize_anything_adapter.optimize_anything_adapter import OptimizeAnythingAdapter
+
+
+def _make_evaluator(barrier: threading.Barrier | None = None):
+    """Evaluator returning the (score, output, side_info) 3-tuple the adapter expects.
+
+    score = example + candidate["bias"]; an optional barrier lets a test assert
+    that N pairs run concurrently.
+    """
+
+    def _eval(candidate, example=None, opt_state=None):
+        if barrier is not None:
+            barrier.wait(timeout=5)
+        score = float(example) + float(candidate["bias"])
+        side_info = {"example": example, "bias": candidate["bias"]}
+        output = (score, candidate, side_info)
+        return score, output, side_info
+
+    return _eval
+
+
+def test_batch_evaluate_fans_all_pairs_concurrently():
+    # 2 candidates x 2 examples = 4 pairs. A Barrier(4) only releases when all
+    # four evaluator calls are in flight at once. The old per-candidate path
+    # (2-wide waves) could never assemble 4 at the barrier -> BrokenBarrierError.
+    barrier = threading.Barrier(4)
+    adapter = OptimizeAnythingAdapter(
+        evaluator=_make_evaluator(barrier=barrier),
+        parallel=True,
+        max_workers=8,
+        cache_mode="off",
+    )
+    items = [
+        ({"bias": "0"}, [1, 2]),
+        ({"bias": "10"}, [3, 4]),
+    ]
+
+    results = adapter.batch_evaluate(items)
+
+    assert [r.scores for r in results] == [[1.0, 2.0], [13.0, 14.0]]
+
+
+def test_batch_evaluate_regroups_results_per_item():
+    # Uneven batch sizes: results must be regrouped back to the right item and
+    # keep per-item example order.
+    adapter = OptimizeAnythingAdapter(
+        evaluator=_make_evaluator(),
+        parallel=True,
+        max_workers=4,
+        cache_mode="off",
+    )
+    items = [
+        ({"bias": "0"}, [1, 2, 3]),
+        ({"bias": "100"}, [5]),
+    ]
+
+    results = adapter.batch_evaluate(items)
+
+    assert len(results) == 2
+    assert results[0].scores == [1.0, 2.0, 3.0]
+    assert results[1].scores == [105.0]
+    # outputs carry the candidate that produced them
+    assert all(out[1]["bias"] == "0" for out in results[0].outputs)
+    assert results[1].outputs[0][1]["bias"] == "100"
+    # trajectories (side_infos) line up with examples, in order
+    assert [t["example"] for t in results[0].trajectories] == [1, 2, 3]
+    assert [t["example"] for t in results[1].trajectories] == [5]
+
+
+def test_batch_evaluate_matches_per_item_evaluate():
+    # The batched fallback must produce results identical to calling evaluate()
+    # once per item (the behavior it replaces).
+    adapter = OptimizeAnythingAdapter(
+        evaluator=_make_evaluator(),
+        parallel=True,
+        max_workers=4,
+        cache_mode="off",
+    )
+    items = [
+        ({"bias": "0"}, [1, 2]),
+        ({"bias": "5"}, [3]),
+    ]
+
+    batched = adapter.batch_evaluate(items)
+    per_item = [adapter.evaluate(batch, candidate, capture_traces=True) for candidate, batch in items]
+
+    for b, p in zip(batched, per_item, strict=True):
+        assert b.scores == p.scores
+        assert b.objective_scores == p.objective_scores
+        assert b.num_metric_calls == p.num_metric_calls
+
+
+@pytest.mark.parametrize("parallel", [True, False])
+def test_batch_evaluate_single_item_unchanged(parallel):
+    # A single item is not routed through the cross-candidate fan-out; it still
+    # produces correct results on both parallel and sequential settings.
+    adapter = OptimizeAnythingAdapter(
+        evaluator=_make_evaluator(),
+        parallel=parallel,
+        max_workers=4,
+        cache_mode="off",
+    )
+    items = [({"bias": "1"}, [1, 2, 3])]
+
+    results = adapter.batch_evaluate(items)
+
+    assert len(results) == 1
+    assert results[0].scores == [2.0, 3.0, 4.0]

--- a/tests/test_parallel_proposals.py
+++ b/tests/test_parallel_proposals.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""Tests for batch-based parallel proposals."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gepa.core.adapter import EvaluationBatch, default_batch_evaluate
+from gepa.core.state import GEPAState, ValsetEvaluation
+from gepa.proposer.base import CandidateProposal, SubsampleEvaluation
+from gepa.strategies.acceptance import StrictImprovementAcceptance
+from gepa.strategies.proposal_sampling import (
+    IndependentSampling,
+    PxNSampling,
+    SameParentSampling,
+    SingleMutationSampling,
+)
+from gepa.strategies.proposal_selection import (
+    AllImprovements,
+    BestImprovement,
+    TopKImprovements,
+)
+
+
+@pytest.fixture
+def mock_state():
+    """Create a GEPAState with 2 candidates."""
+    seed_candidate = {"system_prompt": "test0"}
+    base_eval = ValsetEvaluation(
+        outputs_by_val_id={0: "out0", 1: "out1"},
+        scores_by_val_id={0: 0.5, 1: 0.5},
+        objective_scores_by_val_id=None,
+    )
+    state = GEPAState(seed_candidate, base_eval, track_best_outputs=False)
+
+    # Add a second candidate
+    state.program_candidates.append({"system_prompt": "test1"})
+    state.prog_candidate_val_subscores.append({0: 0.7, 1: 0.7})
+    state.prog_candidate_objective_scores.append({})
+    state.parent_program_for_candidate.append([0])
+    state.named_predictor_id_to_update_next_for_program_candidate.append(0)
+    state.num_metric_calls_by_discovery.append(0)
+
+    for i in range(len(state.pareto_front_valset)):
+        state.program_at_pareto_front_valset[i] = {0, 1}
+
+    assert state.is_consistent()
+    return state
+
+
+@pytest.fixture
+def mock_candidate_selector():
+    selector = MagicMock()
+    selector.select_candidate_idx = MagicMock(return_value=0)
+    return selector
+
+
+@pytest.fixture
+def mock_batch_sampler():
+    sampler = MagicMock()
+    call_count = 0
+
+    def next_ids(trainset, state):
+        nonlocal call_count
+        call_count += 1
+        return [call_count - 1]
+
+    sampler.next_minibatch_ids = MagicMock(side_effect=next_ids)
+    return sampler
+
+
+@pytest.fixture
+def mock_trainset():
+    trainset = MagicMock()
+    trainset.fetch = MagicMock(side_effect=lambda ids: [f"example_{i}" for i in ids])
+    trainset.all_ids = MagicMock(return_value=[0, 1, 2, 3])
+    trainset.__len__ = MagicMock(return_value=4)
+    return trainset
+
+
+class TestSamplingStrategies:
+    def test_single_mutation(self, mock_state, mock_candidate_selector, mock_batch_sampler, mock_trainset):
+        strategy = SingleMutationSampling()
+        tasks = strategy.sample_tasks(mock_state, mock_candidate_selector, mock_batch_sampler, mock_trainset)
+        assert len(tasks) == 1
+        assert tasks[0].parent_idx == 0
+
+    def test_same_parent_sampling(self, mock_state, mock_candidate_selector, mock_batch_sampler, mock_trainset):
+        strategy = SameParentSampling(n=3)
+        tasks = strategy.sample_tasks(mock_state, mock_candidate_selector, mock_batch_sampler, mock_trainset)
+        assert len(tasks) == 3
+        # All tasks should have the same parent
+        assert all(t.parent_idx == tasks[0].parent_idx for t in tasks)
+        # But different minibatches
+        ids = [tuple(t.minibatch_ids) for t in tasks]
+        assert len(set(ids)) == 3
+
+    def test_independent_sampling(self, mock_state, mock_candidate_selector, mock_batch_sampler, mock_trainset):
+        strategy = IndependentSampling(n=4)
+        tasks = strategy.sample_tasks(mock_state, mock_candidate_selector, mock_batch_sampler, mock_trainset)
+        assert len(tasks) == 4
+        # Selector called 4 times
+        assert mock_candidate_selector.select_candidate_idx.call_count == 4
+
+    def test_pxn_sampling(self, mock_state, mock_candidate_selector, mock_batch_sampler, mock_trainset):
+        strategy = PxNSampling(p=2, n=3)
+        tasks = strategy.sample_tasks(mock_state, mock_candidate_selector, mock_batch_sampler, mock_trainset)
+        assert len(tasks) == 6  # 2 * 3
+        # Selector called 2 times (once per parent)
+        assert mock_candidate_selector.select_candidate_idx.call_count == 2
+
+
+class TestSelectionStrategies:
+    def _make_proposal(self, before: float, after: float) -> CandidateProposal:
+        return CandidateProposal(
+            candidate={"prompt": "test"},
+            parent_program_ids=[0],
+            subsample_indices=[0],
+            subsample_scores_before=[before],
+            subsample_scores_after=[after],
+            eval_before=SubsampleEvaluation(scores=[before], outputs=["out"]),
+            eval_after=SubsampleEvaluation(scores=[after], outputs=["out"]),
+            tag="test",
+        )
+
+    def test_all_improvements(self, mock_state):
+        strategy = AllImprovements()
+        criterion = StrictImprovementAcceptance()
+        proposals = [
+            self._make_proposal(0.5, 0.8),  # improvement
+            self._make_proposal(0.5, 0.3),  # regression
+            self._make_proposal(0.5, 0.6),  # improvement
+        ]
+        accepted = strategy.select(proposals, mock_state, criterion)
+        assert len(accepted) == 2
+
+    def test_best_improvement(self, mock_state):
+        strategy = BestImprovement()
+        criterion = StrictImprovementAcceptance()
+        proposals = [
+            self._make_proposal(0.5, 0.8),
+            self._make_proposal(0.5, 0.9),
+            self._make_proposal(0.5, 0.6),
+        ]
+        accepted = strategy.select(proposals, mock_state, criterion)
+        assert len(accepted) == 1
+        assert accepted[0].subsample_scores_after == [0.9]
+
+    def test_best_improvement_none_pass(self, mock_state):
+        strategy = BestImprovement()
+        criterion = StrictImprovementAcceptance()
+        proposals = [self._make_proposal(0.5, 0.3)]
+        accepted = strategy.select(proposals, mock_state, criterion)
+        assert len(accepted) == 0
+
+    def test_top_k_improvements(self, mock_state):
+        strategy = TopKImprovements(k=2)
+        criterion = StrictImprovementAcceptance()
+        proposals = [
+            self._make_proposal(0.5, 0.9),
+            self._make_proposal(0.5, 0.6),
+            self._make_proposal(0.5, 0.8),
+            self._make_proposal(0.5, 0.3),
+        ]
+        accepted = strategy.select(proposals, mock_state, criterion)
+        assert len(accepted) == 2
+        assert accepted[0].subsample_scores_after == [0.9]
+        assert accepted[1].subsample_scores_after == [0.8]
+
+
+class TestDefaultBatchEvaluate:
+    def test_sequential_fallback(self):
+        adapter = MagicMock()
+        eval_result = EvaluationBatch(outputs=["out"], scores=[0.5])
+        adapter.evaluate = MagicMock(return_value=eval_result)
+
+        items = [
+            ({"prompt": "a"}, ["ex1"]),
+            ({"prompt": "b"}, ["ex2"]),
+        ]
+        results = default_batch_evaluate(adapter, items)
+        assert len(results) == 2
+        assert adapter.evaluate.call_count == 2
+
+
+class TestDefaultStrategiesRetainBehavior:
+    """Verify that default strategies produce the expected behavior."""
+
+    def test_single_mutation_is_default_sampling(self):
+        strategy = SingleMutationSampling()
+        assert hasattr(strategy, "sample_tasks")
+
+    def test_all_improvements_is_default_selection(self):
+        strategy = AllImprovements()
+        assert hasattr(strategy, "select")

--- a/tests/test_parallel_proposals.py
+++ b/tests/test_parallel_proposals.py
@@ -3,9 +3,12 @@
 
 """Tests for batch-based parallel proposals."""
 
+from itertools import pairwise
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from conftest import create_mocked_lms_context
 
 from gepa.core.adapter import EvaluationBatch, default_batch_evaluate
 from gepa.core.state import GEPAState, ValsetEvaluation
@@ -185,13 +188,154 @@ class TestDefaultBatchEvaluate:
         assert adapter.evaluate.call_count == 2
 
 
+class _EventLog:
+    """Records every callback event GEPA emits, in order."""
+
+    def __init__(self):
+        self.events: list[tuple[str, dict]] = []
+
+    def __getattr__(self, name):
+        if name.startswith("on_"):
+
+            def _record(event, _name=name):
+                self.events.append((_name, dict(event)))
+
+            return _record
+        raise AttributeError(name)
+
+    def names(self) -> list[str]:
+        return [n for n, _ in self.events]
+
+    def of(self, name: str) -> list[dict]:
+        return [e for n, e in self.events if n == name]
+
+
+_AIME_CACHE_DIR = Path(__file__).parent / "test_aime_prompt_optimization"
+_AIME_SEED_PROMPT = (
+    "You are a helpful assistant. You are given a question and you need to answer it. "
+    "The answer should be given at the end of your response in exactly the format '### <final answer>'"
+)
+
+
+@pytest.fixture(scope="module")
+def aime_lms():
+    """Replay LMs backed by the recorded AIME run (fails on any unseen LM input)."""
+    yield from create_mocked_lms_context(_AIME_CACHE_DIR)
+
+
+def _run_recorded_optimization(aime_lms, sampling_strategy=None, selection_strategy=None):
+    import gepa
+    from gepa.adapters.default_adapter.default_adapter import DefaultAdapter
+
+    task_lm, reflection_lm = aime_lms
+    trainset, valset, _ = gepa.examples.aime.init_dataset()
+    log = _EventLog()
+    result = gepa.optimize(
+        seed_candidate={"system_prompt": _AIME_SEED_PROMPT},
+        trainset=trainset[:10],
+        valset=valset[:10],
+        adapter=DefaultAdapter(model=task_lm),
+        max_metric_calls=30,
+        reflection_lm=reflection_lm,
+        callbacks=[log],
+        display_progress_bar=False,
+        sampling_strategy=sampling_strategy,
+        selection_strategy=selection_strategy,
+    )
+    return result, log
+
+
+@pytest.fixture(scope="module")
+def default_run(aime_lms):
+    """The default path (sampling/selection strategies left unset)."""
+    return _run_recorded_optimization(aime_lms)
+
+
+@pytest.fixture(scope="module")
+def explicit_run(aime_lms):
+    """Same run with the documented defaults passed explicitly."""
+    return _run_recorded_optimization(
+        aime_lms,
+        sampling_strategy=SingleMutationSampling(),
+        selection_strategy=AllImprovements(),
+    )
+
+
 class TestDefaultStrategiesRetainBehavior:
-    """Verify that default strategies produce the expected behavior."""
+    """Pin the default path against a fully cached, pre-#369 GEPA run.
 
-    def test_single_mutation_is_default_sampling(self):
-        strategy = SingleMutationSampling()
-        assert hasattr(strategy, "sample_tasks")
+    The replay fixture hard-fails on any LM input that is not in the recorded
+    cache, so these tests only pass if the default
+    SingleMutationSampling + AllImprovements path reproduces the recorded run's
+    exact LM request stream. On top of that we pin the final result, the budget
+    ledger, and the callback-event stream.
+    """
 
-    def test_all_improvements_is_default_selection(self):
-        strategy = AllImprovements()
-        assert hasattr(strategy, "select")
+    def test_default_path_reproduces_recorded_run(self, default_run):
+        result, _ = default_run
+        golden = (_AIME_CACHE_DIR / "optimized_prompt.txt").read_text()
+        assert result.best_candidate["system_prompt"] == golden
+
+    def test_budget_ledger_is_consistent(self, default_run):
+        result, log = default_run
+        budget = log.of("on_budget_updated")
+        assert budget, "expected at least one on_budget_updated event"
+        assert all(e["metric_calls_delta"] > 0 for e in budget)
+        used = [e["metric_calls_used"] for e in budget]
+        assert used == sorted(used), "metric_calls_used must be monotonic"
+        # Every event's absolute counter must agree with the previous one plus
+        # its own delta (no unaccounted increments once the hook is live).
+        for prev, cur in pairwise(budget):
+            assert cur["metric_calls_used"] == prev["metric_calls_used"] + cur["metric_calls_delta"]
+        # The only increment that predates hook registration is the seed's
+        # full-valset evaluation (10 examples in the recorded run).
+        assert used[0] - budget[0]["metric_calls_delta"] == 10
+        assert used[-1] == result.total_metric_calls
+
+    def test_explicit_defaults_identical_to_implicit_defaults(self, default_run, explicit_run):
+        d_result, d_log = default_run
+        e_result, e_log = explicit_run
+        assert e_result.best_candidate == d_result.best_candidate
+        assert e_result.total_metric_calls == d_result.total_metric_calls
+        assert e_log.names() == d_log.names()
+
+    def test_proposal_event_ordering(self, default_run):
+        _, log = default_run
+        names = log.names()
+        for earlier, later in [
+            ("on_candidate_selected", "on_minibatch_sampled"),
+            ("on_minibatch_sampled", "on_reflective_dataset_built"),
+            ("on_reflective_dataset_built", "on_proposal_start"),
+            ("on_proposal_start", "on_proposal_end"),
+        ]:
+            assert earlier in names and later in names, f"missing {earlier}/{later}"
+            assert names.index(earlier) < names.index(later)
+
+    def test_budget_event_granularity_contract(self, default_run):
+        """Each completed proposal emits separate parent-eval and child-eval
+        budget events (finer granularity than pre-#369; totals unchanged), and
+        each *accepted* candidate's full-valset evaluation emits one more (the
+        seed's valset eval precedes budget-hook registration, so it produces an
+        on_valset_evaluated event but no budget event). Pin the composition so
+        any future change to budget-event granularity is made consciously."""
+        _, log = default_run
+        n_proposals = len(log.of("on_proposal_end"))
+        n_budget = len(log.of("on_budget_updated"))
+        n_accepted = len(log.of("on_candidate_accepted"))
+        assert n_budget == 2 * n_proposals + n_accepted, (
+            f"budget-event composition changed: {n_budget} events for "
+            f"{n_proposals} proposals + {n_accepted} accepted candidates"
+        )
+
+    def test_child_evaluation_events_are_emitted(self, default_run):
+        """Parity with the pre-#369 sequential path: every completed proposal
+        produces an evaluation start/end pair for the parent minibatch eval AND
+        one for the new candidate's minibatch eval (child pairs carry
+        candidate_idx=None because the child is not in the pool yet)."""
+        _, log = default_run
+        starts = log.of("on_evaluation_start")
+        ends = log.of("on_evaluation_end")
+        n_proposals = len(log.of("on_proposal_end"))
+        assert len(starts) == len(ends) == 2 * n_proposals
+        child_ends = [e for e in ends if e["candidate_idx"] is None]
+        assert len(child_ends) == n_proposals

--- a/tests/test_parallel_proposals.py
+++ b/tests/test_parallel_proposals.py
@@ -364,3 +364,41 @@ def test_selection_strategy_sees_all_proposals_including_rejected(aime_lms):
     assert True in spy.seen
     golden = (_AIME_CACHE_DIR / "optimized_prompt.txt").read_text()
     assert result.best_candidate["system_prompt"] == golden
+
+
+def test_selection_dropped_rejection_reason_is_truthful():
+    """A proposal that PASSES acceptance but is dropped by selection must not
+    be reported as a score regression (engine reason poisoning fix)."""
+    from unittest.mock import MagicMock
+
+    from gepa.core.engine import GEPAEngine
+
+    proposal = CandidateProposal(
+        candidate={"p": "x"},
+        parent_program_ids=[0],
+        subsample_indices=[0],
+        subsample_scores_before=[5.0],
+        subsample_scores_after=[8.0],
+        eval_before=SubsampleEvaluation(scores=[5.0], outputs=["o"]),
+        eval_after=SubsampleEvaluation(scores=[8.0], outputs=["o"]),
+        tag="test",
+    )
+    mock_engine = MagicMock()
+    mock_engine.acceptance_criterion = StrictImprovementAcceptance()
+    mock_engine.selection_strategy = BestImprovement()
+    logged: list[str] = []
+    mock_engine.logger.log = lambda m: logged.append(m)
+    events: list[dict] = []
+    mock_engine.callbacks = [type("Cb", (), {"on_candidate_rejected": staticmethod(lambda e: events.append(dict(e)))})()]
+
+    GEPAEngine._report_rejected_proposal(mock_engine, proposal, 3, MagicMock(), dropped_by_selection=True)
+
+    assert "not selected by the selection strategy (BestImprovement)" in logged[0]
+    assert "not better than" not in logged[0]
+    assert "not selected by the selection strategy" in events[0]["reason"]
+
+    # Acceptance-failed path keeps the classic message.
+    logged.clear()
+    events.clear()
+    GEPAEngine._report_rejected_proposal(mock_engine, proposal, 3, MagicMock(), dropped_by_selection=False)
+    assert "not better than" in logged[0] or "rejected by acceptance criterion" in logged[0]

--- a/tests/test_parallel_proposals.py
+++ b/tests/test_parallel_proposals.py
@@ -339,3 +339,28 @@ class TestDefaultStrategiesRetainBehavior:
         assert len(starts) == len(ends) == 2 * n_proposals
         child_ends = [e for e in ends if e["candidate_idx"] is None]
         assert len(child_ends) == n_proposals
+
+
+class _SpySelection(AllImprovements):
+    """Records every (proposal, criterion verdict) the engine hands to selection."""
+
+    def __init__(self):
+        self.seen: list[bool] = []
+
+    def select(self, proposals, state, acceptance_criterion):
+        self.seen.extend(acceptance_criterion.should_accept(p, state) for p in proposals)
+        return super().select(proposals, state, acceptance_criterion)
+
+
+def test_selection_strategy_sees_all_proposals_including_rejected(aime_lms):
+    """The engine must not pre-filter: a custom SelectionStrategy receives ALL
+    evaluated proposals together with the acceptance criterion, including ones
+    the criterion rejects (which the built-in strategies then filter). In the
+    recorded run, iteration 1's proposal fails acceptance and iteration 2's
+    passes — the spy must see both verdicts."""
+    spy = _SpySelection()
+    result, _ = _run_recorded_optimization(aime_lms, selection_strategy=spy)
+    assert False in spy.seen, "criterion-rejected proposal was pre-filtered before selection"
+    assert True in spy.seen
+    golden = (_AIME_CACHE_DIR / "optimized_prompt.txt").read_text()
+    assert result.best_candidate["system_prompt"] == golden

--- a/tests/test_parallel_valset_eval.py
+++ b/tests/test_parallel_valset_eval.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""End-to-end test for batched full-valset eval of multiple accepted candidates.
+
+A multi-proposal sampler (``IndependentSampling``) can accept several candidates
+in one iteration. Their full-valset evaluations are batched into a single
+``adapter.batch_evaluate`` call (where any parallelism lives), while the engine
+stays single-threaded and pool/Pareto mutation stays sequential.
+"""
+
+from gepa.core.adapter import EvaluationBatch
+from gepa.strategies.proposal_sampling import IndependentSampling, SingleMutationSampling
+from gepa.strategies.proposal_selection import AllImprovements
+
+
+class ImprovingAdapter:
+    """Each proposal lengthens the prompt; score grows with length, so the
+    proposed candidate beats its parent and is accepted."""
+
+    def __init__(self):
+        self.propose_new_texts = self._propose_new_texts
+        self._suffix = 0
+
+    def evaluate(self, batch, candidate, capture_traces=False):
+        score = min(1.0, len(candidate["system_prompt"]) / 80.0)
+        outputs = [score for _ in batch]
+        scores = [score for _ in batch]
+        trajectories = [{"score": score} for _ in batch] if capture_traces else None
+        return EvaluationBatch(outputs=outputs, scores=scores, trajectories=trajectories)
+
+    def make_reflective_dataset(self, candidate, eval_batch, components_to_update):
+        return {c: [{"score": s} for s in eval_batch.scores] for c in components_to_update}
+
+    def _propose_new_texts(self, candidate, reflective_dataset, components_to_update):
+        out = {}
+        for c in components_to_update:
+            self._suffix += 1
+            out[c] = candidate.get(c, "") + f" w{self._suffix}"  # distinct + longer => improves
+        return out
+
+
+class BatchImprovingAdapter(ImprovingAdapter):
+    """Adds a real ``batch_evaluate`` and records the items of each call."""
+
+    def __init__(self):
+        super().__init__()
+        self.batch_calls: list[int] = []
+
+    def batch_evaluate(self, items):
+        self.batch_calls.append(len(items))
+        return [self.evaluate(batch, candidate, capture_traces=True) for candidate, batch in items]
+
+
+def _run(adapter, sampling_strategy, tmp_path):
+    import gepa
+
+    return gepa.optimize(
+        seed_candidate={"system_prompt": "s"},
+        trainset=[{"id": i} for i in range(4)],
+        valset=[{"id": i} for i in range(4)],
+        adapter=adapter,
+        max_metric_calls=300,
+        reflection_lm=None,
+        sampling_strategy=sampling_strategy,
+        selection_strategy=AllImprovements(),
+        run_dir=str(tmp_path),
+    )
+
+
+def test_multiple_candidates_accepted_and_evaluated_in_one_iteration(tmp_path):
+    """IndependentSampling(3) + AllImprovements accepts several candidates per
+    iteration; all are full-eval'd and added to the pool."""
+    result = _run(ImprovingAdapter(), IndependentSampling(3), tmp_path)
+    # Seed plus multiple accepted candidates (3 per iteration when all improve).
+    assert len(result.candidates) > 2
+    assert result.total_metric_calls > 0
+    # Best discovered candidate is at least as good as the seed.
+    assert max(result.val_aggregate_scores) >= result.val_aggregate_scores[0]
+
+
+def test_accepted_candidates_share_one_batch_evaluate_call(tmp_path):
+    """When the adapter implements batch_evaluate, the valset evals of all
+    candidates accepted in one iteration go out as a single batched call."""
+    adapter = BatchImprovingAdapter()
+    result = _run(adapter, IndependentSampling(3), tmp_path)
+    assert len(result.candidates) > 2
+    # At least one iteration batched several candidates into one batch_evaluate call.
+    assert any(n > 1 for n in adapter.batch_calls)
+
+
+def test_single_mutation_still_works(tmp_path):
+    """Default single-proposal path (one accepted candidate) is unaffected."""
+    result = _run(ImprovingAdapter(), SingleMutationSampling(), tmp_path)
+    assert len(result.candidates) >= 1
+    assert result.total_metric_calls > 0

--- a/tests/test_reflection_lm.py
+++ b/tests/test_reflection_lm.py
@@ -212,3 +212,117 @@ def test_reflect_only_strategy_used_per_task_in_batch_path():
     results = proposer._propose_texts_batch(jobs)
     assert stub.calls == [["c"], ["c"]]
     assert [r[0] for r in results] == [{"c": "new_c"}, {"c": "new_c"}]
+
+
+# ---------------------------------------------------------------------------
+# H1: empty reflection output must not produce a phantom child
+# ---------------------------------------------------------------------------
+
+
+class _FixedProposalLM:
+    """ReflectionLM stub returning a fixed new_texts dict."""
+
+    def __init__(self, new_texts):
+        self._new_texts = new_texts
+
+    def reflect(self, candidate, reflective_dataset, components_to_update):
+        return ReflectionProposal(new_texts=dict(self._new_texts)), self
+
+
+def _make_propose_harness(reflection_strategy):
+    from unittest.mock import MagicMock
+
+    from gepa.core.adapter import EvaluationBatch
+
+    parent_eval = EvaluationBatch(
+        outputs=["o"], scores=[0.4], trajectories=[{"step": 1}], objective_scores=None, num_metric_calls=1
+    )
+    adapter = MagicMock()
+    adapter.propose_new_texts = None
+    adapter.batch_evaluate = MagicMock(return_value=[parent_eval])
+    adapter.make_reflective_dataset = MagicMock(return_value={"c": [{"feedback": "f"}]})
+
+    candidate_selector = MagicMock()
+    candidate_selector.select_candidate_idx.return_value = 0
+    batch_sampler = MagicMock()
+    batch_sampler.next_minibatch_ids.return_value = [0]
+    module_selector = MagicMock(return_value=["c"])
+
+    proposer = _make_proposer(
+        adapter=adapter,
+        candidate_selector=candidate_selector,
+        batch_sampler=batch_sampler,
+        module_selector=module_selector,
+        trainset=[{"q": 0}],
+        reflection_strategy=reflection_strategy,
+    )
+    return proposer, adapter
+
+
+def _make_state():
+    from gepa.core.state import GEPAState, ValsetEvaluation
+
+    base_eval = ValsetEvaluation(
+        outputs_by_val_id={0: "o"}, scores_by_val_id={0: 0.5}, objective_scores_by_val_id=None
+    )
+    state = GEPAState({"c": "seed"}, base_eval, track_best_outputs=False)
+    # Set by the engine's seed initialization in real runs (state.py:704).
+    state.total_num_evals = 1
+    # The engine appends a per-iteration trace entry before calling propose().
+    state.full_program_trace.append({"i": 0})
+    return state
+
+
+def test_empty_new_texts_skips_child_without_evaluating_it():
+    proposer, adapter = _make_propose_harness(_FixedProposalLM({}))
+    proposals = proposer.propose(_make_state())
+    assert proposals == []
+    # Only the parent-stage batch evaluation ran; no metric calls were burned
+    # evaluating a child byte-identical to its parent.
+    assert adapter.batch_evaluate.call_count == 1
+
+
+def test_nonempty_new_texts_still_produces_a_proposal():
+    proposer, adapter = _make_propose_harness(_FixedProposalLM({"c": "improved"}))
+    proposals = proposer.propose(_make_state())
+    assert len(proposals) == 1
+    assert proposals[0].candidate["c"] == "improved"
+    assert adapter.batch_evaluate.call_count == 2  # parent stage + child stage
+
+
+# ---------------------------------------------------------------------------
+# H2: optimize_anything exposes reflection_strategy via ReflectionConfig
+# ---------------------------------------------------------------------------
+
+
+def test_reflection_config_accepts_reflection_strategy():
+    from gepa.optimize_anything import ReflectionConfig
+
+    stub = _ReflectOnlyLM()
+    assert ReflectionConfig(reflection_strategy=stub).reflection_strategy is stub
+    assert ReflectionConfig().reflection_strategy is None
+
+
+# ---------------------------------------------------------------------------
+# M2: TrackingLM must not hide batch_complete from callables that provide it
+# ---------------------------------------------------------------------------
+
+
+def test_tracking_lm_exposes_batch_complete_conditionally():
+    from gepa.lm import TrackingLM
+
+    plain = TrackingLM(lambda p: "x")
+    assert not hasattr(plain, "batch_complete")
+
+    class WithBatch:
+        def __call__(self, prompt):
+            return "x"
+
+        def batch_complete(self, messages_list):
+            return ["y"] * len(messages_list)
+
+    tracked = TrackingLM(WithBatch())
+    assert hasattr(tracked, "batch_complete")
+    out = tracked.batch_complete([[{"role": "user", "content": "hi"}]] * 3)
+    assert out == ["y", "y", "y"]
+    assert tracked.total_tokens_out > 0

--- a/tests/test_reflection_lm.py
+++ b/tests/test_reflection_lm.py
@@ -22,6 +22,18 @@ class RecordingLM:
         return f"Here is the update:\n```\n{self.reply}\n```"
 
 
+class BatchRecordingLM(RecordingLM):
+    """A fake LM that also exposes ``batch_complete`` (like ``gepa.lm.LM``)."""
+
+    def __init__(self, reply: str = "improved instruction"):
+        super().__init__(reply)
+        self.batch_calls: list[list] = []
+
+    def batch_complete(self, messages_list, max_workers: int = 10):
+        self.batch_calls.append(messages_list)
+        return [f"```\n{self.reply}\n```" for _ in messages_list]
+
+
 class CollectingLogger:
     def __init__(self):
         self.messages: list[str] = []
@@ -71,6 +83,54 @@ def test_reflect_skips_components_without_feedback():
     assert set(proposal.new_texts.keys()) == {"a"}
     assert len(fake.calls) == 1
     assert any("'b' is not in reflective dataset" in m for m in logger.messages)
+
+
+def test_reflect_many_batches_into_one_call():
+    """N tasks with a batch-capable LM → a single batch_complete covering all prompts."""
+    fake = BatchRecordingLM(reply="new text")
+    lm = StatelessReflectionLM(fake)
+    jobs = [
+        ({"a": "old0"}, _reflective_dataset(["a"]), ["a"]),
+        ({"a": "old1"}, _reflective_dataset(["a"]), ["a"]),
+        ({"a": "old2"}, _reflective_dataset(["a"]), ["a"]),
+    ]
+    results = lm.reflect_many(jobs)
+    assert len(results) == len(jobs)
+    assert all(proposal.new_texts == {"a": "new text"} for proposal, _ in results)
+    assert all(next_lm is lm for _, next_lm in results)
+    # One batched request covering all 3 jobs — not 3 separate completions.
+    assert len(fake.batch_calls) == 1
+    assert len(fake.batch_calls[0]) == 3
+    assert fake.calls == []  # the per-call path was not used
+
+
+def test_reflect_many_scatters_results_per_job():
+    """Each job's components must come back in its own proposal slot, in order."""
+    fake = BatchRecordingLM(reply="X")
+    lm = StatelessReflectionLM(fake)
+    jobs = [
+        ({"a": "0a", "b": "0b"}, _reflective_dataset(["a", "b"]), ["a", "b"]),
+        ({"a": "1a"}, _reflective_dataset(["a"]), ["a"]),
+    ]
+    results = lm.reflect_many(jobs)
+    assert set(results[0][0].new_texts.keys()) == {"a", "b"}
+    assert set(results[1][0].new_texts.keys()) == {"a"}
+    # 3 (job,component) prompts total, one batched call.
+    assert len(fake.batch_calls) == 1
+    assert len(fake.batch_calls[0]) == 3
+
+
+def test_reflect_many_sequential_fallback_without_batch_complete():
+    """A plain callable LM (no batch_complete) still works, one call per prompt."""
+    fake = RecordingLM(reply="Y")
+    lm = StatelessReflectionLM(fake)
+    jobs = [
+        ({"a": "0a"}, _reflective_dataset(["a"]), ["a"]),
+        ({"a": "1a"}, _reflective_dataset(["a"]), ["a"]),
+    ]
+    results = lm.reflect_many(jobs)
+    assert [p.new_texts for p, _ in results] == [{"a": "Y"}, {"a": "Y"}]
+    assert len(fake.calls) == 2
 
 
 def test_per_component_template_dict_and_missing_warning():

--- a/tests/test_reflection_lm.py
+++ b/tests/test_reflection_lm.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""Tests for the ReflectionLM protocol and StatelessReflectionLM (#329 Phase 1)."""
+
+from gepa.proposer.reflective_mutation.reflection_lm import (
+    ReflectionLM,
+    ReflectionProposal,
+    StatelessReflectionLM,
+)
+
+
+class RecordingLM:
+    """A fake reflection LM: records prompts, returns a fenced instruction."""
+
+    def __init__(self, reply: str = "improved instruction"):
+        self.reply = reply
+        self.calls: list = []
+
+    def __call__(self, prompt):
+        self.calls.append(prompt)
+        return f"Here is the update:\n```\n{self.reply}\n```"
+
+
+class CollectingLogger:
+    def __init__(self):
+        self.messages: list[str] = []
+
+    def log(self, message: str) -> None:
+        self.messages.append(message)
+
+
+def _reflective_dataset(components):
+    return {name: [{"Inputs": "x", "Generated Outputs": "y", "Feedback": "bad"}] for name in components}
+
+
+def test_stateless_reflection_lm_satisfies_protocol():
+    lm = StatelessReflectionLM(RecordingLM())
+    assert isinstance(lm, ReflectionLM)
+
+
+def test_reflect_returns_self_as_next_lm():
+    """Stateless: the next LM is the same object (no carried context)."""
+    lm = StatelessReflectionLM(RecordingLM())
+    candidate = {"system_prompt": "old"}
+    proposal, next_lm = lm.reflect(candidate, _reflective_dataset(["system_prompt"]), ["system_prompt"])
+    assert isinstance(proposal, ReflectionProposal)
+    assert next_lm is lm
+
+
+def test_reflect_proposes_new_text_per_component():
+    fake = RecordingLM(reply="brand new prompt")
+    lm = StatelessReflectionLM(fake)
+    candidate = {"a": "old_a", "b": "old_b"}
+    proposal, _ = lm.reflect(candidate, _reflective_dataset(["a", "b"]), ["a", "b"])
+    assert proposal.new_texts == {"a": "brand new prompt", "b": "brand new prompt"}
+    # Diagnostics populated per component.
+    assert set(proposal.prompts.keys()) == {"a", "b"}
+    assert set(proposal.raw_lm_outputs.keys()) == {"a", "b"}
+    assert len(fake.calls) == 2
+
+
+def test_reflect_skips_components_without_feedback():
+    fake = RecordingLM()
+    logger = CollectingLogger()
+    lm = StatelessReflectionLM(fake, logger=logger)
+    candidate = {"a": "old_a", "b": "old_b"}
+    # Only 'a' has data; 'b' is requested but absent from the reflective dataset.
+    reflective_dataset = _reflective_dataset(["a"])
+    proposal, _ = lm.reflect(candidate, reflective_dataset, ["a", "b"])
+    assert set(proposal.new_texts.keys()) == {"a"}
+    assert len(fake.calls) == 1
+    assert any("'b' is not in reflective dataset" in m for m in logger.messages)
+
+
+def test_per_component_template_dict_and_missing_warning():
+    fake = RecordingLM()
+    logger = CollectingLogger()
+    # Template provided for 'a' only; 'b' should warn once and fall back to default.
+    template_a = "Improve <curr_param> using this feedback: <side_info>"
+    lm = StatelessReflectionLM(fake, reflection_prompt_template={"a": template_a}, logger=logger)
+    candidate = {"a": "old_a", "b": "old_b"}
+    reflective_dataset = _reflective_dataset(["a", "b"])
+    lm.reflect(candidate, reflective_dataset, ["a", "b"])
+    # Warn again on a second call — but only once per component overall.
+    lm.reflect(candidate, reflective_dataset, ["a", "b"])
+    missing_warnings = [m for m in logger.messages if "No reflection_prompt_template found for parameter 'b'" in m]
+    assert len(missing_warnings) == 1

--- a/tests/test_reflection_lm.py
+++ b/tests/test_reflection_lm.py
@@ -421,3 +421,124 @@ def test_trace_records_every_task_not_just_the_first():
     # Legacy first-task keys unchanged for older tooling.
     assert entry["selected_program_candidate"] == 0
     assert entry["subsample_ids"] == [0]
+
+
+# ---------------------------------------------------------------------------
+# Adversarial-review fixes: next_lm chaining, reflect_many validation,
+# api entry point, tracker keys
+# ---------------------------------------------------------------------------
+
+
+class _ChainingLM:
+    """Stateful ReflectionLM: each reflect() returns a NEW successor."""
+
+    def __init__(self, generation=0):
+        self.generation = generation
+
+    def reflect(self, candidate, reflective_dataset, components_to_update):
+        proposal = ReflectionProposal(new_texts={c: f"gen{self.generation}_{c}" for c in components_to_update})
+        return proposal, _ChainingLM(self.generation + 1)
+
+
+def test_stateful_reflection_lm_successor_is_chained():
+    proposer = _make_proposer(reflection_strategy=_ChainingLM())
+    assert proposer._reflection_lm.generation == 0
+    proposer.propose_new_texts({"c": "x"}, {"c": [{"f": 1}]}, ["c"])
+    assert proposer._reflection_lm.generation == 1, "next_lm was discarded"
+    proposer.propose_new_texts({"c": "x"}, {"c": [{"f": 1}]}, ["c"])
+    assert proposer._reflection_lm.generation == 2
+
+
+class _WrongLengthLM:
+    def reflect(self, candidate, reflective_dataset, components_to_update):
+        return ReflectionProposal(new_texts={}), self
+
+    def reflect_many(self, jobs):
+        return []  # wrong length
+
+
+def test_reflect_many_wrong_length_raises():
+    import pytest
+
+    proposer = _make_proposer(reflection_strategy=_WrongLengthLM())
+    with pytest.raises(ValueError, match="reflect_many returned 0 results for 1 jobs"):
+        proposer._propose_texts_batch([({"c": "x"}, {"c": [{"f": 1}]}, ["c"])])
+
+
+def test_reflection_metadata_reserved_prefixes_are_remapped():
+    class _CollidingMetaLM:
+        def reflect(self, candidate, reflective_dataset, components_to_update):
+            return ReflectionProposal(
+                new_texts={c: f"new_{c}" for c in components_to_update},
+                metadata={"prompt:phantom": "spoof", "safe_key": 1},
+            ), self
+
+    proposer, _ = _make_propose_harness(_CollidingMetaLM())
+    proposals = proposer.propose(_make_state())
+    md = proposals[0].metadata
+    assert "prompt:phantom" not in md
+    assert md["reflection_meta:prompt:phantom"] == "spoof"
+    assert md["safe_key"] == 1
+
+
+def test_legacy_tracker_metric_keys_still_emitted():
+    from unittest.mock import MagicMock
+
+    tracker = MagicMock()
+    proposer, _ = _make_propose_harness(_FixedProposalLM({"c": "improved"}))
+    proposer.experiment_tracker = tracker
+    proposer.propose(_make_state())
+    logged_keys = set()
+    for call in tracker.log_metrics.call_args_list:
+        logged_keys |= set(call.args[0].keys())
+    assert {"subsample_score", "new_subsample_score"} <= logged_keys, logged_keys
+
+
+def test_gepa_optimize_accepts_reflection_strategy_without_reflection_lm():
+    import gepa
+    from gepa.core.adapter import EvaluationBatch
+
+    class Adapter:
+        propose_new_texts = None
+
+        def evaluate(self, batch, candidate, capture_traces=False):
+            return EvaluationBatch(
+                outputs=["o"] * len(batch),
+                scores=[0.5] * len(batch),
+                trajectories=[{"f": 1}] * len(batch) if capture_traces else None,
+                objective_scores=None,
+                num_metric_calls=len(batch),
+            )
+
+        def make_reflective_dataset(self, candidate, eval_batch, components):
+            return {c: [{"Feedback": "f"}] for c in components}
+
+    stub = _ReflectOnlyLM()
+    result = gepa.optimize(
+        seed_candidate={"c": "x"},
+        trainset=[{"q": 1}] * 4,
+        valset=[{"q": 1}] * 4,
+        adapter=Adapter(),
+        reflection_strategy=stub,
+        max_metric_calls=25,
+        display_progress_bar=False,
+        seed=0,
+    )
+    assert stub.calls, "reflection_strategy never invoked via gepa.optimize"
+    assert result is not None
+
+
+def test_max_reflection_cost_with_costless_strategy_raises():
+    import pytest
+
+    import gepa
+
+    with pytest.raises(ValueError, match="total_cost"):
+        gepa.optimize(
+            seed_candidate={"c": "x"},
+            trainset=[{"q": 1}],
+            adapter=__import__("unittest.mock", fromlist=["MagicMock"]).MagicMock(propose_new_texts=None),
+            reflection_strategy=_ReflectOnlyLM(),
+            max_reflection_cost=5.0,
+            max_metric_calls=10,
+        )

--- a/tests/test_reflection_lm.py
+++ b/tests/test_reflection_lm.py
@@ -326,3 +326,98 @@ def test_tracking_lm_exposes_batch_complete_conditionally():
     out = tracked.batch_complete([[{"role": "user", "content": "hi"}]] * 3)
     assert out == ["y", "y", "y"]
     assert tracked.total_tokens_out > 0
+
+
+# ---------------------------------------------------------------------------
+# reflection_strategy conflict guard + metadata threading + per-task trace
+# ---------------------------------------------------------------------------
+
+
+def test_reflection_strategy_conflicts_with_custom_proposer():
+    import pytest
+
+    with pytest.raises(ValueError, match="custom_candidate_proposer"):
+        _make_proposer(
+            reflection_strategy=_ReflectOnlyLM(),
+            custom_candidate_proposer=lambda c, d, comps: {},
+        )
+
+
+def test_reflection_strategy_conflicts_with_adapter_proposer():
+    from unittest.mock import MagicMock
+
+    import pytest
+
+    adapter = MagicMock()
+    adapter.propose_new_texts = lambda c, d, comps: {}
+    with pytest.raises(ValueError, match=r"adapter\.propose_new_texts"):
+        _make_proposer(reflection_strategy=_ReflectOnlyLM(), adapter=adapter)
+
+
+class _MetadataLM:
+    """ReflectionLM stub recording multi-call diagnostics in metadata."""
+
+    def reflect(self, candidate, reflective_dataset, components_to_update):
+        proposal = ReflectionProposal(
+            new_texts={c: f"new_{c}" for c in components_to_update},
+            metadata={"combee:level1_outputs": ["draft-1", "draft-2"]},
+        )
+        return proposal, self
+
+
+def test_reflection_metadata_reaches_candidate_proposal():
+    proposer, _adapter = _make_propose_harness(_MetadataLM())
+    proposals = proposer.propose(_make_state())
+    assert len(proposals) == 1
+    assert proposals[0].metadata["combee:level1_outputs"] == ["draft-1", "draft-2"]
+    # Single-call diagnostics still present alongside.
+    assert "prompt:c" in proposals[0].metadata
+
+
+def test_trace_records_every_task_not_just_the_first():
+    from unittest.mock import MagicMock
+
+    from gepa.core.adapter import EvaluationBatch
+    from gepa.strategies.proposal_sampling import ProposalTask
+
+    class TwoTaskSampling:
+        def sample_tasks(self, state, candidate_selector, batch_sampler, trainset):
+            return [
+                ProposalTask(parent_idx=0, parent_candidate=dict(state.program_candidates[0]), minibatch_ids=[0], minibatch=[{"q": 0}]),
+                ProposalTask(parent_idx=0, parent_candidate=dict(state.program_candidates[0]), minibatch_ids=[1], minibatch=[{"q": 1}]),
+            ]
+
+    adapter = MagicMock()
+    adapter.propose_new_texts = None
+    adapter.batch_evaluate = MagicMock(
+        side_effect=lambda items: [
+            EvaluationBatch(outputs=["o"], scores=[0.4], trajectories=[{"step": 1}], objective_scores=None, num_metric_calls=1)
+            for _ in items
+        ]
+    )
+    adapter.make_reflective_dataset = MagicMock(return_value={"c": [{"feedback": "f"}]})
+    module_selector = MagicMock(return_value=["c"])
+
+    proposer = _make_proposer(
+        adapter=adapter,
+        candidate_selector=MagicMock(),
+        batch_sampler=MagicMock(),
+        module_selector=module_selector,
+        trainset=[{"q": 0}, {"q": 1}],
+        reflection_strategy=_FixedProposalLM({"c": "improved"}),
+        sampling_strategy=TwoTaskSampling(),
+    )
+    state = _make_state()
+    proposals = proposer.propose(state)
+    assert len(proposals) == 2
+
+    entry = state.full_program_trace[-1]
+    assert entry["n_tasks"] == 2
+    assert len(entry["tasks"]) == 2
+    assert [t["subsample_ids"] for t in entry["tasks"]] == [[0], [1]]
+    for t in entry["tasks"]:
+        assert t["subsample_scores"] == [0.4]
+        assert t["new_subsample_scores"] == [0.4]
+    # Legacy first-task keys unchanged for older tooling.
+    assert entry["selected_program_candidate"] == 0
+    assert entry["subsample_ids"] == [0]

--- a/tests/test_reflection_lm.py
+++ b/tests/test_reflection_lm.py
@@ -146,3 +146,69 @@ def test_per_component_template_dict_and_missing_warning():
     lm.reflect(candidate, reflective_dataset, ["a", "b"])
     missing_warnings = [m for m in logger.messages if "No reflection_prompt_template found for parameter 'b'" in m]
     assert len(missing_warnings) == 1
+
+
+# ---------------------------------------------------------------------------
+# reflection_strategy injection seam (#329 Phase 2 entry point)
+# ---------------------------------------------------------------------------
+
+
+class _ReflectOnlyLM:
+    """A ReflectionLM implementation that provides only reflect() — no reflect_many."""
+
+    def __init__(self):
+        self.calls: list[list[str]] = []
+
+    def reflect(self, candidate, reflective_dataset, components_to_update):
+        self.calls.append(list(components_to_update))
+        proposal = ReflectionProposal(new_texts={c: f"new_{c}" for c in components_to_update})
+        return proposal, self
+
+
+def _make_proposer(**overrides):
+    from unittest.mock import MagicMock
+
+    from gepa.proposer.reflective_mutation.reflective_mutation import ReflectiveMutationProposer
+
+    adapter = MagicMock()
+    adapter.propose_new_texts = None
+    kwargs = {
+        "logger": MagicMock(),
+        "trainset": [{"q": 1}, {"q": 2}],
+        "adapter": adapter,
+        "candidate_selector": MagicMock(),
+        "module_selector": MagicMock(),
+        "batch_sampler": MagicMock(),
+        "perfect_score": None,
+        "skip_perfect_score": False,
+        "experiment_tracker": MagicMock(),
+        "reflection_lm": None,
+        "custom_candidate_proposer": None,
+    }
+    kwargs.update(overrides)
+    return ReflectiveMutationProposer(**kwargs)
+
+
+def test_injected_reflection_strategy_takes_precedence_over_stateless_default():
+    stub = _ReflectOnlyLM()
+    proposer = _make_proposer(reflection_strategy=stub, reflection_lm=RecordingLM())
+    assert proposer._reflection_lm is stub
+
+
+def test_without_injection_stateless_default_is_built():
+    proposer = _make_proposer(reflection_lm=RecordingLM())
+    assert isinstance(proposer._reflection_lm, StatelessReflectionLM)
+
+
+def test_reflect_only_strategy_used_per_task_in_batch_path():
+    """A ReflectionLM without reflect_many must be called once per job by
+    _propose_texts_batch (the seam a ComBEE-style reflector plugs into)."""
+    stub = _ReflectOnlyLM()
+    proposer = _make_proposer(reflection_strategy=stub)
+    jobs = [
+        ({"c": "old1"}, {"c": [{"feedback": "f1"}]}, ["c"]),
+        ({"c": "old2"}, {"c": [{"feedback": "f2"}]}, ["c"]),
+    ]
+    results = proposer._propose_texts_batch(jobs)
+    assert stub.calls == [["c"], ["c"]]
+    assert [r[0] for r in results] == [{"c": "new_c"}, {"c": "new_c"}]


### PR DESCRIPTION
## Summary

Implements **Phase 1** and **Phase 4** of the unified reflection LM design (#329), on top of `main`. Two focused commits:

### Phase 1 — ReflectionLM protocol + StatelessReflectionLM
- New `proposer/reflective_mutation/reflection_lm.py`: a `ReflectionLM` whose `reflect()` returns `(proposal, next_lm)` — the stateful-capable signature from #329. The stateless default (`StatelessReflectionLM`) returns itself, so behavior is identical to today.
- `ReflectiveMutationProposer.propose_new_texts` now delegates to it; the per-component reflection loop and missing-template warning moved into `StatelessReflectionLM`.

### Phase 4 — batch-based parallel proposals (replaces #314)
- Reverts #314's `ThreadPoolExecutor` parallelism. Parallelism now lives at the edges — `adapter.batch_evaluate()` and the LM — keeping GEPA's engine sequential and async-ready (no threading in core state management).
- **Sampling strategies** (`strategies/proposal_sampling.py`): `SingleMutationSampling` (default), `SameParentSampling(n)`, `IndependentSampling(n)`, `PxNSampling(p, n)`.
- **Selection strategies** (`strategies/proposal_selection.py`): `AllImprovements` (default), `BestImprovement`, `TopKImprovements(k)`.
- `ReflectiveMutationProposer.propose()` is a 5-stage pipeline returning `list[CandidateProposal]`: sample → batch-eval parents (deduplicated) → reflect per task (via the Phase 1 `ReflectionLM`) → batch-eval children → select.
- Optional `batch_evaluate` on the `GEPAAdapter` protocol with a `default_batch_evaluate()` sequential fallback; `batch_evaluator` wired through `optimize_anything()` → `OptimizeAnythingAdapter` (incorporates #279).
- Engine has **one** code path: always calls `propose()`, iterates results. Removes `num_parallel_proposals`, `ProposalContext`/`ProposalOutput`, and the threaded batch runner.

**Defaults preserve behavior exactly:** `SingleMutationSampling` + `AllImprovements` reproduce the original single-proposal flow.

## Deferred

Additional reflection-LM / proposer variants from #329 are **not** in this PR and are deferred to follow-ups:
- **ComBEE** map-shuffle-reduce reflection (#307) — Phase 3.
- Stateful **session** / **coding-agent** reflection LMs and the reflection-LM **pool** + selectors — Phase 2.

The Phase 1 `ReflectionLM` protocol is the seam these will plug into.

## Test plan

- [x] `uv run pytest` — 492 passed, 4 skipped
- [x] `uv run pyright src/` — 0 errors
- [x] `uv run ruff check src/` — no new warnings (pre-existing only)
- New tests: `tests/test_reflection_lm.py` (Phase 1), `tests/test_parallel_proposals.py` (Phase 4 sampling/selection + `default_batch_evaluate`)

Closes #314 (superseded). Incorporates #279 (batch_evaluator concept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
