### PR TITLE
Add per-parent rejected-proposal memory (fixes #379)

### DIFF
--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -27,7 +27,14 @@ from gepa.core.callbacks import (
     notify_callbacks,
 )
 from gepa.core.data_loader import DataId, DataLoader, ensure_loader
-from gepa.core.state import EvaluationCache, FrontierType, GEPAState, ValsetEvaluation, initialize_gepa_state
+from gepa.core.state import (
+    EvaluationCache, 
+    FrontierType,
+    GEPAState,
+    RejectionRecord ,
+    ValsetEvaluation, 
+    initialize_gepa_state
+)
 from gepa.logging.experiment_tracker import ExperimentTracker
 from gepa.logging.logger import LoggerProtocol
 from gepa.logging.utils import log_detailed_metrics_after_discovering_new_program
@@ -309,6 +316,20 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                 reject_reason = f"Candidate rejected by acceptance criterion (old_sum={old_sum}, new_sum={new_sum})"
             self.logger.log(reject_msg)
             self._log_proposal_lm_calls(iteration, proposal, candidate_idx=-1)
+            parent_candidates = [state.program_candidates[pid] for pid in proposal.parent_program_ids]
+            proposed_text_diff = {
+                name: text
+                for name, text in proposal.candidate.items()
+                if not any(parent.get(name) == text for parent in parent_candidates)
+            }
+            rejection_record = RejectionRecord(
+                proposed_text_diff=proposed_text_diff,
+                summarized_failure=reject_reason,
+                minibatch_score=new_sum,
+                iteration=iteration,
+            )
+            for parent_id in proposal.parent_program_ids:
+                state.rejected_proposals_by_parent.setdefault(parent_id, []).append(rejection_record)
             notify_callbacks(
                 self.callbacks,
                 "on_candidate_rejected",

--- a/src/gepa/core/state.py
+++ b/src/gepa/core/state.py
@@ -32,6 +32,23 @@ def _candidate_hash(candidate: dict[str, str]) -> CandidateHash:
     """Compute a deterministic hash of a candidate dictionary."""
     return hashlib.sha256(json.dumps(sorted(candidate.items())).encode()).hexdigest()
 
+@dataclass
+class RejectionRecord:
+    """A single rejected reflective-mutation attempt, kept per parent.
+
+    Lets the reflective proposer see what was already tried (and why it
+    failed) the next time the same parent is sampled, instead of starting
+    from a blank slate every iteration. Intentionally informational, not a
+    hard tabu list -- the reflection LM decides how much weight to give it.
+    """
+
+    proposed_text_diff: dict[str, str]
+    """Component name -> proposed text, for components that differed from the parent."""
+    summarized_failure: str
+    """Short human-readable reason the proposal was rejected (mirrors engine.py's reject_reason)."""
+    minibatch_score: float
+    """The rejected candidate's subsample score sum (proposal.subsample_scores_after)."""
+    iteration: int
 
 @dataclass
 class CachedEvaluation(Generic[RolloutOutput]):
@@ -150,7 +167,7 @@ class GEPAState(Generic[RolloutOutput, DataId]):
     returned by :func:`~gepa.optimize_anything.optimize_anything`.
     """
 
-    _VALIDATION_SCHEMA_VERSION: ClassVar[int] = 5
+    _VALIDATION_SCHEMA_VERSION: ClassVar[int] = 6
     # Attributes that are runtime-only and should not be serialized (e.g., callback hooks, caches)
     _EXCLUDED_FROM_SERIALIZATION: ClassVar[frozenset[str]] = frozenset({"_budget_hooks"})
 
@@ -187,6 +204,7 @@ class GEPAState(Generic[RolloutOutput, DataId]):
     # Opaque bag for adapter-specific persistent state.
     # Core GEPA never inspects this; adapters read/write via get_adapter_state()/set_adapter_state().
     adapter_state: dict[str, Any]
+    rejected_proposals_by_parent: dict[ProgramIdx, list[RejectionRecord]]
 
     def __init__(
         self,
@@ -252,7 +270,7 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         self.validation_schema_version = self._VALIDATION_SCHEMA_VERSION
         self.evaluation_cache = evaluation_cache
         self.adapter_state: dict[str, Any] = {}
-
+        self.rejected_proposals_by_parent: dict[ProgramIdx, list[RejectionRecord]] = {}
     def is_consistent(self) -> bool:
         assert len(self.program_candidates) == len(self.parent_program_for_candidate)
         assert len(self.program_candidates) == len(self.named_predictor_id_to_update_next_for_program_candidate)
@@ -373,6 +391,7 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         assert set(state.pareto_front_valset.keys()) == set(state.program_at_pareto_front_valset.keys())
         assert set(state.objective_pareto_front.keys()) == set(state.program_at_pareto_front_objectives.keys())
         assert isinstance(state.adapter_state, dict)
+        assert isinstance(state.rejected_proposals_by_parent, dict)
         return state
 
     @staticmethod
@@ -417,6 +436,8 @@ class GEPAState(Generic[RolloutOutput, DataId]):
             d["evaluation_cache"] = None
         if "adapter_state" not in d:
             d["adapter_state"] = {}
+        if "rejected_proposals_by_parent" not in d:       
+            d["rejected_proposals_by_parent"] = {}
         d["validation_schema_version"] = GEPAState._VALIDATION_SCHEMA_VERSION
 
     @staticmethod

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -365,10 +365,39 @@ class ReflectiveMutationProposer(ProposeNewCandidate[DataId]):
                     reflective_dataset=reflective_dataset_concrete,
                 ),
             )
+            # Surface earlier rejected attempts from this same parent so the
+            # reflection step has context about what was already tried and
+            # why it failed, instead of starting from a blank slate every
+            # time this parent is sampled (issue #379). This is purely
+            # informational -- not a tabu list -- so the reflection LM can
+            # still retry a similar idea if it has reason to believe it
+            # would work this time. Bounded to the last 3 per parent so hot
+            # parents don't bloat the prompt indefinitely. Only added to
+            # components that already have feedback data, so components
+            # with no data are still skipped as before.
+            rejection_records = state.rejected_proposals_by_parent.get(ctx.curr_prog_id, [])
+            if rejection_records:
+                history_note = {
+                    "note": "Earlier attempted edits from this parent and what went wrong",
+                    "previous_attempts": [
+                        {
+                            "iteration": rec.iteration,
+                            "proposed_change": rec.proposed_text_diff,
+                            "why_it_was_rejected": rec.summarized_failure,
+                        }
+                        for rec in rejection_records[-3:]
+                    ],
+                }
+                reflective_dataset = {
+                    name: ([*items, history_note] if name in predictor_names_to_update and items else items)
+                    for name, items in reflective_dataset.items()
+                }
 
             new_texts, prompts, raw_lm_outputs = self.propose_new_texts(
                 ctx.curr_prog, reflective_dataset, predictor_names_to_update
             )
+
+            
 
             notify_callbacks(
                 self.callbacks,

--- a/tests/test_rejected_proposal_memory.py
+++ b/tests/test_rejected_proposal_memory.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""Tests for per-parent rejected-proposal memory (issue #379).
+
+GEPA previously discarded all information about a rejected reflective
+mutation the moment it was rejected. If the same parent was re-selected
+later, the reflective proposer started from a blank slate and could
+regenerate the exact same broken mutation indefinitely, burning the
+evaluation budget on one dead end.
+
+These tests cover the acceptance criteria from the issue:
+  * GEPAState retains rejected proposals per parent.
+  * The reflective proposer surfaces them in the reflection prompt under a
+    clearly labeled section -- but only once a rejection has actually
+    happened for that parent, never on the very first attempt.
+  * The surfaced history is bounded (last 3 per parent) so hot parents
+    don't bloat the prompt indefinitely.
+  * Rejection memory survives a save/load round-trip, and a run_dir saved
+    before this feature existed still loads cleanly.
+"""
+
+import os
+import pickle
+import tempfile
+
+from gepa.core.state import GEPAState, RejectionRecord, ValsetEvaluation
+from gepa.optimize_anything import EngineConfig, GEPAConfig, ReflectionConfig, optimize_anything
+
+SEED = "BASELINE_SOLUTION"
+BROKEN_MUTATION = "import nonexistent_pkg\nBASELINE_SOLUTION"
+
+
+def _make_seed_state() -> GEPAState:
+    seed = {"instructions": "be helpful"}
+    ve = ValsetEvaluation(outputs_by_val_id={0: "out"}, scores_by_val_id={0: 0.5}, objective_scores_by_val_id=None)
+    return GEPAState(seed, ve)
+
+
+def _evaluate(candidate, opt_state):
+    """Deterministic stand-in for 'this code throws ImportError and scores 0'."""
+    score = 1.0 if candidate == SEED else 0.0
+    return score, {"score": score}
+
+
+def _make_fake_reflection_lm(captured_prompts: list):
+    """A zero-memory 'reflection LM' that always proposes the same broken edit."""
+
+    def fake_reflection_lm(prompt):
+        captured_prompts.append(prompt)
+        return f"```\n{BROKEN_MUTATION}\n```"
+
+    return fake_reflection_lm
+
+
+class TestGEPAStateRejectionMemory:
+    def test_fresh_state_has_empty_rejection_memory(self):
+        state = _make_seed_state()
+        assert state.rejected_proposals_by_parent == {}
+
+    def test_save_load_round_trip_preserves_rejection_memory(self):
+        state = _make_seed_state()
+        state.rejected_proposals_by_parent.setdefault(0, []).append(
+            RejectionRecord(
+                proposed_text_diff={"instructions": "broken"},
+                summarized_failure="nope",
+                minibatch_score=0.0,
+                iteration=1,
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as run_dir:
+            state.save(run_dir)
+            loaded = GEPAState.load(run_dir)
+
+        assert loaded.rejected_proposals_by_parent[0][0].summarized_failure == "nope"
+        assert loaded.rejected_proposals_by_parent[0][0].proposed_text_diff == {"instructions": "broken"}
+
+    def test_loading_old_run_dir_without_field_defaults_to_empty(self):
+        """A run_dir saved before issue #379's fix should still load cleanly."""
+        state = _make_seed_state()
+
+        with tempfile.TemporaryDirectory() as run_dir:
+            state.save(run_dir)
+            path = os.path.join(run_dir, "gepa_state.bin")
+            with open(path, "rb") as f:
+                data = pickle.load(f)
+            del data["rejected_proposals_by_parent"]
+            data["validation_schema_version"] = 5
+            with open(path, "wb") as f:
+                pickle.dump(data, f)
+
+            loaded = GEPAState.load(run_dir)
+
+        assert loaded.rejected_proposals_by_parent == {}
+        assert loaded.validation_schema_version == GEPAState._VALIDATION_SCHEMA_VERSION
+
+
+class TestReflectionPromptThreadsRejectionHistory:
+    def test_no_history_on_first_attempt(self):
+        """The very first proposal for a parent has nothing to recall yet."""
+        captured_prompts: list = []
+        optimize_anything(
+            seed_candidate=SEED,
+            evaluator=_evaluate,
+            objective="test: no history on first attempt",
+            config=GEPAConfig(
+                engine=EngineConfig(max_metric_calls=2, display_progress_bar=False),
+                reflection=ReflectionConfig(reflection_lm=_make_fake_reflection_lm(captured_prompts)),
+            ),
+        )
+
+        assert len(captured_prompts) >= 1
+        assert "Earlier attempted edits" not in captured_prompts[0]
+
+    def test_rejection_history_surfaces_on_next_attempt_with_same_parent(self):
+        """Core repro for issue #379: same parent re-selected -> history must appear."""
+        captured_prompts: list = []
+        optimize_anything(
+            seed_candidate=SEED,
+            evaluator=_evaluate,
+            objective="test: rejection history surfaces",
+            config=GEPAConfig(
+                engine=EngineConfig(max_metric_calls=10, display_progress_bar=False),
+                reflection=ReflectionConfig(reflection_lm=_make_fake_reflection_lm(captured_prompts)),
+            ),
+        )
+
+        assert len(captured_prompts) >= 2
+        assert "Earlier attempted edits" not in captured_prompts[0]
+        for later_prompt in captured_prompts[1:]:
+            assert "Earlier attempted edits" in later_prompt
+            assert "New subsample score 0.0 not better than old score 1.0" in later_prompt
+
+    def test_rejection_history_is_bounded_to_last_three(self):
+        """Issue #379 requirement: bound the list so hot parents don't bloat the prompt."""
+        captured_prompts: list = []
+        optimize_anything(
+            seed_candidate=SEED,
+            evaluator=_evaluate,
+            objective="test: rejection history is bounded",
+            config=GEPAConfig(
+                engine=EngineConfig(max_metric_calls=20, display_progress_bar=False),
+                reflection=ReflectionConfig(reflection_lm=_make_fake_reflection_lm(captured_prompts)),
+            ),
+        )
+
+        last_prompt = captured_prompts[-1]
+        # By the last iteration there have been far more than 3 rejections
+        # for this parent; only the most recent 3 should be surfaced.
+        assert last_prompt.count("#### iteration") == 3


### PR DESCRIPTION
Fixes #379

Adds per-parent memory of rejected reflective-mutation attempts so the same parent doesn't regenerate the identical failed mutation indefinitely.

**Changes:**
- `GEPAState.rejected_proposals_by_parent: dict[ProgramIdx, list[RejectionRecord]]` (schema v6, backward-compatible with existing `run_dir`s)
- Populated in `_accept_reflective_proposal`'s reject branch (`engine.py`), keyed by parent program id
- Surfaced in the reflection prompt (`reflective_mutation.py`) under "Earlier attempted edits from this parent and what went wrong" -- purely informational, not a hard tabu list
- Bounded to last 3 rejections per parent to avoid context bloat on hot parents

**Tests:** `tests/test_rejected_proposal_memory.py` -- covers state persistence, backward-compat load from pre-fix `run_dir`s, prompt-threading behavior (no history on first attempt, history surfaces on repeat parent, bounded to 3). All passing, no regressions in existing suite.