### PR TITLE
feat: add format-validation decorators for evaluators

### DIFF
--- a/src/gepa/utils/__init__.py
+++ b/src/gepa/utils/__init__.py
@@ -10,6 +10,9 @@ Re-exports:
 
     **Stdio capture** — thread-safe stdout/stderr capture during evaluation:
     ``StreamCaptureManager``, ``ThreadLocalStreamCapture``.
+
+    **Format validation** — evaluator decorators for hard-failing malformed outputs:
+    ``require_json_output``, ``require_format``, ``require_regex_match``.
 """
 
 # Code execution utilities for fitness functions that evaluate generated code
@@ -20,6 +23,7 @@ from .code_execution import (
     execute_code,
     get_code_hash,
 )
+from .format_validator import require_format, require_json_output, require_regex_match
 from .stdio_capture import (
     StreamCaptureManager,
     ThreadLocalStreamCapture,
@@ -56,6 +60,10 @@ __all__ = [
     "TimeLimitError",
     "execute_code",
     "get_code_hash",
+    # Format validation utilities
+    "require_format",
+    "require_json_output",
+    "require_regex_match",
     # Stdio capture utilities
     "StreamCaptureManager",
     "ThreadLocalStreamCapture",

--- a/src/gepa/utils/format_validator.py
+++ b/src/gepa/utils/format_validator.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""Format-validation decorators for GEPA evaluators."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable, Mapping
+from functools import wraps
+from typing import Any
+
+EvaluatorResult = tuple[float, dict[str, Any]]
+EvaluatorFn = Callable[..., EvaluatorResult]
+FormatValidatorFn = Callable[[Any], bool]
+SchemaType = type[Any] | tuple[type[Any], ...]
+
+
+def require_json_output(schema: Mapping[str, SchemaType] | None = None) -> Callable[[EvaluatorFn], EvaluatorFn]:
+    """
+    Require the response to be parseable JSON before running the evaluator.
+
+    When validation succeeds, the wrapped evaluator receives the parsed JSON
+    value in place of the raw response string. When parsing or schema
+    validation fails, the evaluator is not called and the failure reason is
+    returned as feedback.
+    """
+
+    def decorator(evaluator: EvaluatorFn) -> EvaluatorFn:
+        @wraps(evaluator)
+        def wrapper(data: Any, response: Any, *args: Any, **kwargs: Any) -> EvaluatorResult:
+            try:
+                parsed_response = json.loads(response)
+            except (json.JSONDecodeError, TypeError) as error:
+                return _failure("Malformed JSON", str(error))
+
+            if schema is not None:
+                schema_error = _validate_schema(parsed_response, schema)
+                if schema_error is not None:
+                    return _failure("Schema mismatch", schema_error)
+
+            return evaluator(data, parsed_response, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def require_format(validator_fn: FormatValidatorFn) -> Callable[[EvaluatorFn], EvaluatorFn]:
+    """
+    Require ``validator_fn(response)`` to pass before running the evaluator.
+
+    The validator should return ``True`` for valid responses. Returning a falsey
+    value or raising an exception short-circuits the evaluator with a zero score
+    and feedback that includes the validation failure.
+    """
+
+    return _require_format(
+        validator_fn,
+        failure_prefix="Format validation failed",
+        false_detail="validator returned False",
+    )
+
+
+def require_regex_match(pattern: str | re.Pattern[str]) -> Callable[[EvaluatorFn], EvaluatorFn]:
+    """Require the response string to fully match ``pattern`` before evaluation."""
+
+    compiled_pattern = re.compile(pattern) if isinstance(pattern, str) else pattern
+
+    def validator_fn(response: Any) -> bool:
+        return isinstance(response, str) and compiled_pattern.fullmatch(response) is not None
+
+    return _require_format(
+        validator_fn,
+        failure_prefix="Regex match failed",
+        false_detail=f"response did not fully match pattern {compiled_pattern.pattern}",
+    )
+
+
+def _require_format(
+    validator_fn: FormatValidatorFn,
+    failure_prefix: str,
+    false_detail: str,
+) -> Callable[[EvaluatorFn], EvaluatorFn]:
+    def decorator(evaluator: EvaluatorFn) -> EvaluatorFn:
+        @wraps(evaluator)
+        def wrapper(data: Any, response: Any, *args: Any, **kwargs: Any) -> EvaluatorResult:
+            try:
+                is_valid = validator_fn(response)
+            except Exception as error:
+                return _failure(failure_prefix, f"{type(error).__name__}: {error}")
+
+            if not is_valid:
+                return _failure(failure_prefix, false_detail)
+
+            return evaluator(data, response, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def _validate_schema(parsed_response: Any, schema: Mapping[str, SchemaType]) -> str | None:
+    if not isinstance(parsed_response, dict):
+        return "expected JSON object for schema validation"
+
+    for key, expected_type in schema.items():
+        if key not in parsed_response:
+            return f"missing required key {key!r}"
+
+        try:
+            if not isinstance(parsed_response[key], expected_type):
+                return f"key {key!r} expected {_type_name(expected_type)}, got {type(parsed_response[key]).__name__}"
+        except TypeError as error:
+            return f"invalid schema for key {key!r}: {error}"
+
+    return None
+
+
+def _type_name(expected_type: SchemaType) -> str:
+    if isinstance(expected_type, tuple):
+        return " or ".join(type_.__name__ for type_ in expected_type)
+    return expected_type.__name__
+
+
+def _failure(prefix: str, detail: str) -> EvaluatorResult:
+    message = prefix if not detail else f"{prefix}: {detail}"
+    return 0.0, {"feedback": message}
+
+
+__all__ = [
+    "require_format",
+    "require_json_output",
+    "require_regex_match",
+]

--- a/tests/test_format_validator.py
+++ b/tests/test_format_validator.py
@@ -1,0 +1,151 @@
+from gepa.utils import require_format, require_json_output, require_regex_match
+
+
+def test_require_json_output_forwards_parsed_dict_matching_schema():
+    calls = []
+
+    @require_json_output(schema={"answer": str, "confidence": float})
+    def evaluator(data, response):
+        calls.append((data, response))
+        return 1.0, {"feedback": "ok"}
+
+    result = evaluator({"id": 1}, '{"answer": "yes", "confidence": 0.9}')
+
+    assert result == (1.0, {"feedback": "ok"})
+    assert calls == [({"id": 1}, {"answer": "yes", "confidence": 0.9})]
+
+
+def test_require_json_output_short_circuits_malformed_json():
+    calls = []
+
+    @require_json_output(schema={"answer": str})
+    def evaluator(data, response):
+        calls.append((data, response))
+        return 1.0, {"feedback": "ok"}
+
+    score, feedback = evaluator({}, '{"answer": "yes"')
+
+    assert score == 0.0
+    assert "Malformed JSON" in feedback["feedback"]
+    assert "Expecting" in feedback["feedback"]
+    assert calls == []
+
+
+def test_require_json_output_short_circuits_missing_schema_key():
+    calls = []
+
+    @require_json_output(schema={"answer": str, "confidence": float})
+    def evaluator(data, response):
+        calls.append((data, response))
+        return 1.0, {"feedback": "ok"}
+
+    score, feedback = evaluator({}, '{"answer": "yes"}')
+
+    assert score == 0.0
+    assert "Schema mismatch" in feedback["feedback"]
+    assert "missing required key 'confidence'" in feedback["feedback"]
+    assert calls == []
+
+
+def test_require_json_output_short_circuits_wrong_schema_type():
+    calls = []
+
+    @require_json_output(schema={"answer": str, "confidence": float})
+    def evaluator(data, response):
+        calls.append((data, response))
+        return 1.0, {"feedback": "ok"}
+
+    score, feedback = evaluator({}, '{"answer": "yes", "confidence": "high"}')
+
+    assert score == 0.0
+    assert "Schema mismatch" in feedback["feedback"]
+    assert "key 'confidence' expected float, got str" in feedback["feedback"]
+    assert calls == []
+
+
+def test_require_json_output_without_schema_accepts_any_parseable_json():
+    calls = []
+
+    @require_json_output()
+    def evaluator(data, response):
+        calls.append((data, response))
+        return 0.5, {"feedback": "parsed"}
+
+    result = evaluator("example", '["a", "b"]')
+
+    assert result == (0.5, {"feedback": "parsed"})
+    assert calls == [("example", ["a", "b"])]
+
+
+def test_require_format_short_circuits_when_validator_returns_false():
+    calls = []
+
+    @require_format(lambda response: response.startswith("ok:"))
+    def evaluator(data, response):
+        calls.append((data, response))
+        return 1.0, {"feedback": "ok"}
+
+    score, feedback = evaluator({}, "bad: value")
+
+    assert score == 0.0
+    assert "Format validation failed" in feedback["feedback"]
+    assert calls == []
+
+
+def test_require_format_short_circuits_when_validator_raises():
+    calls = []
+
+    def validator_fn(response):
+        raise ValueError(f"cannot validate {response}")
+
+    @require_format(validator_fn)
+    def evaluator(data, response):
+        calls.append((data, response))
+        return 1.0, {"feedback": "ok"}
+
+    score, feedback = evaluator({}, "bad")
+
+    assert score == 0.0
+    assert "Format validation failed" in feedback["feedback"]
+    assert "cannot validate bad" in feedback["feedback"]
+    assert calls == []
+
+
+def test_require_format_forwards_when_validator_returns_true():
+    calls = []
+
+    @require_format(lambda response: response.endswith("done"))
+    def evaluator(data, response):
+        calls.append((data, response))
+        return 1.0, {"feedback": "ok"}
+
+    result = evaluator("example", "all done")
+
+    assert result == (1.0, {"feedback": "ok"})
+    assert calls == [("example", "all done")]
+
+
+def test_require_regex_match_validates_full_response():
+    calls = []
+
+    @require_regex_match(r"answer: \d+")
+    def evaluator(data, response):
+        calls.append((data, response))
+        return 1.0, {"feedback": "ok"}
+
+    assert evaluator({}, "answer: 42") == (1.0, {"feedback": "ok"})
+
+    score, feedback = evaluator({}, "prefix answer: 42")
+
+    assert score == 0.0
+    assert "Regex match failed" in feedback["feedback"]
+    assert "answer: \\d+" in feedback["feedback"]
+    assert calls == [({}, "answer: 42")]
+
+
+def test_format_validators_are_public_exports():
+    from gepa.utils import __all__
+
+    assert "require_json_output" in __all__
+    assert "require_format" in __all__
+    assert "require_regex_match" in __all__


### PR DESCRIPTION
## Summary
Evaluators had no reusable way to hard-fail malformed model output before scoring. Each evaluator re-implemented JSON parsing and format checks.

## Changes
Add `gepa.utils.format_validator` with three decorators: `require_json_output` (parse JSON, optional shallow schema check, pass parsed value through), `require_format` (arbitrary predicate), and `require_regex_match`. On failure the wrapped evaluator is skipped and a `(0.0, {feedback})` result is returned. Re-exported from `gepa.utils`.

## Testing
Added `tests/test_format_validator.py` covering success, malformed JSON, schema mismatch, and regex paths.

Fixes #265
