### PR TITLE
docs: add Nubank 100M-user customer support AI agents use-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ Finally:
     - [LangChain Adapter](src/gepa/adapters/langchain_adapter/) - Optimize prompts for any LangChain pipeline: single-turn chat models, tool-using agents built with `create_agent`, custom LangGraph graphs, RAG, and more. Provider-agnostic via LangChain's `init_chat_model`. Install with `pip install "gepa[langchain]"` plus a provider package (e.g. `langchain-openai`).
 - **GEPA uses**
     - [Microsoft AI: MAI-Thinking-1](https://microsoft.ai/wp-content/uploads/2026/06/main_20260602_2.pdf) — GEPA / DSPy optimizes the Qwen3-30B LLM-judge prompt used to filter Code pages in the pre-training pipeline (~233B tokens curated from ~2,000 human labels).
+    - [Nubank: Building Customer Support AI Agents at 100M-User Scale](https://arxiv.org/abs/2606.08867) — GEPA inside DSPy optimizes LLM-as-a-Judge prompts; lifts E2 eval accuracy 68.88% → 88.89%, drives Cohen's κ (GPT-4.1 vs GPT-4.1-mini) from 0.00 → 0.745; downstream production wins include +37pp AI transactional NPS and +29pp self-service rate across 5 deployed domains.
     - [Google: Gemini Enterprise Agent Platform — `adk optimize` powered by GEPA](https://docs.cloud.google.com/gemini-enterprise-agent-platform/optimize/evaluation/optimize-agent)
     - [Nous Research Hermes Agent: evolutionary self-improvement with DSPy + GEPA](https://github.com/NousResearch/hermes-agent-self-evolution)
     - [Context Compression using GEPA](https://github.com/Laurian/context-compression-experiments-2508)

--- a/docs/docs/guides/use-cases.md
+++ b/docs/docs/guides/use-cases.md
@@ -144,6 +144,27 @@ Discover how organizations and researchers are using GEPA to optimize AI systems
 
     [:material-arrow-right: Read the paper](https://microsoft.ai/wp-content/uploads/2026/06/main_20260602_2.pdf)
 
+-   **Nubank: 100M-User Customer Support Agents**
+
+    ---
+
+    Nubank's evaluation-driven framework for building customer-support AI agents at **100M+ user scale** uses **GEPA inside DSPy to optimize their LLM-as-a-Judge prompts**. GEPA-tuned judges align with human annotators and produce stable cross-model scores, which then drive prompt iteration on the production agents. Deployed across **five production domains** (card delivery, debt management, credit-limit support, and more).
+
+    **Key Results (LLM-judge evaluation accuracy, starter prompt → GEPA-optimized):**
+
+    - **E1: 77.78% → 82.00%**; **E2: 68.88% → 88.89%** on customer-support evals (5-run mean, narrow 95% CIs)
+    - **Cohen's κ (GPT-4.1 vs GPT-4.1-mini): 0.00 → 0.745** — judges go from random to strong cross-model agreement
+    - **GPT-4.1 vs GPT-4o: κ = 0.895** post-optimization
+    - GEPA settings: `auto="light"` (~500 iterations), reflection minibatch 3, Pareto selection, GPT-4.1-mini base + GPT-5.1 reflection, free-text human rationales fed to the optimizer
+
+    **Downstream production wins (enabled by the GEPA-tuned eval stack):**
+
+    - **+37 pp AI transactional NPS** in card-delivery deployment
+    - **+29 pp self-service rate** vs. prior agent variants
+    - AI satisfaction within a few percentage points of expert human agents
+
+    [:material-arrow-right: Read the paper](https://arxiv.org/abs/2606.08867)
+
 -   **Comet-ml Opik Integration**
 
     ---

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -63,7 +63,7 @@ hide:
       <a href="https://www.linkedin.com/posts/dria-ai_today-were-releasing-something-weve-used-activity-7396920472237477888-WyXN" target="_blank">Dria</a>
       <a href="https://github.com/PrimeIntellect-ai/verifiers/tree/main/verifiers/gepa" target="_blank">Prime Intellect</a>
       <a href="https://github.com/NousResearch/hermes-agent-self-evolution" target="_blank">Nous Research</a>
-      <span>NuBank</span>
+      <a href="https://arxiv.org/abs/2606.08867" target="_blank">Nubank</a>
       <span>Infosys</span>
       <a href="https://sutro.sh/" target="_blank">Sutro</a>
       <span>Invitae</span>
@@ -90,7 +90,7 @@ hide:
       <a href="https://www.linkedin.com/posts/dria-ai_today-were-releasing-something-weve-used-activity-7396920472237477888-WyXN" target="_blank">Dria</a>
       <a href="https://github.com/PrimeIntellect-ai/verifiers/tree/main/verifiers/gepa" target="_blank">Prime Intellect</a>
       <a href="https://github.com/NousResearch/hermes-agent-self-evolution" target="_blank">Nous Research</a>
-      <span>NuBank</span>
+      <a href="https://arxiv.org/abs/2606.08867" target="_blank">Nubank</a>
       <span>Infosys</span>
       <a href="https://sutro.sh/" target="_blank">Sutro</a>
       <span>Invitae</span>


### PR DESCRIPTION
## Summary

Adds [Building Customer Support AI Agents at 100M-User Scale: An Evaluation-Driven Framework](https://arxiv.org/abs/2606.08867) (Gupta, Rossell, Alcobaça, Lima Pacheco et al., Nubank) to the docs and README, and links the previously unlinked Nubank entry in the homepage marquee.

## Why it's worth linking

The paper uses **GEPA as the core method to optimize LLM-as-a-Judge prompts** inside Nubank's evaluation-driven framework for production customer-support agents. From the paper:

> "rigorous LLM judge evaluation with measured inter-rater agreement and GEPA-optimization for consistency"
> "We used GEPA within the DSPy framework to automatically refine the eval instructions. ... We ran GEPA with auto=light (approximately 500 iterations), reflection minibatch size = 3, and Pareto-based candidate selection..."

The result is a calibrated eval stack that drives downstream agent iteration at 100M+ user scale.

## Key results

**LLM-judge accuracy (starter prompt → GEPA-optimized):**

- **E1: 77.78% → 82.00%**
- **E2: 68.88% → 88.89%**
- Narrow 95% CIs (0.00–0.79) across runs

**Cross-model inter-rater agreement (Cohen's κ) after GEPA:**

- GPT-4.1 vs GPT-4.1-mini: **0.00 → 0.745**
- GPT-4.1 vs GPT-4o: **κ = 0.895**
- GPT-4.1 vs GPT-5: 0.109 → high agreement

**Downstream production wins (enabled by the GEPA-tuned eval stack):**

- **+37 pp AI transactional NPS** in card-delivery deployment
- **+29 pp self-service rate** vs. prior agent variants
- 5 production-deployed domains; AI satisfaction within a few pp of expert human agents

## Changes

- \`docs/docs/guides/use-cases.md\`: new \"Nubank: 100M-User Customer Support Agents\" card under **Enterprise & Production**, placed after the Microsoft AI MAI-Thinking-1 card.
- \`docs/docs/index.md\`: linked the previously unlinked \`<span>NuBank</span>\` entries in both halves of the homepage marquee to the arXiv paper. Also normalized the casing to the company's actual spelling (\"Nubank\").
- \`README.md\`: matching bullet under \"GEPA uses\" near the top of the list.

## Test plan

- [ ] \`mkdocs serve\` and confirm the new card renders inside the Enterprise & Production grid, and the homepage marquee Nubank link works on both loop halves.
- [ ] arXiv link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)