### PR TITLE
docs: add MarkTechPost tutorial on building reflective prompt optimization with GEPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Finally:
     - [Google ADK: Official agent optimization powered by GEPA](https://adk.dev/optimize/)
     - [HuggingFace Cookbook on prompt optimization for with DSPy and GEPA](https://huggingface.co/learn/cookbook/en/dspy_gepa)
     - [OpenAI Cookbook showing how to build self-evolving agents using GEPA](https://cookbook.openai.com/examples/partners/self_evolving_agents/autonomous_agent_retraining)
+    - [MarkTechPost tutorial: Reflective Prompt Optimization with GEPA — multi-component prompts, structured feedback, held-out validation](https://www.marktechpost.com/2026/06/07/building-reflective-prompt-optimization-with-gepa-multi-component-prompts-structured-feedback-and-held-out-validation/)
     - [What Do Prompts Reveal About Model Capabilities in Low-Resource Languages? (AfricaNLP 2026)](https://openreview.net/attachment?id=7JZmTp85Yf&name=pdf)
     - [Beyond the Answer: Decoding the Behavior of LLMs as Scientific Reasoners (ICLR 2026 Workshop)](https://arxiv.org/abs/2603.28038)
     - [Self-Optimizing Multi-Agent Systems for Deep Research (ECIR 2026 Workshop) — GEPA outperforms TextGrad and expert-crafted prompts](https://arxiv.org/abs/2604.02988)

--- a/docs/docs/guides/use-cases.md
+++ b/docs/docs/guides/use-cases.md
@@ -1258,6 +1258,22 @@ Discover how organizations and researchers are using GEPA to optimize AI systems
 
     [:material-arrow-right: Read the guide](https://gaodalie.substack.com/p/dspy-3-gepa-the-most-advanced-rag)
 
+-   **MarkTechPost: Reflective Prompt Optimization with GEPA**
+
+    ---
+
+    Sana Hassan's hands-on walkthrough on **MarkTechPost** showing how to build a full GEPA optimization loop on arithmetic word problems — from installing `gepa` with LiteLLM, through structured evaluators with actionable feedback, to comparing baseline vs. optimized prompts on a held-out validation set.
+
+    **What's Covered:**
+
+    - Installing and configuring GEPA with LiteLLM backends
+    - Building deterministic benchmark datasets
+    - Writing structured evaluators that return actionable feedback
+    - Multi-component prompts (instructions + format rules)
+    - Held-out validation and evolution-history analysis
+
+    [:material-arrow-right: Read the tutorial](https://www.marktechpost.com/2026/06/07/building-reflective-prompt-optimization-with-gepa-multi-component-prompts-structured-feedback-and-held-out-validation/)
+
 -   **Teaching AI to Spot Fake XKCD Comics**
 
     ---


### PR DESCRIPTION
## Summary

Adds [Sana Hassan's MarkTechPost tutorial](https://www.marktechpost.com/2026/06/07/building-reflective-prompt-optimization-with-gepa-multi-component-prompts-structured-feedback-and-held-out-validation/) — a hands-on walkthrough showing how to build a full GEPA optimization loop on arithmetic word problems, covering multi-component prompts (instructions + format rules), structured evaluator feedback, and held-out validation.

## Why it's worth linking

It's a concrete, end-to-end tutorial published on a major AI-media outlet (MarkTechPost). Fills a gap in the existing Community Tutorials section — most current entries are either short blog posts or DSPy-centric; this one walks through the GEPA Python API directly with LiteLLM:

- Installing and configuring GEPA with LiteLLM backends
- Building deterministic benchmark datasets
- Writing structured evaluators that return actionable feedback
- Multi-component prompts (instructions + format rules)
- Held-out validation and evolution-history analysis
- Baseline vs. optimized comparison

## Changes

- `docs/docs/guides/use-cases.md`: new card under **Community Tutorials & Guides** (placed after the DSPy 3 + GEPA Advanced RAG entry).
- `README.md`: matching bullet under \"GEPA uses\" near the existing OpenAI/HuggingFace cookbook lines.

## Test plan

- [ ] `mkdocs serve` — confirm the new card renders inside the Community Tutorials grid
- [ ] MarkTechPost link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)