### PR TITLE
Add structured output format validation helpers

### DIFF
--- a/docs/docs/guides/faq.md
+++ b/docs/docs/guides/faq.md
@@ -254,26 +254,25 @@ result = optimize_anything(..., config=config)
 
 Yes, and this is one of GEPA's strongest use cases for smaller models. Dropbox reduced gemma-3-12b's malformed JSON rate from **40% to under 3%** while simultaneously improving relevance quality, by optimizing the prompt to enforce structured output compliance.
 
-The key is to **penalize format failures in your metric** so GEPA learns this is a hard constraint:
+The key is to **penalize format failures in your metric** so GEPA learns this is a hard constraint. GEPA includes evaluator wrappers for common structured-output formats:
 
 ```python
-def evaluator(data, response):
-    import json
-    # Hard penalty for format violations
-    try:
-        parsed = json.loads(response)
-    except json.JSONDecodeError:
-        return 0.0, {"Output": response, "Error": "Malformed JSON — failed to parse"}
+from gepa.utils import require_json_output
 
-    score = compute_quality_score(parsed, data)
+
+@require_json_output(schema={"score": int, "reasoning": str})
+def evaluator(data, response):
+    # response is already parsed JSON here. If parsing or schema validation
+    # fails, GEPA returns score=0.0 with the parse error in side_info.
+    score = compute_quality_score(response, data)
     return score, {
-        "Output": parsed,
+        "Output": response,
         "Expected": data["expected"],
         "Score": score,
     }
 ```
 
-Including the parse error in `side_info` gives GEPA's reflection LM the signal it needs to add explicit formatting instructions to the prompt.
+`require_json_output` automatically returns `score=0.0` with the malformed output and validation error in `side_info`. The parse error gives GEPA's reflection LM the signal it needs to add explicit formatting instructions to the prompt. For non-JSON formats, use `require_regex_match`, `require_xml_output`, or `require_format` with a custom validator.
 
 ### Does GEPA support async optimization?
 

--- a/src/gepa/utils/__init__.py
+++ b/src/gepa/utils/__init__.py
@@ -10,6 +10,10 @@ Re-exports:
 
     **Stdio capture** — thread-safe stdout/stderr capture during evaluation:
     ``StreamCaptureManager``, ``ThreadLocalStreamCapture``.
+
+    **Format validation** — evaluator wrappers for structured outputs:
+    ``require_json_output``, ``require_xml_output``, ``require_regex_match``,
+    ``require_format``.
 """
 
 # Code execution utilities for fitness functions that evaluate generated code
@@ -19,6 +23,13 @@ from .code_execution import (
     TimeLimitError,
     execute_code,
     get_code_hash,
+)
+from .format_validation import (
+    FormatValidationError,
+    require_format,
+    require_json_output,
+    require_regex_match,
+    require_xml_output,
 )
 from .stdio_capture import (
     StreamCaptureManager,
@@ -56,6 +67,12 @@ __all__ = [
     "TimeLimitError",
     "execute_code",
     "get_code_hash",
+    # Format validation utilities
+    "FormatValidationError",
+    "require_format",
+    "require_json_output",
+    "require_regex_match",
+    "require_xml_output",
     # Stdio capture utilities
     "StreamCaptureManager",
     "ThreadLocalStreamCapture",

--- a/src/gepa/utils/format_validation.py
+++ b/src/gepa/utils/format_validation.py
@@ -37,10 +37,11 @@ def require_format(
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Wrap an evaluator so invalid structured output returns a hard-failure score.
 
-    ``validator_fn`` receives the raw output argument and should return the value
-    to pass into the wrapped evaluator. If it raises an exception, the evaluator
-    is not called and the wrapper returns ``(failure_score, side_info)`` by
-    default.
+    ``validator_fn`` receives the raw output argument. It may return ``True`` to
+    pass the original output through, ``False`` to fail validation, or another
+    value to pass into the wrapped evaluator. If it raises an exception, the
+    evaluator is not called and the wrapper returns ``(failure_score, side_info)``
+    by default.
 
     Args:
         validator_fn: Function that validates and optionally parses the output.
@@ -277,10 +278,15 @@ def _replace_output_argument(
 
 def _validate_or_fail(validator_fn: Callable[[Any], Any], raw_output: Any) -> Any:
     try:
-        return validator_fn(raw_output)
+        validated = validator_fn(raw_output)
     except Exception as exc:
         message = str(exc) or exc.__class__.__name__
         raise _ValidationFailureError(raw_output, message) from exc
+    if validated is False:
+        raise _ValidationFailureError(raw_output, "Format validator returned False.")
+    if validated is True:
+        return raw_output
+    return validated
 
 
 def _failure_side_info(

--- a/src/gepa/utils/format_validation.py
+++ b/src/gepa/utils/format_validation.py
@@ -1,0 +1,376 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""Evaluator wrappers for treating structured-output format errors as hard failures."""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import json
+import re
+import xml.etree.ElementTree as ET
+from collections.abc import Callable, Mapping
+from typing import Any
+
+FailureFactory = Callable[[float, dict[str, Any]], Any]
+
+
+class FormatValidationError(ValueError):
+    """Raised when an output does not satisfy a required format."""
+
+
+def require_format(
+    validator_fn: Callable[[Any], Any],
+    *,
+    output_arg: str | None = None,
+    output_index: int = -1,
+    failure_score: float = 0.0,
+    failure_factory: FailureFactory | None = None,
+    format_name: str = "format",
+    include_output: bool = True,
+    output_key: str = "Output",
+    error_key: str = "Error",
+    feedback_key: str = "Feedback",
+    track_format: bool = False,
+    format_objective_name: str = "format_valid",
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Wrap an evaluator so invalid structured output returns a hard-failure score.
+
+    ``validator_fn`` receives the raw output argument and should return the value
+    to pass into the wrapped evaluator. If it raises an exception, the evaluator
+    is not called and the wrapper returns ``(failure_score, side_info)`` by
+    default.
+
+    Args:
+        validator_fn: Function that validates and optionally parses the output.
+        output_arg: Named argument containing the output. If omitted, the wrapper
+            validates the positional argument at ``output_index``.
+        output_index: Positional argument index to validate when ``output_arg``
+            is not set. Defaults to the last positional argument.
+        failure_score: Score returned when validation fails.
+        failure_factory: Optional factory for custom evaluator return types. It
+            receives ``(failure_score, side_info)``.
+        format_name: Human-readable format label used in feedback.
+        include_output: Include the raw output in failure ``side_info``.
+        output_key: Key used for the raw output in failure ``side_info``.
+        error_key: Key used for the validation error in failure ``side_info``.
+        feedback_key: Key used for reflection-facing feedback in failure
+            ``side_info``.
+        track_format: Add a ``scores[format_objective_name]`` objective with
+            ``0.0`` on failure and ``1.0`` on success when the wrapped evaluator
+            returns score/side_info.
+        format_objective_name: Objective name used when ``track_format=True``.
+    """
+
+    def decorator(evaluator_fn: Callable[..., Any]) -> Callable[..., Any]:
+        sig = inspect.signature(evaluator_fn) if output_arg is not None else None
+
+        @functools.wraps(evaluator_fn)
+        def wrapped(*args: Any, **kwargs: Any) -> Any:
+            try:
+                _, replaced_args, replaced_kwargs = _replace_output_argument(
+                    args,
+                    kwargs,
+                    validator_fn,
+                    output_arg=output_arg,
+                    output_index=output_index,
+                    sig=sig,
+                )
+            except _ValidationFailureError as failure:
+                side_info = _failure_side_info(
+                    raw_output=failure.raw_output,
+                    message=failure.message,
+                    format_name=format_name,
+                    include_output=include_output,
+                    output_key=output_key,
+                    error_key=error_key,
+                    feedback_key=feedback_key,
+                    track_format=track_format,
+                    format_objective_name=format_objective_name,
+                )
+                if failure_factory is not None:
+                    return failure_factory(failure_score, side_info)
+                return failure_score, side_info
+
+            result = evaluator_fn(*replaced_args, **replaced_kwargs)
+            return _attach_success_format_score(result, track_format, format_objective_name)
+
+        return wrapped
+
+    return decorator
+
+
+def require_json_output(
+    evaluator_fn: Callable[..., Any] | None = None,
+    *,
+    schema: Any | None = None,
+    output_arg: str | None = None,
+    output_index: int = -1,
+    failure_score: float = 0.0,
+    failure_factory: FailureFactory | None = None,
+    track_format: bool = False,
+    format_objective_name: str = "json_valid",
+) -> Callable[..., Any]:
+    """Require an evaluator output argument to be valid JSON.
+
+    The wrapped evaluator receives the parsed JSON value. ``schema`` is an
+    optional lightweight Python schema: mappings require keys, types require
+    ``isinstance`` matches, and single-item lists validate every list item.
+    """
+
+    def validator(raw_output: Any) -> Any:
+        if isinstance(raw_output, (str, bytes, bytearray)):
+            try:
+                parsed = json.loads(raw_output)
+            except json.JSONDecodeError as exc:
+                raise FormatValidationError(f"Malformed JSON: {exc}") from exc
+        else:
+            parsed = raw_output
+
+        _validate_python_schema(parsed, schema)
+        return parsed
+
+    decorator = require_format(
+        validator,
+        output_arg=output_arg,
+        output_index=output_index,
+        failure_score=failure_score,
+        failure_factory=failure_factory,
+        format_name="JSON",
+        track_format=track_format,
+        format_objective_name=format_objective_name,
+    )
+    if evaluator_fn is not None:
+        return decorator(evaluator_fn)
+    return decorator
+
+
+def require_xml_output(
+    evaluator_fn: Callable[..., Any] | None = None,
+    *,
+    root_tag: str | None = None,
+    output_arg: str | None = None,
+    output_index: int = -1,
+    failure_score: float = 0.0,
+    failure_factory: FailureFactory | None = None,
+    track_format: bool = False,
+    format_objective_name: str = "xml_valid",
+) -> Callable[..., Any]:
+    """Require an evaluator output argument to be well-formed XML.
+
+    The wrapped evaluator receives the parsed ``xml.etree.ElementTree.Element``.
+    """
+
+    def validator(raw_output: Any) -> ET.Element:
+        if not isinstance(raw_output, str):
+            raise FormatValidationError(f"Expected XML output as str, got {type(raw_output).__name__}.")
+        try:
+            root = ET.fromstring(raw_output)
+        except ET.ParseError as exc:
+            raise FormatValidationError(f"Malformed XML: {exc}") from exc
+        if root_tag is not None and root.tag != root_tag:
+            raise FormatValidationError(f"Expected XML root tag '{root_tag}', got '{root.tag}'.")
+        return root
+
+    decorator = require_format(
+        validator,
+        output_arg=output_arg,
+        output_index=output_index,
+        failure_score=failure_score,
+        failure_factory=failure_factory,
+        format_name="XML",
+        track_format=track_format,
+        format_objective_name=format_objective_name,
+    )
+    if evaluator_fn is not None:
+        return decorator(evaluator_fn)
+    return decorator
+
+
+def require_regex_match(
+    evaluator_fn: Callable[..., Any] | None = None,
+    *,
+    pattern: str | re.Pattern[str],
+    flags: int = 0,
+    fullmatch: bool = True,
+    pass_match: bool = False,
+    output_arg: str | None = None,
+    output_index: int = -1,
+    failure_score: float = 0.0,
+    failure_factory: FailureFactory | None = None,
+    track_format: bool = False,
+    format_objective_name: str = "regex_valid",
+) -> Callable[..., Any]:
+    """Require an evaluator output argument to match a regular expression."""
+
+    compiled = re.compile(pattern, flags) if isinstance(pattern, str) else pattern
+
+    def validator(raw_output: Any) -> Any:
+        if not isinstance(raw_output, str):
+            raise FormatValidationError(f"Expected regex input as str, got {type(raw_output).__name__}.")
+        match = compiled.fullmatch(raw_output) if fullmatch else compiled.search(raw_output)
+        if match is None:
+            match_type = "fullmatch" if fullmatch else "match"
+            raise FormatValidationError(f"Regex {match_type} failed for pattern {compiled.pattern!r}.")
+        return match if pass_match else raw_output
+
+    decorator = require_format(
+        validator,
+        output_arg=output_arg,
+        output_index=output_index,
+        failure_score=failure_score,
+        failure_factory=failure_factory,
+        format_name="regex",
+        track_format=track_format,
+        format_objective_name=format_objective_name,
+    )
+    if evaluator_fn is not None:
+        return decorator(evaluator_fn)
+    return decorator
+
+
+class _ValidationFailureError(Exception):
+    def __init__(self, raw_output: Any, message: str) -> None:
+        self.raw_output = raw_output
+        self.message = message
+        super().__init__(message)
+
+
+def _replace_output_argument(
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    validator_fn: Callable[[Any], Any],
+    *,
+    output_arg: str | None,
+    output_index: int,
+    sig: inspect.Signature | None,
+) -> tuple[Any, tuple[Any, ...], dict[str, Any]]:
+    if output_arg is not None:
+        if output_arg in kwargs:
+            raw_output = kwargs[output_arg]
+            parsed = _validate_or_fail(validator_fn, raw_output)
+            replaced_kwargs = {**kwargs, output_arg: parsed}
+            return raw_output, args, replaced_kwargs
+        if sig is None:
+            raise TypeError("Internal error: output_arg requires an inspected signature.")
+        bound = sig.bind_partial(*args, **kwargs)
+        if output_arg not in bound.arguments:
+            raise TypeError(f"Missing output argument '{output_arg}' for format validation.")
+        raw_output = bound.arguments[output_arg]
+        parsed = _validate_or_fail(validator_fn, raw_output)
+        bound.arguments[output_arg] = parsed
+        return raw_output, bound.args, bound.kwargs
+
+    if not args:
+        raise TypeError("Format validation requires a positional output argument or output_arg.")
+    normalized_index = output_index if output_index >= 0 else len(args) + output_index
+    if normalized_index < 0 or normalized_index >= len(args):
+        raise TypeError(f"output_index {output_index} is out of range for {len(args)} positional arguments.")
+
+    raw_output = args[normalized_index]
+    parsed = _validate_or_fail(validator_fn, raw_output)
+    replaced_args = list(args)
+    replaced_args[normalized_index] = parsed
+    return raw_output, tuple(replaced_args), kwargs
+
+
+def _validate_or_fail(validator_fn: Callable[[Any], Any], raw_output: Any) -> Any:
+    try:
+        return validator_fn(raw_output)
+    except Exception as exc:
+        message = str(exc) or exc.__class__.__name__
+        raise _ValidationFailureError(raw_output, message) from exc
+
+
+def _failure_side_info(
+    *,
+    raw_output: Any,
+    message: str,
+    format_name: str,
+    include_output: bool,
+    output_key: str,
+    error_key: str,
+    feedback_key: str,
+    track_format: bool,
+    format_objective_name: str,
+) -> dict[str, Any]:
+    feedback = f"{format_name} validation failed: {message}"
+    side_info: dict[str, Any] = {
+        feedback_key: feedback,
+        error_key: message,
+        "format": format_name,
+        "format_valid": False,
+    }
+    if include_output:
+        side_info[output_key] = raw_output
+    if track_format:
+        side_info["scores"] = {format_objective_name: 0.0}
+    return side_info
+
+
+def _attach_success_format_score(result: Any, track_format: bool, format_objective_name: str) -> Any:
+    if not track_format:
+        return result
+
+    success_info: dict[str, Any] = {"format_valid": True, "scores": {format_objective_name: 1.0}}
+    if isinstance(result, tuple) and len(result) == 2:
+        score, side_info = result
+        merged = dict(side_info) if side_info is not None else {}
+        existing_scores = merged.get("scores")
+        scores = dict(existing_scores) if isinstance(existing_scores, Mapping) else {}
+        scores[format_objective_name] = 1.0
+        merged["scores"] = scores
+        merged.setdefault("format_valid", True)
+        return score, merged
+    if isinstance(result, (int, float)) and not isinstance(result, bool):
+        return result, success_info
+    return result
+
+
+def _validate_python_schema(value: Any, schema: Any, path: str = "$") -> None:
+    if schema is None:
+        return
+    if isinstance(schema, type):
+        if not _matches_type(value, schema):
+            raise FormatValidationError(
+                f"{path} expected {schema.__name__}, got {type(value).__name__}."
+            )
+        return
+    if _is_type_tuple(schema):
+        if not any(_matches_type(value, expected_type) for expected_type in schema):
+            expected = " | ".join(t.__name__ for t in schema)
+            raise FormatValidationError(f"{path} expected {expected}, got {type(value).__name__}.")
+        return
+    if isinstance(schema, Mapping):
+        if not isinstance(value, Mapping):
+            raise FormatValidationError(f"{path} expected object, got {type(value).__name__}.")
+        for key, expected_schema in schema.items():
+            if key not in value:
+                raise FormatValidationError(f"{path} missing required key {key!r}.")
+            _validate_python_schema(value[key], expected_schema, f"{path}.{key}")
+        return
+    if isinstance(schema, list):
+        if len(schema) != 1:
+            raise FormatValidationError(f"{path} schema list must contain exactly one item schema.")
+        if not isinstance(value, list):
+            raise FormatValidationError(f"{path} expected list, got {type(value).__name__}.")
+        for idx, item in enumerate(value):
+            _validate_python_schema(item, schema[0], f"{path}[{idx}]")
+        return
+    if callable(schema):
+        if not schema(value):
+            raise FormatValidationError(f"{path} failed custom schema predicate.")
+        return
+    if value != schema:
+        raise FormatValidationError(f"{path} expected {schema!r}, got {value!r}.")
+
+
+def _is_type_tuple(schema: Any) -> bool:
+    return isinstance(schema, tuple) and all(isinstance(item, type) for item in schema)
+
+
+def _matches_type(value: Any, expected_type: type) -> bool:
+    if expected_type is int and isinstance(value, bool):
+        return False
+    return isinstance(value, expected_type)

--- a/tests/test_format_validation.py
+++ b/tests/test_format_validation.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+import re
+
+import pytest
+
+from gepa.adapters.default_adapter.default_adapter import EvaluationResult
+from gepa.utils import (
+    FormatValidationError,
+    require_format,
+    require_json_output,
+    require_regex_match,
+    require_xml_output,
+)
+
+
+def test_require_json_output_parses_before_calling_evaluator():
+    seen = {}
+
+    @require_json_output(schema={"score": int, "reasoning": str})
+    def evaluator(data, response):
+        seen["response"] = response
+        return response["score"] / 10, {"Output": response, "Expected": data["expected"]}
+
+    score, side_info = evaluator({"expected": 7}, '{"score": 7, "reasoning": "matched"}')
+
+    assert score == 0.7
+    assert seen["response"] == {"score": 7, "reasoning": "matched"}
+    assert side_info["Output"] == {"score": 7, "reasoning": "matched"}
+
+
+def test_require_json_output_malformed_json_returns_zero_and_feedback():
+    called = False
+
+    @require_json_output(schema={"score": int})
+    def evaluator(data, response):
+        nonlocal called
+        called = True
+        return 1.0, {"Output": response}
+
+    score, side_info = evaluator({"expected": 7}, '{"score": ')
+
+    assert score == 0.0
+    assert called is False
+    assert side_info["format"] == "JSON"
+    assert side_info["format_valid"] is False
+    assert "Malformed JSON" in side_info["Error"]
+    assert "JSON validation failed" in side_info["Feedback"]
+    assert side_info["Output"] == '{"score": '
+
+
+def test_require_json_output_schema_failure_reports_missing_key():
+    @require_json_output(schema={"score": int, "reasoning": str})
+    def evaluator(data, response):
+        return 1.0, {"Output": response}
+
+    score, side_info = evaluator({}, '{"score": 7}')
+
+    assert score == 0.0
+    assert "missing required key 'reasoning'" in side_info["Error"]
+
+
+def test_require_json_output_supports_named_output_argument():
+    @require_json_output(output_arg="response", schema={"answer": str})
+    def evaluator(data, response):
+        return 1.0 if response["answer"] == data["expected"] else 0.0
+
+    assert evaluator({"expected": "Paris"}, response='{"answer": "Paris"}') == 1.0
+
+
+def test_require_json_output_failure_factory_supports_custom_return_types():
+    @require_json_output(
+        schema={"answer": str},
+        failure_factory=lambda score, side_info: EvaluationResult(
+            score=score,
+            feedback=side_info["Feedback"],
+            objective_scores=side_info.get("scores"),
+        ),
+    )
+    def evaluator(data, response):
+        return EvaluationResult(score=1.0, feedback="ok")
+
+    result = evaluator({}, "{bad json")
+
+    assert result.score == 0.0
+    assert "JSON validation failed" in result.feedback
+
+
+def test_require_json_output_track_format_objective_on_success_and_failure():
+    @require_json_output(schema={"answer": str}, track_format=True)
+    def evaluator(data, response):
+        return 0.8, {"scores": {"quality": 0.8}}
+
+    success_score, success_info = evaluator({}, '{"answer": "A"}')
+    failure_score, failure_info = evaluator({}, '{"missing": "A"}')
+
+    assert success_score == 0.8
+    assert success_info["scores"] == {"quality": 0.8, "json_valid": 1.0}
+    assert success_info["format_valid"] is True
+    assert failure_score == 0.0
+    assert failure_info["scores"] == {"json_valid": 0.0}
+
+
+def test_require_regex_match_failure_and_match_passing():
+    @require_regex_match(pattern=r"ID-(\d+)", pass_match=True)
+    def evaluator(response: re.Match[str]):
+        return int(response.group(1)), {"matched": response.group(0)}
+
+    assert evaluator("ID-42") == (42, {"matched": "ID-42"})
+
+    score, side_info = evaluator("bad")
+    assert score == 0.0
+    assert "Regex fullmatch failed" in side_info["Error"]
+
+
+def test_require_xml_output_parses_and_checks_root_tag():
+    @require_xml_output(root_tag="answer")
+    def evaluator(response):
+        return 1.0, {"value": response.text}
+
+    assert evaluator("<answer>yes</answer>") == (1.0, {"value": "yes"})
+
+    score, side_info = evaluator("<wrong>yes</wrong>")
+    assert score == 0.0
+    assert "Expected XML root tag 'answer'" in side_info["Error"]
+
+
+def test_require_format_supports_custom_validator():
+    def validate_uppercase(raw_output):
+        if raw_output != raw_output.upper():
+            raise FormatValidationError("Output must be uppercase.")
+        return raw_output.lower()
+
+    @require_format(validate_uppercase, format_name="uppercase")
+    def evaluator(response):
+        return 1.0, {"normalized": response}
+
+    assert evaluator("YES") == (1.0, {"normalized": "yes"})
+
+    score, side_info = evaluator("Yes")
+    assert score == 0.0
+    assert side_info["format"] == "uppercase"
+    assert side_info["Error"] == "Output must be uppercase."
+
+
+def test_schema_list_validates_every_item():
+    @require_json_output(schema={"answers": [str]})
+    def evaluator(response):
+        return 1.0, {"Output": response}
+
+    assert evaluator('{"answers": ["a", "b"]}')[0] == 1.0
+
+    score, side_info = evaluator('{"answers": ["a", 2]}')
+    assert score == 0.0
+    assert "$.answers[1] expected str" in side_info["Error"]
+
+
+def test_schema_predicate_can_validate_values():
+    @require_json_output(schema={"score": lambda value: 0 <= value <= 1})
+    def evaluator(response):
+        return response["score"], {"Output": response}
+
+    assert evaluator('{"score": 0.5}')[0] == 0.5
+
+    score, side_info = evaluator('{"score": 2}')
+    assert score == 0.0
+    assert "$.score failed custom schema predicate" in side_info["Error"]
+
+
+def test_schema_int_does_not_accept_json_bool():
+    @require_json_output(schema={"score": int})
+    def evaluator(response):
+        return response["score"], {"Output": response}
+
+    score, side_info = evaluator('{"score": true}')
+
+    assert score == 0.0
+    assert "$.score expected int, got bool" in side_info["Error"]
+
+
+def test_invalid_output_index_raises_clear_type_error():
+    @require_json_output(output_index=1)
+    def evaluator(response):
+        return 1.0, {"Output": response}
+
+    with pytest.raises(TypeError, match="output_index 1 is out of range"):
+        evaluator('{"answer": "ok"}')

--- a/tests/test_format_validation.py
+++ b/tests/test_format_validation.py
@@ -144,6 +144,47 @@ def test_require_format_supports_custom_validator():
     assert side_info["Error"] == "Output must be uppercase."
 
 
+def test_require_format_supports_boolean_predicate_validators():
+    called = False
+
+    @require_format(lambda raw_output: raw_output.startswith("ok:"), format_name="prefix")
+    def evaluator(response):
+        nonlocal called
+        called = True
+        return 1.0, {"Output": response}
+
+    assert evaluator("ok:value") == (1.0, {"Output": "ok:value"})
+
+    called = False
+    score, side_info = evaluator("bad:value")
+    assert score == 0.0
+    assert side_info["format"] == "prefix"
+    assert side_info["Error"] == "Format validator returned False."
+    assert side_info["Output"] == "bad:value"
+    assert called is False
+
+
+def test_require_format_validator_exception_returns_failure_feedback():
+    called = False
+
+    def validator(raw_output):
+        raise ValueError(f"cannot validate {raw_output}")
+
+    @require_format(validator, format_name="custom")
+    def evaluator(response):
+        nonlocal called
+        called = True
+        return 1.0, {"Output": response}
+
+    score, side_info = evaluator("bad")
+
+    assert score == 0.0
+    assert called is False
+    assert side_info["format"] == "custom"
+    assert side_info["Error"] == "cannot validate bad"
+    assert "custom validation failed: cannot validate bad" in side_info["Feedback"]
+
+
 def test_schema_list_validates_every_item():
     @require_json_output(schema={"answers": [str]})
     def evaluator(response):


### PR DESCRIPTION
## Summary

Fixes #265.

This PR adds evaluator wrappers for structured-output validation:

- `require_json_output`
- `require_xml_output`
- `require_regex_match`
- `require_format`

When validation fails, the wrapper returns `score=0.0` and includes the parse or validation error in `side_info`, so GEPA's reflection step can learn from format failures.

This is related to #379/#384, but intentionally limited to evaluator-side format failure feedback. It does not implement rejected-proposal memory.

## Tests

- `python -m pytest -q`
- `python -m ruff check src/gepa/utils/format_validation.py src/gepa/utils/__init__.py tests/test_format_validation.py docs/docs/guides/faq.md`
- `python -m pyright --pythonversion 3.12 src/gepa/utils/format_validation.py`
- `mkdocs build -f docs/mkdocs.yml`
