### PR TITLE
Add opt-in admission manifest: per-decision JSONL audit ledger (#381)

### DIFF
--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -165,6 +165,7 @@ def optimize(
     - logger: A `LoggerProtocol` instance that is used to log the progress of the optimization.
     - callbacks: Optional list of callback objects for observing optimization progress. Callbacks receive events like on_optimization_start, on_iteration_start, on_candidate_accepted, etc. See `gepa.core.callbacks.GEPACallback` for the full protocol.
     - run_dir: The directory to save the results to. Optimization state and results will be saved to this directory. If the directory already exists, GEPA will read the state from this directory and resume the optimization from the last saved state. If provided, a FileStopper is automatically created which checks for the presence of "gepa.stop" in this directory, allowing graceful stopping of the optimization process upon its presence.
+    - write_admission_manifest: When True, append a per-decision JSONL audit ledger to "<run_dir>/admission_manifest.jsonl" recording why each candidate was admitted into (or rejected from) the candidate pool, keyed by candidate and parent hashes so a run can be replayed from local files alone. Requires run_dir. Off by default and zero-cost when off. See gepa.logging.admission_manifest.
     - use_wandb: Whether to use Weights and Biases to log the progress of the optimization.
     - wandb_api_key: The API key to use for Weights and Biases.
     - wandb_init_kwargs: Additional keyword arguments to pass to the Weights and Biases initialization.

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -72,6 +72,7 @@ def optimize(
     # Logging and Callbacks
     logger: LoggerProtocol | None = None,
     run_dir: str | None = None,
+    write_admission_manifest: bool = False,
     callbacks: "list[GEPACallback] | None" = None,
     use_wandb: bool = False,
     wandb_api_key: str | None = None,
@@ -431,6 +432,7 @@ def optimize(
         acceptance_criterion=acceptance_criterion_instance,
         use_cloudpickle=use_cloudpickle,
         evaluation_cache=evaluation_cache,
+        write_admission_manifest=write_admission_manifest,
     )
 
     with experiment_tracker:

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -83,6 +83,8 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         evaluation_cache: EvaluationCache[RolloutOutput, DataId] | None = None,
         # Parallel proposals
         num_parallel_proposals: int = 1,
+        # Admission manifest (opt-in per-decision JSONL audit ledger; requires run_dir)
+        write_admission_manifest: bool = False,
     ):
         self.logger = logger
         self.run_dir = run_dir
@@ -131,6 +133,21 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         self.val_evaluation_policy: EvaluationPolicy[DataId, DataInst] = (
             val_evaluation_policy if val_evaluation_policy is not None else FullEvaluationPolicy()
         )
+
+        # Admission manifest: opt-in per-decision JSONL audit ledger under run_dir.
+        # Off by default and zero-cost when off. Requires run_dir so existing runs
+        # never start emitting a (potentially sensitive) artifact unexpectedly.
+        self.write_admission_manifest = write_admission_manifest
+        self._admission_writer = None
+        if write_admission_manifest:
+            if run_dir is None:
+                raise ValueError(
+                    "write_admission_manifest=True requires run_dir to be set; the "
+                    "manifest is written to <run_dir>/admission_manifest.jsonl."
+                )
+            from gepa.logging.admission_manifest import MANIFEST_FILENAME, AdmissionManifestWriter
+
+            self._admission_writer = AdmissionManifestWriter(os.path.join(run_dir, MANIFEST_FILENAME))
 
     def _sync_adapter_state_to_state(self, state: GEPAState) -> None:
         """Snapshot adapter state into GEPAState before saving.
@@ -294,6 +311,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
 
         Returns True if the proposal was accepted.
         """
+        metric_calls_before = state.total_num_evals
         old_sum = sum(proposal.subsample_scores_before or [])
         new_sum = sum(proposal.subsample_scores_after or [])
         _uses_builtin_criterion = isinstance(
@@ -319,6 +337,16 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                     reason=reject_reason,
                 ),
             )
+            self._emit_admission_reject(
+                iteration=iteration,
+                proposal=proposal,
+                proposal_kind=proposal.tag or "reflective_mutation",
+                decision_reason=reject_reason,
+                subsample_score_before=old_sum,
+                subsample_score_after=new_sum,
+                metric_calls_before=metric_calls_before,
+                state=state,
+            )
             return False
 
         if _uses_builtin_criterion:
@@ -327,7 +355,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             accept_msg = f"Iteration {iteration}: Candidate accepted (old_sum={old_sum}, new_sum={new_sum}). Continue to full eval and add to candidate pool."
         self.logger.log(accept_msg)
 
-        new_idx, _ = self._run_full_eval_and_add(
+        new_idx, linear_pareto_idx = self._run_full_eval_and_add(
             new_program=proposal.candidate,
             state=state,
             parent_program_idx=proposal.parent_program_ids,
@@ -344,6 +372,18 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                 new_score=new_sum,
                 parent_ids=proposal.parent_program_ids,
             ),
+        )
+        self._emit_admission_accept(
+            iteration=iteration,
+            proposal=proposal,
+            proposal_kind=proposal.tag or "reflective_mutation",
+            decision_reason=f"subsample score {new_sum} > {old_sum} (accepted by {type(self.acceptance_criterion).__name__})",
+            subsample_score_before=old_sum,
+            subsample_score_after=new_sum,
+            metric_calls_before=metric_calls_before,
+            new_idx=new_idx,
+            linear_pareto_idx=linear_pareto_idx,
+            state=state,
         )
         return True
 
@@ -673,6 +713,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                                 float("-inf"),
                             ]
                             new_sum = sum(proposal.subsample_scores_after or [])
+                            merge_metric_calls_before = state.total_num_evals
 
                             # Notify merge attempted
                             notify_callbacks(
@@ -687,7 +728,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
 
                             if new_sum >= max(parent_sums):
                                 # ACCEPTED: consume one merge attempt and record it
-                                new_idx, _ = self._run_full_eval_and_add(
+                                new_idx, merge_linear_pareto_idx = self._run_full_eval_and_add(
                                     new_program=proposal.candidate,
                                     state=state,
                                     parent_program_idx=proposal.parent_program_ids,
@@ -716,6 +757,18 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                                         parent_ids=proposal.parent_program_ids,
                                     ),
                                 )
+                                self._emit_admission_accept(
+                                    iteration=state.i + 1,
+                                    proposal=proposal,
+                                    proposal_kind="merge",
+                                    decision_reason=f"merged subsample score {new_sum} >= max(parent sums) {max(parent_sums)}",
+                                    subsample_score_before=max(parent_sums),
+                                    subsample_score_after=new_sum,
+                                    metric_calls_before=merge_metric_calls_before,
+                                    new_idx=new_idx,
+                                    linear_pareto_idx=merge_linear_pareto_idx,
+                                    state=state,
+                                )
                                 continue  # skip reflective this iteration
                             else:
                                 # REJECTED: do NOT consume merges_due or total_merges_tested
@@ -732,6 +785,16 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                                         parent_ids=proposal.parent_program_ids,
                                         reason=f"Merged score {new_sum} worse than both parents {parent_sums}",
                                     ),
+                                )
+                                self._emit_admission_reject(
+                                    iteration=state.i + 1,
+                                    proposal=proposal,
+                                    proposal_kind="merge",
+                                    decision_reason=f"merged subsample score {new_sum} < max(parent sums) {max(parent_sums)}",
+                                    subsample_score_before=max(parent_sums),
+                                    subsample_score_after=new_sum,
+                                    metric_calls_before=merge_metric_calls_before,
+                                    state=state,
                                 )
                                 # Skip reflective this iteration (old behavior)
                                 continue
@@ -814,6 +877,99 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         self.experiment_tracker.log_summary(summary)
 
         return state
+
+    # ------------------------------------------------------------------
+    # Admission manifest (opt-in per-decision audit ledger)
+    # ------------------------------------------------------------------
+
+    def _emit_admission_reject(
+        self,
+        *,
+        iteration: int,
+        proposal: CandidateProposal,
+        proposal_kind: str,
+        decision_reason: str,
+        subsample_score_before: float,
+        subsample_score_after: float,
+        metric_calls_before: int,
+        state: GEPAState[RolloutOutput, DataId],
+    ) -> None:
+        """Append a rejected-decision record immediately (validation fields stay null)."""
+        if self._admission_writer is None:
+            return
+        try:
+            from gepa.logging.admission_manifest import build_decision_record
+
+            parents = [state.program_candidates[i] for i in proposal.parent_program_ids]
+            record = build_decision_record(
+                iteration=iteration,
+                proposal_kind=proposal_kind,
+                decision="rejected",
+                decision_reason=decision_reason,
+                candidate=proposal.candidate,
+                parent_ids=proposal.parent_program_ids,
+                parents=parents,
+                subsample_ids=proposal.subsample_indices,
+                subsample_score_before=subsample_score_before,
+                subsample_score_after=subsample_score_after,
+                metric_calls_before_decision=metric_calls_before,
+            )
+            self._admission_writer.append_record(record)
+        except Exception as e:  # an audit log must never crash the optimization
+            self.logger.log(f"Warning: failed to write admission manifest (reject): {e}")
+
+    def _emit_admission_accept(
+        self,
+        *,
+        iteration: int,
+        proposal: CandidateProposal,
+        proposal_kind: str,
+        decision_reason: str,
+        subsample_score_before: float,
+        subsample_score_after: float,
+        metric_calls_before: int,
+        new_idx: int,
+        linear_pareto_idx: int,
+        state: GEPAState[RolloutOutput, DataId],
+    ) -> None:
+        """Finalize and append an accepted-decision record once, after the full-val eval.
+
+        Shared by the reflective and merge accept paths. The decision snapshot is
+        built from the proposal; the ``validation`` block is post-decision
+        enrichment from the just-completed ``_run_full_eval_and_add``.
+        """
+        if self._admission_writer is None:
+            return
+        try:
+            from gepa.logging.admission_manifest import build_decision_record
+
+            parents = [state.program_candidates[i] for i in proposal.parent_program_ids]
+            record = build_decision_record(
+                iteration=iteration,
+                proposal_kind=proposal_kind,
+                decision="accepted",
+                decision_reason=decision_reason,
+                candidate=proposal.candidate,
+                parent_ids=proposal.parent_program_ids,
+                parents=parents,
+                subsample_ids=proposal.subsample_indices,
+                subsample_score_before=subsample_score_before,
+                subsample_score_after=subsample_score_after,
+                metric_calls_before_decision=metric_calls_before,
+            )
+            trace_entry = state.full_program_trace[-1] if state.full_program_trace else {}
+            evaluated_val_ids = sorted(trace_entry.get("evaluated_val_indices", []) or [])
+            record["candidate_idx"] = new_idx
+            record["validation"] = {
+                "val_average_score": self.val_evaluation_policy.get_valset_score(new_idx, state),
+                "evaluated_val_ids": evaluated_val_ids,
+                "is_best_program": new_idx == linear_pareto_idx,
+                "metric_calls_after_validation": state.total_num_evals,
+                "metric_calls_charged_validation": state.total_num_evals - metric_calls_before,
+            }
+            self._admission_writer.append_record(record)
+        except Exception as e:  # an audit log must never crash the optimization
+            self.logger.log(f"Warning: failed to write admission manifest (accept): {e}")
 
     def _log_proposal_lm_calls(
         self,

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -318,6 +318,10 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             self.acceptance_criterion, StrictImprovementAcceptance | ImprovementOrEqualAcceptance
         )
 
+        from gepa.logging.admission_manifest import acceptance_operator, criterion_name
+
+        crit_name = criterion_name(self.acceptance_criterion)
+
         if not self.acceptance_criterion.should_accept(proposal, state):
             if _uses_builtin_criterion:
                 reject_msg = f"Iteration {iteration}: New subsample score {new_sum} is not better than old score {old_sum}, skipping"
@@ -342,6 +346,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                 proposal=proposal,
                 proposal_kind=proposal.tag or "reflective_mutation",
                 decision_reason=reject_reason,
+                acceptance_criterion=crit_name,
                 subsample_score_before=old_sum,
                 subsample_score_after=new_sum,
                 metric_calls_before=metric_calls_before,
@@ -350,9 +355,12 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             return False
 
         if _uses_builtin_criterion:
+            op = acceptance_operator(crit_name)
             accept_msg = f"Iteration {iteration}: New subsample score {new_sum} is better than old score {old_sum}. Continue to full eval and add to candidate pool."
+            accept_reason = f"subsample score {new_sum} {op} {old_sum} (accepted by {crit_name})"
         else:
             accept_msg = f"Iteration {iteration}: Candidate accepted (old_sum={old_sum}, new_sum={new_sum}). Continue to full eval and add to candidate pool."
+            accept_reason = f"accepted by acceptance criterion {crit_name} (old_sum={old_sum}, new_sum={new_sum})"
         self.logger.log(accept_msg)
 
         new_idx, linear_pareto_idx = self._run_full_eval_and_add(
@@ -377,7 +385,8 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             iteration=iteration,
             proposal=proposal,
             proposal_kind=proposal.tag or "reflective_mutation",
-            decision_reason=f"subsample score {new_sum} > {old_sum} (accepted by {type(self.acceptance_criterion).__name__})",
+            decision_reason=accept_reason,
+            acceptance_criterion=crit_name,
             subsample_score_before=old_sum,
             subsample_score_after=new_sum,
             metric_calls_before=metric_calls_before,
@@ -715,6 +724,8 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                             new_sum = sum(proposal.subsample_scores_after or [])
                             merge_metric_calls_before = state.total_num_evals
 
+                            from gepa.logging.admission_manifest import MERGE_GATE
+
                             # Notify merge attempted
                             notify_callbacks(
                                 self.callbacks,
@@ -762,6 +773,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                                     proposal=proposal,
                                     proposal_kind="merge",
                                     decision_reason=f"merged subsample score {new_sum} >= max(parent sums) {max(parent_sums)}",
+                                    acceptance_criterion=MERGE_GATE,
                                     subsample_score_before=max(parent_sums),
                                     subsample_score_after=new_sum,
                                     metric_calls_before=merge_metric_calls_before,
@@ -791,6 +803,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                                     proposal=proposal,
                                     proposal_kind="merge",
                                     decision_reason=f"merged subsample score {new_sum} < max(parent sums) {max(parent_sums)}",
+                                    acceptance_criterion=MERGE_GATE,
                                     subsample_score_before=max(parent_sums),
                                     subsample_score_after=new_sum,
                                     metric_calls_before=merge_metric_calls_before,
@@ -889,6 +902,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         proposal: CandidateProposal,
         proposal_kind: str,
         decision_reason: str,
+        acceptance_criterion: str,
         subsample_score_before: float,
         subsample_score_after: float,
         metric_calls_before: int,
@@ -906,6 +920,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                 proposal_kind=proposal_kind,
                 decision="rejected",
                 decision_reason=decision_reason,
+                acceptance_criterion=acceptance_criterion,
                 candidate=proposal.candidate,
                 parent_ids=proposal.parent_program_ids,
                 parents=parents,
@@ -925,6 +940,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         proposal: CandidateProposal,
         proposal_kind: str,
         decision_reason: str,
+        acceptance_criterion: str,
         subsample_score_before: float,
         subsample_score_after: float,
         metric_calls_before: int,
@@ -949,6 +965,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                 proposal_kind=proposal_kind,
                 decision="accepted",
                 decision_reason=decision_reason,
+                acceptance_criterion=acceptance_criterion,
                 candidate=proposal.candidate,
                 parent_ids=proposal.parent_program_ids,
                 parents=parents,

--- a/src/gepa/logging/admission_manifest.py
+++ b/src/gepa/logging/admission_manifest.py
@@ -21,6 +21,10 @@ Design notes:
   accepted candidate), not a second admission gate.
 - ``components_changed`` is derived from a candidate-versus-parent diff rather
   than proposer metadata, which can be absent for custom adapters/proposers.
+- The acceptance criterion *and* its comparison operator are recorded on every
+  line, so :func:`verify_record` re-derives the decision from local files alone
+  (the caller need not know whether the run used strict-improvement,
+  improvement-or-equal, or the merge gate).
 
 Opt-in via ``EngineConfig(write_admission_manifest=True)`` or
 ``optimize(write_admission_manifest=True)``, both of which require ``run_dir``.
@@ -36,6 +40,57 @@ from gepa.gepa_utils import json_default
 
 SCHEMA_VERSION = 1
 MANIFEST_FILENAME = "admission_manifest.jsonl"
+
+# Canonical names for GEPA's built-in subsample acceptance criteria. The first
+# two match the string values accepted by ``optimize(acceptance_criterion=...)``;
+# ``merge_gate`` is the (instance-less) rule the merge path applies. Each record
+# stores its criterion name *and* the comparison operator below, so a verifier
+# re-derives the decision from local files alone, without knowing how the run was
+# configured or what GEPA's internal class names are.
+STRICT_IMPROVEMENT = "strict_improvement"
+IMPROVEMENT_OR_EQUAL = "improvement_or_equal"
+MERGE_GATE = "merge_gate"
+
+# Comparison applied between the new and old subsample score for each criterion.
+_ACCEPTANCE_OPERATORS = {
+    STRICT_IMPROVEMENT: ">",
+    IMPROVEMENT_OR_EQUAL: ">=",
+    MERGE_GATE: ">=",
+}
+
+# Built-in acceptance-criterion class name -> canonical manifest name.
+_CRITERION_CLASS_TO_NAME = {
+    "StrictImprovementAcceptance": STRICT_IMPROVEMENT,
+    "ImprovementOrEqualAcceptance": IMPROVEMENT_OR_EQUAL,
+}
+
+
+def criterion_name(acceptance_criterion: object) -> str:
+    """Canonical manifest name for an acceptance-criterion instance or class.
+
+    Returns the public string name (``"strict_improvement"`` /
+    ``"improvement_or_equal"``) for a built-in criterion, matching
+    ``optimize(acceptance_criterion=...)``. For a custom criterion returns its
+    class name, so the rule is still identified in the audit log even though its
+    score decision is out of scope for replay.
+    """
+    cls = acceptance_criterion if isinstance(acceptance_criterion, type) else type(acceptance_criterion)
+    return _CRITERION_CLASS_TO_NAME.get(cls.__name__, cls.__name__)
+
+
+def acceptance_operator(acceptance_criterion: str | None) -> str | None:
+    """Comparison operator (``">"`` / ``">="``) for a recorded criterion name.
+
+    Returns ``None`` for a custom or unknown criterion, whose score decision is
+    not re-derivable from the two recorded scalars and is therefore out of scope
+    for replay (hashes and ``components_changed`` are still verified).
+    """
+    if acceptance_criterion is None:
+        return None
+    return _ACCEPTANCE_OPERATORS.get(acceptance_criterion)
+
+
+_MISSING = object()
 
 
 def components_changed(candidate: dict[str, str], parents: list[dict[str, str]]) -> list[str]:
@@ -60,6 +115,7 @@ def build_decision_record(
     proposal_kind: str,
     decision: str,
     decision_reason: str,
+    acceptance_criterion: str,
     candidate: dict[str, str],
     parent_ids: list[int],
     parents: list[dict[str, str]],
@@ -78,6 +134,11 @@ def build_decision_record(
     subsample score was compared against: for reflective proposals the parent's
     subsample sum, for a merge ``max`` of the parent sums (the merge gate). This
     keeps the decision re-derivable from the two recorded scalars.
+
+    ``acceptance_criterion`` is the canonical name of the rule that produced the
+    decision (see :func:`criterion_name`); the matching comparison operator is
+    recorded alongside it so :func:`verify_record` replays without the caller
+    re-supplying the strategy.
     """
     return {
         "schema_version": SCHEMA_VERSION,
@@ -86,6 +147,8 @@ def build_decision_record(
         "decision": decision,
         "decision_reason": decision_reason,
         "decision_basis": "subsample_acceptance",
+        "acceptance_criterion": acceptance_criterion,
+        "acceptance_operator": acceptance_operator(acceptance_criterion),
         "candidate_hash": _candidate_hash(candidate),
         "candidate_idx": None,
         "parent_candidate_ids": list(parent_ids),
@@ -152,15 +215,20 @@ def verify_record(
     candidate: dict[str, str],
     parents: list[dict[str, str]],
     *,
-    acceptance: str = "strict_improvement",
+    acceptance: str | None = None,
 ) -> bool:
     """Replay check: recompute hashes and re-derive the decision from the record.
 
     Returns True if the record is internally consistent with the given candidate
     and parent dictionaries. Hashes and ``components_changed`` are checked for
     every record; the decision is re-derived from the recorded subsample scores
-    for built-in acceptance (``strict_improvement`` / ``improvement_or_equal``)
-    and the merge gate. Custom acceptance criteria are out of scope for replay.
+    using the operator the record itself stored (``acceptance_operator``), so the
+    caller does not need to know which acceptance strategy the run used. A custom
+    criterion (operator recorded as null) has its score decision left out of
+    scope; its hashes and ``components_changed`` are still verified.
+
+    ``acceptance`` is an optional override for older records written before the
+    criterion was recorded; the recorded operator always takes precedence.
     """
     if record["candidate_hash"] != _candidate_hash(candidate):
         return False
@@ -171,10 +239,20 @@ def verify_record(
     before = record["subsample_score_before"]
     after = record["subsample_score_after"]
     if before is not None and after is not None:
-        if record["proposal_kind"] == "merge" or acceptance == "improvement_or_equal":
+        op = record.get("acceptance_operator", _MISSING)
+        if op is _MISSING:
+            # Record predates the recorded criterion: fall back to the recorded
+            # name, then a caller override, then the merge-gate / strict default.
+            name = record.get("acceptance_criterion") or acceptance
+            op = acceptance_operator(name)
+            if op is None:
+                op = ">=" if record.get("proposal_kind") == "merge" else ">"
+        if op == ">=":
             improved = after >= before
-        else:
+        elif op == ">":
             improved = after > before
+        else:
+            return True  # custom/unknown criterion: score decision out of scope
         expected = "accepted" if improved else "rejected"
         if record["decision"] != expected:
             return False

--- a/src/gepa/logging/admission_manifest.py
+++ b/src/gepa/logging/admission_manifest.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""Admission manifest: a per-decision JSONL audit ledger under ``run_dir``.
+
+When enabled, GEPA appends one JSON line per candidate-admission decision
+(accepted or rejected), keyed by candidate hash and parent hashes, so a run can
+be audited and reproduced from local files alone: *why was this mutation admitted
+into the candidate pool, on what evidence?*
+
+Every recorded field is derivable from facts GEPA already holds, so the manifest
+is **replayable for free**: a verifier can recompute the candidate/parent hashes
+and re-derive the decision from the recorded subsample scores without re-running
+the optimizer (see :func:`verify_record` and ``tests/test_admission_manifest.py``).
+
+Design notes:
+- One complete JSON object per line, appended and flushed (not an atomic
+  whole-document replace), because the manifest is an append-only log.
+- The recorded ``decision`` is the *subsample acceptance* decision. The
+  ``validation`` block is post-decision enrichment (full-val results for an
+  accepted candidate), not a second admission gate.
+- ``components_changed`` is derived from a candidate-versus-parent diff rather
+  than proposer metadata, which can be absent for custom adapters/proposers.
+
+Opt-in via ``EngineConfig(write_admission_manifest=True)`` or
+``optimize(write_admission_manifest=True)``, both of which require ``run_dir``.
+Off by default and zero-cost when off.
+"""
+
+import json
+import os
+from typing import Any
+
+from gepa.core.state import _candidate_hash
+from gepa.gepa_utils import json_default
+
+SCHEMA_VERSION = 1
+MANIFEST_FILENAME = "admission_manifest.jsonl"
+
+
+def components_changed(candidate: dict[str, str], parents: list[dict[str, str]]) -> list[str]:
+    """Sorted component names whose text differs from at least one parent.
+
+    Deterministic and replayable: computed from the candidate and parent
+    dictionaries, not from proposer metadata. For the common single-parent
+    reflective case this is exactly the set of components the mutation changed;
+    for a two-parent merge it is the components that differ from some parent.
+    """
+    if not parents:
+        return sorted(candidate)
+    names: set[str] = set(candidate)
+    for parent in parents:
+        names |= set(parent)
+    return sorted(name for name in names if any(candidate.get(name) != parent.get(name) for parent in parents))
+
+
+def build_decision_record(
+    *,
+    iteration: int,
+    proposal_kind: str,
+    decision: str,
+    decision_reason: str,
+    candidate: dict[str, str],
+    parent_ids: list[int],
+    parents: list[dict[str, str]],
+    subsample_ids: list[Any] | None,
+    subsample_score_before: float | None,
+    subsample_score_after: float | None,
+    metric_calls_before_decision: int,
+) -> dict[str, Any]:
+    """Build the decision-time snapshot of an admission record.
+
+    Captures identity, lineage, the subsample acceptance inputs, and the
+    decision. ``candidate_idx`` and ``validation`` are left null here; for an
+    accepted candidate they are filled after the full-val evaluation.
+
+    ``subsample_score_before`` is the acceptance *baseline* the candidate's
+    subsample score was compared against: for reflective proposals the parent's
+    subsample sum, for a merge ``max`` of the parent sums (the merge gate). This
+    keeps the decision re-derivable from the two recorded scalars.
+    """
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "iteration": iteration,
+        "proposal_kind": proposal_kind,
+        "decision": decision,
+        "decision_reason": decision_reason,
+        "decision_basis": "subsample_acceptance",
+        "candidate_hash": _candidate_hash(candidate),
+        "candidate_idx": None,
+        "parent_candidate_ids": list(parent_ids),
+        "parent_candidate_hashes": [_candidate_hash(p) for p in parents],
+        "components_changed": components_changed(candidate, parents),
+        "subsample_ids": list(subsample_ids) if subsample_ids is not None else None,
+        "subsample_score_before": subsample_score_before,
+        "subsample_score_after": subsample_score_after,
+        "metric_calls_before_decision": metric_calls_before_decision,
+        # Post-decision enrichment; null for rejects (see module docstring).
+        "validation": None,
+        # Cache hit/miss accounting is not tracked in v1.
+        "cache_hits": None,
+        "cache_misses": None,
+    }
+
+
+class AdmissionManifestWriter:
+    """Appends one complete JSON record per line to ``admission_manifest.jsonl``.
+
+    A dedicated single-record append (serialize a complete line, append, flush),
+    not an atomic whole-document replace: the manifest is append-only. A process
+    killed mid-append can leave a truncated final line; :func:`read_manifest`
+    tolerates that.
+    """
+
+    def __init__(self, path: str):
+        self.path = path
+
+    def append_record(self, record: dict[str, Any]) -> None:
+        line = json.dumps(record, default=json_default)
+        with open(self.path, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+            f.flush()
+
+
+def read_manifest(path: str) -> list[dict[str, Any]]:
+    """Read all complete records, tolerating a truncated final line.
+
+    A process killed mid-append can leave a partial final line; every prior line
+    is a complete record. Parse line by line and drop only a final line that
+    fails to parse; a non-final unparseable line is a real corruption and raises.
+    """
+    records: list[dict[str, Any]] = []
+    if not os.path.exists(path):
+        return records
+    with open(path, encoding="utf-8") as f:
+        lines = f.readlines()
+    for idx, raw in enumerate(lines):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            if idx == len(lines) - 1:
+                break  # tolerated: truncated final line from an interrupted append
+            raise
+    return records
+
+
+def verify_record(
+    record: dict[str, Any],
+    candidate: dict[str, str],
+    parents: list[dict[str, str]],
+    *,
+    acceptance: str = "strict_improvement",
+) -> bool:
+    """Replay check: recompute hashes and re-derive the decision from the record.
+
+    Returns True if the record is internally consistent with the given candidate
+    and parent dictionaries. Hashes and ``components_changed`` are checked for
+    every record; the decision is re-derived from the recorded subsample scores
+    for built-in acceptance (``strict_improvement`` / ``improvement_or_equal``)
+    and the merge gate. Custom acceptance criteria are out of scope for replay.
+    """
+    if record["candidate_hash"] != _candidate_hash(candidate):
+        return False
+    if record["parent_candidate_hashes"] != [_candidate_hash(p) for p in parents]:
+        return False
+    if record["components_changed"] != components_changed(candidate, parents):
+        return False
+    before = record["subsample_score_before"]
+    after = record["subsample_score_after"]
+    if before is not None and after is not None:
+        if record["proposal_kind"] == "merge" or acceptance == "improvement_or_equal":
+            improved = after >= before
+        else:
+            improved = after > before
+        expected = "accepted" if improved else "rejected"
+        if record["decision"] != expected:
+            return False
+    return True

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -457,6 +457,11 @@ class EngineConfig:
     """
 
     run_dir: str | None = None
+    # When True, append a per-decision JSONL admission ledger to
+    # <run_dir>/admission_manifest.jsonl (one record per accept/reject decision,
+    # keyed by candidate + parent hashes). Requires run_dir; off by default so
+    # existing runs never start emitting a new artifact unexpectedly.
+    write_admission_manifest: bool = False
     seed: int = 0
     display_progress_bar: bool = False
     raise_on_exception: bool = True
@@ -1625,6 +1630,7 @@ def optimize_anything(
             config.engine.max_workers or (os.cpu_count() or 32),
             config.reflection.reflection_minibatch_size or 1,
         ),
+        write_admission_manifest=config.engine.write_admission_manifest,
     )
 
     # --- 15. Run optimization ---

--- a/tests/test_admission_manifest.py
+++ b/tests/test_admission_manifest.py
@@ -1,0 +1,231 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""Tests for the opt-in admission manifest (per-decision JSONL audit ledger)."""
+
+import json
+import os
+
+import pytest
+
+from gepa.core.state import _candidate_hash
+from gepa.logging.admission_manifest import (
+    SCHEMA_VERSION,
+    AdmissionManifestWriter,
+    build_decision_record,
+    components_changed,
+    read_manifest,
+    verify_record,
+)
+
+# ---------------------------------------------------------------------------
+# Unit: components_changed (candidate-vs-parent diff, not metadata)
+# ---------------------------------------------------------------------------
+
+
+def test_components_changed_single_parent():
+    assert components_changed({"a": "x", "b": "Y2"}, [{"a": "x", "b": "y"}]) == ["b"]
+
+
+def test_components_changed_new_component():
+    assert components_changed({"a": "x", "b": "new"}, [{"a": "x"}]) == ["b"]
+
+
+def test_components_changed_two_parents_merge():
+    # a taken from p1, b taken from p2 -> each differs from one parent.
+    assert components_changed({"a": "1", "b": "2"}, [{"a": "1", "b": "1"}, {"a": "2", "b": "2"}]) == ["a", "b"]
+
+
+def test_components_changed_no_parents():
+    assert components_changed({"a": "x", "b": "y"}, []) == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# Unit: build_decision_record
+# ---------------------------------------------------------------------------
+
+
+def test_build_decision_record_schema_and_hashes():
+    parent, cand = {"sys": "old"}, {"sys": "new"}
+    rec = build_decision_record(
+        iteration=3,
+        proposal_kind="reflective_mutation",
+        decision="accepted",
+        decision_reason="r",
+        candidate=cand,
+        parent_ids=[0],
+        parents=[parent],
+        subsample_ids=["t1", "t2"],
+        subsample_score_before=1.0,
+        subsample_score_after=2.0,
+        metric_calls_before_decision=10,
+    )
+    assert rec["schema_version"] == SCHEMA_VERSION
+    assert rec["candidate_hash"] == _candidate_hash(cand)
+    assert rec["parent_candidate_hashes"] == [_candidate_hash(parent)]
+    assert rec["candidate_idx"] is None
+    assert rec["validation"] is None
+    assert rec["cache_hits"] is None and rec["cache_misses"] is None
+    assert rec["components_changed"] == ["sys"]
+    assert rec["decision_basis"] == "subsample_acceptance"
+    assert rec["subsample_ids"] == ["t1", "t2"]
+
+
+# ---------------------------------------------------------------------------
+# Unit: writer + read_manifest (incl. truncated final line)
+# ---------------------------------------------------------------------------
+
+
+def test_writer_roundtrip_and_truncated_final_line(tmp_path):
+    path = str(tmp_path / "admission_manifest.jsonl")
+    w = AdmissionManifestWriter(path)
+    w.append_record({"i": 1, "decision": "accepted"})
+    w.append_record({"i": 2, "decision": "rejected"})
+    # Simulate a crash mid-append: an unterminated, invalid final line.
+    with open(path, "a") as f:
+        f.write('{"i": 3, "decision": "acce')
+    records = read_manifest(path)
+    assert [r["i"] for r in records] == [1, 2]
+
+
+def test_read_manifest_missing_file(tmp_path):
+    assert read_manifest(str(tmp_path / "nope.jsonl")) == []
+
+
+def test_read_manifest_raises_on_nonfinal_corruption(tmp_path):
+    path = str(tmp_path / "m.jsonl")
+    with open(path, "w") as f:
+        f.write("not json\n")
+        f.write('{"i": 2}\n')
+    with pytest.raises(json.JSONDecodeError):
+        read_manifest(path)
+
+
+# ---------------------------------------------------------------------------
+# Unit: verify_record replay (accept / reject / merge + tamper detection)
+# ---------------------------------------------------------------------------
+
+
+def _rec(decision, before, after, cand, parents, kind="reflective_mutation"):
+    return build_decision_record(
+        iteration=1,
+        proposal_kind=kind,
+        decision=decision,
+        decision_reason="r",
+        candidate=cand,
+        parent_ids=list(range(len(parents))),
+        parents=parents,
+        subsample_ids=None,
+        subsample_score_before=before,
+        subsample_score_after=after,
+        metric_calls_before_decision=0,
+    )
+
+
+def test_verify_record_accept_reflective():
+    parent, cand = {"a": "x"}, {"a": "y"}
+    assert verify_record(_rec("accepted", 1.0, 2.0, cand, [parent]), cand, [parent]) is True
+
+
+def test_verify_record_reject_reflective():
+    parent, cand = {"a": "x"}, {"a": "y"}
+    assert verify_record(_rec("rejected", 2.0, 1.0, cand, [parent]), cand, [parent]) is True
+
+
+def test_verify_record_merge_accept_uses_ge_gate():
+    p1, p2, cand = {"a": "1"}, {"a": "2"}, {"a": "3"}
+    # merge gate is new_sum >= baseline; equal scores still accept.
+    assert verify_record(_rec("accepted", 1.0, 1.0, cand, [p1, p2], kind="merge"), cand, [p1, p2]) is True
+
+
+def test_verify_record_detects_tampered_hash():
+    parent, cand = {"a": "x"}, {"a": "y"}
+    rec = _rec("accepted", 1.0, 2.0, cand, [parent])
+    rec["candidate_hash"] = "deadbeef"
+    assert verify_record(rec, cand, [parent]) is False
+
+
+def test_verify_record_detects_inconsistent_decision():
+    parent, cand = {"a": "x"}, {"a": "y"}
+    # after < before but labelled accepted -> not re-derivable -> False.
+    assert verify_record(_rec("accepted", 2.0, 1.0, cand, [parent]), cand, [parent]) is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: a real optimize_anything run writes a replayable manifest
+# ---------------------------------------------------------------------------
+
+
+def _content_evaluator(candidate):
+    """Seed ('x') scores 0; the reflection's 'improved' candidate scores 1."""
+    return (1.0 if "improved" in str(candidate) else 0.0), {}
+
+
+def _improve_lm(prompt):
+    return "```\nimproved\n```"
+
+
+def _run(tmp_path, **engine_kwargs):
+    from gepa.optimize_anything import EngineConfig, GEPAConfig, ReflectionConfig, optimize_anything
+
+    return optimize_anything(
+        seed_candidate="x",
+        evaluator=_content_evaluator,
+        config=GEPAConfig(
+            engine=EngineConfig(max_metric_calls=40, run_dir=str(tmp_path), **engine_kwargs),
+            reflection=ReflectionConfig(reflection_lm=_improve_lm),
+        ),
+    )
+
+
+def test_manifest_absent_when_flag_off(tmp_path):
+    _run(tmp_path)  # write_admission_manifest defaults to False
+    assert not os.path.exists(os.path.join(str(tmp_path), "admission_manifest.jsonl"))
+
+
+def test_requires_run_dir():
+    from gepa.optimize_anything import EngineConfig, GEPAConfig, ReflectionConfig, optimize_anything
+
+    with pytest.raises(ValueError, match="requires run_dir"):
+        optimize_anything(
+            seed_candidate="x",
+            evaluator=_content_evaluator,
+            config=GEPAConfig(
+                engine=EngineConfig(max_metric_calls=5, run_dir=None, write_admission_manifest=True),
+                reflection=ReflectionConfig(reflection_lm=_improve_lm),
+            ),
+        )
+
+
+def test_manifest_written_and_replayable(tmp_path):
+    _run(tmp_path, write_admission_manifest=True)
+    path = os.path.join(str(tmp_path), "admission_manifest.jsonl")
+    assert os.path.exists(path)
+
+    records = read_manifest(path)
+    assert len(records) >= 1
+
+    candidates = json.load(open(os.path.join(str(tmp_path), "candidates.json")))
+    accepted = [r for r in records if r["decision"] == "accepted"]
+    rejected = [r for r in records if r["decision"] == "rejected"]
+    # The seed 'x' -> 'improved' improvement should be admitted at least once.
+    assert len(accepted) >= 1
+
+    for r in records:
+        assert r["schema_version"] == SCHEMA_VERSION
+        assert r["decision_basis"] == "subsample_acceptance"
+        assert len(r["parent_candidate_ids"]) == len(r["parent_candidate_hashes"])
+
+    for r in accepted:
+        assert r["candidate_idx"] is not None
+        assert r["validation"] is not None
+        assert "val_average_score" in r["validation"]
+        cand = candidates[r["candidate_idx"]]
+        parents = [candidates[i] for i in r["parent_candidate_ids"]]
+        assert verify_record(r, cand, parents) is True
+
+    for r in rejected:
+        assert r["candidate_idx"] is None
+        assert r["validation"] is None
+        parents = [candidates[i] for i in r["parent_candidate_ids"]]
+        assert r["parent_candidate_hashes"] == [_candidate_hash(p) for p in parents]

--- a/tests/test_admission_manifest.py
+++ b/tests/test_admission_manifest.py
@@ -10,13 +10,19 @@ import pytest
 
 from gepa.core.state import _candidate_hash
 from gepa.logging.admission_manifest import (
+    IMPROVEMENT_OR_EQUAL,
+    MERGE_GATE,
     SCHEMA_VERSION,
+    STRICT_IMPROVEMENT,
     AdmissionManifestWriter,
+    acceptance_operator,
     build_decision_record,
     components_changed,
+    criterion_name,
     read_manifest,
     verify_record,
 )
+from gepa.strategies.acceptance import ImprovementOrEqualAcceptance, StrictImprovementAcceptance
 
 # ---------------------------------------------------------------------------
 # Unit: components_changed (candidate-vs-parent diff, not metadata)
@@ -52,6 +58,7 @@ def test_build_decision_record_schema_and_hashes():
         proposal_kind="reflective_mutation",
         decision="accepted",
         decision_reason="r",
+        acceptance_criterion=IMPROVEMENT_OR_EQUAL,
         candidate=cand,
         parent_ids=[0],
         parents=[parent],
@@ -69,6 +76,35 @@ def test_build_decision_record_schema_and_hashes():
     assert rec["components_changed"] == ["sys"]
     assert rec["decision_basis"] == "subsample_acceptance"
     assert rec["subsample_ids"] == ["t1", "t2"]
+    # The criterion and its operator are recorded so replay is self-contained.
+    assert rec["acceptance_criterion"] == IMPROVEMENT_OR_EQUAL
+    assert rec["acceptance_operator"] == ">="
+
+
+# ---------------------------------------------------------------------------
+# Unit: criterion_name / acceptance_operator
+# ---------------------------------------------------------------------------
+
+
+def test_criterion_name_builtins_use_public_string_names():
+    # Instance or class, the built-ins map to the public optimize() string names.
+    assert criterion_name(StrictImprovementAcceptance()) == STRICT_IMPROVEMENT
+    assert criterion_name(ImprovementOrEqualAcceptance) == IMPROVEMENT_OR_EQUAL
+
+
+def test_criterion_name_custom_falls_back_to_class_name():
+    class MyCriterion:
+        pass
+
+    assert criterion_name(MyCriterion()) == "MyCriterion"
+
+
+def test_acceptance_operator_mapping():
+    assert acceptance_operator(STRICT_IMPROVEMENT) == ">"
+    assert acceptance_operator(IMPROVEMENT_OR_EQUAL) == ">="
+    assert acceptance_operator(MERGE_GATE) == ">="
+    assert acceptance_operator("MyCriterion") is None
+    assert acceptance_operator(None) is None
 
 
 # ---------------------------------------------------------------------------
@@ -106,12 +142,15 @@ def test_read_manifest_raises_on_nonfinal_corruption(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def _rec(decision, before, after, cand, parents, kind="reflective_mutation"):
+def _rec(decision, before, after, cand, parents, kind="reflective_mutation", acceptance=None):
+    if acceptance is None:
+        acceptance = MERGE_GATE if kind == "merge" else STRICT_IMPROVEMENT
     return build_decision_record(
         iteration=1,
         proposal_kind=kind,
         decision=decision,
         decision_reason="r",
+        acceptance_criterion=acceptance,
         candidate=cand,
         parent_ids=list(range(len(parents))),
         parents=parents,
@@ -149,6 +188,51 @@ def test_verify_record_detects_inconsistent_decision():
     parent, cand = {"a": "x"}, {"a": "y"}
     # after < before but labelled accepted -> not re-derivable -> False.
     assert verify_record(_rec("accepted", 2.0, 1.0, cand, [parent]), cand, [parent]) is False
+
+
+def test_verify_record_equal_score_accept_under_improvement_or_equal():
+    # The maintainer's bug: an equal-score acceptance under improvement_or_equal
+    # must replay True from the record alone, without the caller re-supplying the
+    # strategy. Under the default strict-improvement operator it would be False.
+    parent, cand = {"a": "x"}, {"a": "y"}
+    rec = _rec("accepted", 1.0, 1.0, cand, [parent], acceptance=IMPROVEMENT_OR_EQUAL)
+    assert rec["acceptance_operator"] == ">="
+    assert verify_record(rec, cand, [parent]) is True  # no acceptance= override needed
+    # Same record under strict improvement would (correctly) be inconsistent.
+    strict = _rec("accepted", 1.0, 1.0, cand, [parent], acceptance=STRICT_IMPROVEMENT)
+    assert verify_record(strict, cand, [parent]) is False
+
+
+def test_verify_record_uses_recorded_operator_over_caller_override():
+    # A stale/incorrect caller override must not flip a record that stores its
+    # own operator -- the record is authoritative.
+    parent, cand = {"a": "x"}, {"a": "y"}
+    rec = _rec("accepted", 1.0, 1.0, cand, [parent], acceptance=IMPROVEMENT_OR_EQUAL)
+    assert verify_record(rec, cand, [parent], acceptance=STRICT_IMPROVEMENT) is True
+
+
+def test_verify_record_custom_criterion_score_decision_out_of_scope():
+    # A custom criterion records a null operator: hashes/components are still
+    # verified, but the score decision is not re-derivable, so a "surprising"
+    # accept is not flagged as inconsistent.
+    parent, cand = {"a": "x"}, {"a": "y"}
+    rec = _rec("accepted", 2.0, 1.0, cand, [parent], acceptance="MyCriterion")
+    assert rec["acceptance_operator"] is None
+    assert verify_record(rec, cand, [parent]) is True
+    # ...but tampering with identity is still caught.
+    rec["candidate_hash"] = "deadbeef"
+    assert verify_record(rec, cand, [parent]) is False
+
+
+def test_verify_record_legacy_without_recorded_operator():
+    # Backward-compat: a record written before the operator was recorded falls
+    # back to the caller override (then to strict/merge defaults).
+    parent, cand = {"a": "x"}, {"a": "y"}
+    rec = _rec("accepted", 1.0, 1.0, cand, [parent], acceptance=IMPROVEMENT_OR_EQUAL)
+    rec.pop("acceptance_operator")
+    rec.pop("acceptance_criterion")
+    assert verify_record(rec, cand, [parent], acceptance=IMPROVEMENT_OR_EQUAL) is True
+    assert verify_record(rec, cand, [parent]) is False  # defaults to strict
 
 
 # ---------------------------------------------------------------------------
@@ -215,6 +299,11 @@ def test_manifest_written_and_replayable(tmp_path):
         assert r["schema_version"] == SCHEMA_VERSION
         assert r["decision_basis"] == "subsample_acceptance"
         assert len(r["parent_candidate_ids"]) == len(r["parent_candidate_hashes"])
+        # The engine records the criterion that made each decision (default is
+        # strict improvement for reflective, the merge gate for merges).
+        expected = MERGE_GATE if r["proposal_kind"] == "merge" else STRICT_IMPROVEMENT
+        assert r["acceptance_criterion"] == expected
+        assert r["acceptance_operator"] == acceptance_operator(expected)
 
     for r in accepted:
         assert r["candidate_idx"] is not None
@@ -229,3 +318,22 @@ def test_manifest_written_and_replayable(tmp_path):
         assert r["validation"] is None
         parents = [candidates[i] for i in r["parent_candidate_ids"]]
         assert r["parent_candidate_hashes"] == [_candidate_hash(p) for p in parents]
+
+
+def test_manifest_records_improvement_or_equal_criterion(tmp_path):
+    # A run configured with improvement_or_equal records the >= operator, and its
+    # records replay from local files alone (no acceptance= override needed).
+    _run(tmp_path, write_admission_manifest=True, acceptance_criterion="improvement_or_equal")
+    path = os.path.join(str(tmp_path), "admission_manifest.jsonl")
+    records = read_manifest(path)
+    candidates = json.load(open(os.path.join(str(tmp_path), "candidates.json")))
+    reflective = [r for r in records if r["proposal_kind"] != "merge"]
+    assert reflective, "expected at least one reflective decision"
+    for r in reflective:
+        assert r["acceptance_criterion"] == IMPROVEMENT_OR_EQUAL
+        assert r["acceptance_operator"] == ">="
+    for r in records:
+        if r["decision"] == "accepted":
+            cand = candidates[r["candidate_idx"]]
+            parents = [candidates[i] for i in r["parent_candidate_ids"]]
+            assert verify_record(r, cand, parents) is True


### PR DESCRIPTION
Implements the `admission_manifest.jsonl` proposed in #381: one JSON line per candidate-admission decision (accepted or rejected), keyed by candidate and parent hashes, so a run can be audited and reproduced from local files alone. Every field is derivable from facts GEPA already holds, so the manifest is replayable for free. Opt-in, off by default, zero-cost when off.

Follows the design we converged on in the issue thread.

### What it does

- **Opt-in, requires `run_dir`.** `write_admission_manifest: bool = False` on `EngineConfig`, mirrored as a flat kwarg in `optimize()`; raises if `run_dir` is unset, so existing runs never start emitting a new artifact unexpectedly.
- **Append-once, no in-place backfill.** The decision snapshot is built at the subsample-acceptance seam (`_accept_reflective_proposal`); for an accepted candidate the validation fields are finalized after `_run_full_eval_and_add` and the complete record is appended once; rejects append immediately with `validation: null` and `candidate_idx: null`. One shared finalization helper covers the reflective and merge accept paths.
- **Explicit phase.** The recorded `decision` is the subsample acceptance decision (`decision_basis: "subsample_acceptance"`); the `validation` block is post-decision enrichment, not a second admission gate.
- **`components_changed` from a candidate-versus-parent diff**, not metadata parsing (metadata can be absent for custom adapters/proposers, while a diff stays replayable).
- **Dedicated single-record JSONL append helper** (serialize one complete line, append, flush), not `_atomic_write_json`. `read_manifest()` tolerates a truncated final line from an interrupted append.
- **cache hit/miss left null** in v1; signatures, record chaining, and tamper-evidence are intentionally out of scope as a possible separate opt-in follow-up.

`verify_record()` recomputes the candidate and parent hashes and re-derives the decision from the recorded subsample scores.

### Example record (real output from the test run)

An accepted reflective decision:

```json
{
  "schema_version": 1,
  "iteration": 1,
  "proposal_kind": "reflective_mutation",
  "decision": "accepted",
  "decision_reason": "subsample score 1.0 > 0.0 (accepted by StrictImprovementAcceptance)",
  "decision_basis": "subsample_acceptance",
  "candidate_hash": "f554b8d7...098adf",
  "candidate_idx": 1,
  "parent_candidate_ids": [0],
  "parent_candidate_hashes": ["0abb9c2d...8bb4a1"],
  "components_changed": ["current_candidate"],
  "subsample_ids": [0],
  "subsample_score_before": 0.0,
  "subsample_score_after": 1.0,
  "metric_calls_before_decision": 3,
  "validation": {
    "val_average_score": 1.0,
    "evaluated_val_ids": [0],
    "is_best_program": true,
    "metric_calls_after_validation": 4,
    "metric_calls_charged_validation": 1
  },
  "cache_hits": null,
  "cache_misses": null
}
```

A rejected decision is the same shape with `decision: "rejected"`, `candidate_idx: null`, and `validation: null`.

### Files

- `src/gepa/logging/admission_manifest.py` (new): the schema builder, the append and read helpers, and `verify_record`.
- `src/gepa/core/engine.py`: emit at the reflective and merge accept/reject seams via one shared finalization helper; the opt-in flag on `__init__`.
- `src/gepa/optimize_anything.py`, `src/gepa/api.py`: the `EngineConfig` field and the `optimize()` flat kwarg.
- `tests/test_admission_manifest.py` (new, 16 tests).

### Tests and checks

- 16 new tests: accepted / rejected / merge record shapes, the truncated-final-line case, replay verification, and an end-to-end `optimize_anything` run whose accepted records replay against `candidates.json`.
- Full `pytest tests/` passes locally under the `dev` extra; `pyright` is clean; no new `ruff` findings; no new dependencies (the module uses only the standard library and existing GEPA internals).
- Off by default, so existing behavior and cost are unchanged.

### Open questions for you

- Opt-in surface: I went with the `EngineConfig` field mirrored in `optimize()`, per your preference over inferring from `run_dir`.
- Module placement: I put it under `gepa/logging/`; happy to move it (for example to `core/`) if you would rather it sit with the other `run_dir` artifacts.

Opening as a draft for your review. @sunghunkwag

Addresses #381.
