### PR TITLE
Review follow-ups for #369: child-eval events, recorded-run behavior pins, reflection_strategy seam, docs

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -75,6 +75,7 @@ jobs:
     name: Run Tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
@@ -150,6 +151,7 @@ jobs:
     name: Build Package
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:

--- a/docs/docs/guides/parallel-proposals.md
+++ b/docs/docs/guides/parallel-proposals.md
@@ -1,0 +1,113 @@
+# Parallel Proposals: Sampling & Selection Strategies
+
+GEPA's reflective mutation loop can generate and evaluate **multiple candidate
+proposals per iteration**. This is controlled by two small, composable
+strategy objects rather than a numeric knob:
+
+- a **sampling strategy** decides *which (parent, minibatch) proposal tasks*
+  are attempted this iteration, and
+- a **selection strategy** decides *which of the resulting improvements* enter
+  the candidate pool.
+
+The defaults (`SingleMutationSampling` + `AllImprovements`) reproduce classic
+GEPA behavior exactly: one parent, one mutation per iteration. Existing runs
+do not change.
+
+!!! note "Replaces `num_parallel_proposals`"
+    Versions v0.1.2/v0.1.3 briefly shipped an experimental integer knob,
+    `EngineConfig.num_parallel_proposals`. It is replaced by the strategies on
+    this page (see [RFC #329](https://github.com/gepa-ai/gepa/issues/329)).
+
+## Sampling strategies
+
+```python
+from gepa.strategies.proposal_sampling import (
+    SingleMutationSampling,  # default: 1 parent, 1 mutation
+    SameParentSampling,      # n mutations of the same parent
+    IndependentSampling,     # n independent (parent, minibatch) tasks
+    PxNSampling,             # p parents x n mutations each
+)
+```
+
+| Strategy | Per iteration | Use when |
+|---|---|---|
+| `SingleMutationSampling()` | 1 parent, 1 mutation | Default; classic GEPA |
+| `SameParentSampling(n=4)` | 1 parent, `n` mutations | Exploit a strong parent with diverse edits |
+| `IndependentSampling(n=4)` | `n` parents, 1 mutation each | Explore the frontier broadly |
+| `PxNSampling(p=2, n=2)` | `p` parents × `n` mutations | Balanced explore/exploit |
+
+## Selection strategies
+
+```python
+from gepa.strategies.proposal_selection import (
+    AllImprovements,   # default: every improving proposal joins the pool
+    BestImprovement,   # only the single best improvement joins
+    TopKImprovements,  # the k best improvements join
+)
+```
+
+## Using them
+
+Both `gepa.optimize()` and `optimize_anything` accept the strategies directly:
+
+```python
+import gepa
+from gepa.strategies.proposal_sampling import PxNSampling
+from gepa.strategies.proposal_selection import TopKImprovements
+
+result = gepa.optimize(
+    seed_candidate=seed,
+    trainset=trainset,
+    valset=valset,
+    task_lm="openai/gpt-4.1-mini",
+    reflection_lm="openai/gpt-5",
+    max_metric_calls=600,
+    sampling_strategy=PxNSampling(p=2, n=2),
+    selection_strategy=TopKImprovements(k=2),
+)
+```
+
+Acceptance is unchanged: every proposal is still evaluated on its minibatch
+and only improvements (per the configured `acceptance_criterion`) are
+considered by the selection strategy. The engine remains the single accept
+authority.
+
+## Where the parallelism actually runs: `batch_evaluate`
+
+Multi-proposal iterations batch their evaluations at the **adapter edge**. The
+engine and proposer stay sequential; adapters opt into true parallelism by
+implementing one optional method:
+
+```python
+class MyAdapter:
+    def evaluate(self, batch, candidate, capture_traces=False): ...
+
+    # Optional. When absent, GEPA calls evaluate() once per item.
+    def batch_evaluate(self, items: list[tuple[Candidate, list]]) -> list[EvaluationBatch]:
+        ...  # e.g. fan out across threads, processes, or an eval service
+```
+
+Third-party adapters that only implement `evaluate()` keep working unmodified
+(`default_batch_evaluate` is the sequential fallback). The reflection LM side
+is batched analogously: the built-in stateless reflector batches all
+per-component reflection calls via `litellm.batch_completion`.
+
+## Budget accounting and events
+
+Totals are identical to the sequential path, at finer event granularity: each
+iteration emits separate `on_budget_updated` events for the parent-evaluation
+and child-evaluation stages (plus one per accepted candidate's full-valset
+evaluation), and `metric_calls_used` remains monotonic with self-consistent
+deltas. If you aggregate budget events, sum `metric_calls_delta` rather than
+counting events.
+
+## Advanced: custom reflection strategies
+
+The reflection call itself is a seam (`ReflectionLM`,
+[RFC #329](https://github.com/gepa-ai/gepa/issues/329)): pass
+`reflection_strategy=` to `gepa.optimize()` to replace the stateless
+single-call reflector with a stateful or aggregating implementation (e.g.
+session-based reflection, or map-reduce aggregation over parallel reflections
+as in [ComBEE, PR #307](https://github.com/gepa-ai/gepa/pull/307)).
+Implementations provide `reflect()`; `reflect_many()` is optional and enables
+batched reflection.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
         - Candidate Selection Strategies: guides/candidate-selection.md
         - Acceptance Criterion: guides/acceptance-criterion.md
         - Batch Sampling: guides/batch-sampling.md
+        - Parallel Proposals: guides/parallel-proposals.md
         - Using Callbacks: guides/callbacks.md
         - Cost & Token Tracking: guides/cost-tracking.md
         - Experiment Tracking: guides/experiment-tracking.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,11 @@ dependencies = []
 [project.optional-dependencies]
 full = [
     # Common dependencies (all Python versions)
-    "litellm>=1.83.0",
+    # litellm 1.92.0 ships no cp314 wheels and its sdist fails to build on
+    # Python 3.14 (bundled pyo3 0.23.5 predates the 3.14 ABI); cap on 3.14
+    # until upstream publishes cp314 wheels.
+    "litellm>=1.83.0; python_version < '3.14'",
+    "litellm>=1.83.0,<1.92.0; python_version >= '3.14'",
     "tqdm>=4.66.1",
     "cloudpickle>=3.0.0",
     # Python < 3.14
@@ -41,7 +45,7 @@ full = [
 confidence = [
     "llm-structured-confidence>=0.4.5",
     "litellm>=1.64.0; python_version < '3.14'",
-    "litellm>=1.81.0; python_version >= '3.14'",
+    "litellm>=1.81.0,<1.92.0; python_version >= '3.14'",
 ]
 dspy = []
 test = [

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -23,6 +23,7 @@ from gepa.logging.experiment_tracker import create_experiment_tracker
 from gepa.logging.logger import Logger, LoggerProtocol, StdOutLogger
 from gepa.proposer.merge import MergeProposer
 from gepa.proposer.reflective_mutation.base import CandidateSelector, LanguageModel, ReflectionComponentSelector
+from gepa.proposer.reflective_mutation.reflection_lm import ReflectionLM
 from gepa.proposer.reflective_mutation.reflective_mutation import ReflectiveMutationProposer
 from gepa.strategies.acceptance import AcceptanceCriterion, ImprovementOrEqualAcceptance, StrictImprovementAcceptance
 from gepa.strategies.batch_sampler import BatchSampler, EpochShuffledBatchSampler
@@ -98,6 +99,7 @@ def optimize(
     # Proposal strategies (default: 1 parent, 1 mutation per iteration)
     sampling_strategy: SamplingStrategy | None = None,
     selection_strategy: SelectionStrategy | None = None,
+    reflection_strategy: ReflectionLM | None = None,
 ) -> GEPAResult[RolloutOutput, DataId]:
     """
     GEPA is an evolutionary optimizer that evolves (multiple) text components of a complex system to optimize them towards a given metric.
@@ -144,6 +146,9 @@ def optimize(
 
     # Reflection-based configuration
     - reflection_lm: A `LanguageModel` instance that is used to reflect on the performance of the candidate program.
+    - sampling_strategy: Controls how many (parent, minibatch) proposal tasks are sampled per iteration. One of `SingleMutationSampling` (default; 1 parent, 1 mutation — identical to classic GEPA), `SameParentSampling(n)`, `IndependentSampling(n)`, or `PxNSampling(p, n)`, or any custom `SamplingStrategy`.
+    - selection_strategy: Controls which of an iteration's improving proposals enter the candidate pool. One of `AllImprovements` (default), `BestImprovement`, or `TopKImprovements(k)`, or any custom `SelectionStrategy`.
+    - reflection_strategy: Advanced: a `ReflectionLM` implementation that owns how reflective mutation calls the reflection model (e.g. stateful sessions or aggregating reflectors). Defaults to the stateless single-call reflector built from `reflection_lm`. Implementations may provide `reflect_many` for batched reflection; otherwise `reflect` is called once per task.
     - candidate_selection_strategy: The strategy to use for selecting the candidate to update. Supported strategies: 'pareto', 'current_best', 'epsilon_greedy'. Defaults to 'pareto'.
     - frontier_type: Strategy for tracking Pareto frontiers. 'instance' tracks per validation example, 'objective' tracks per objective metric, 'hybrid' combines both, 'cartesian' tracks per (example, objective) pair. Defaults to 'instance'.
     - skip_perfect_score: Whether to skip updating the candidate if it achieves a perfect score on the minibatch.
@@ -395,6 +400,7 @@ def optimize(
         custom_candidate_proposer=custom_candidate_proposer,
         callbacks=callbacks,
         sampling_strategy=sampling_strategy,
+        reflection_strategy=reflection_strategy,
     )
 
     def evaluator_fn(

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -34,7 +34,7 @@ from gepa.proposer.reflective_mutation.base import (
     LanguageModel,
     ReflectionComponentSelector,
 )
-from gepa.proposer.reflective_mutation.reflection_lm import StatelessReflectionLM
+from gepa.proposer.reflective_mutation.reflection_lm import ReflectionLM, StatelessReflectionLM
 from gepa.strategies.batch_sampler import BatchSampler
 from gepa.strategies.instruction_proposal import InstructionProposalSignature
 from gepa.strategies.proposal_sampling import ProposalTask, SamplingStrategy, SingleMutationSampling
@@ -71,6 +71,7 @@ class ReflectiveMutationProposer:
         custom_candidate_proposer: ProposalFn | None = None,
         callbacks: list[GEPACallback] | None = None,
         sampling_strategy: SamplingStrategy | None = None,
+        reflection_strategy: ReflectionLM | None = None,
     ):
         self.logger = logger
         self.trainset = ensure_loader(trainset)
@@ -94,8 +95,12 @@ class ReflectiveMutationProposer:
         else:
             InstructionProposalSignature.validate_prompt_template(reflection_prompt_template)
 
-        # Reflection LM (#329 Phase 1); None when an adapter/custom proposer owns reflection.
-        self._reflection_lm: StatelessReflectionLM | None = (
+        # Reflection LM (#329 Phase 1); None when an adapter/custom proposer owns
+        # reflection. An injected reflection_strategy — any ReflectionLM
+        # implementation, e.g. session-based or ComBEE-style aggregating
+        # reflectors (#329 Phase 2/3) — takes precedence over the stateless
+        # default built from the raw reflection_lm callable.
+        self._reflection_lm: ReflectionLM | None = reflection_strategy or (
             StatelessReflectionLM(reflection_lm, reflection_prompt_template, logger)
             if reflection_lm is not None
             else None
@@ -139,10 +144,12 @@ class ReflectiveMutationProposer:
     ) -> list[tuple[dict[str, str], dict[str, str | list[dict[str, Any]]], dict[str, str]]]:
         """Propose new texts for many tasks, batching the reflection LM calls.
 
-        Only the built-in stateless reflection path can be batched (one
-        ``litellm.batch_completion`` covering every task/component). When an
-        adapter proposer or custom proposer owns the call, fall back to one
-        invocation per task — their batching, if any, is their concern.
+        ReflectionLM implementations that provide ``reflect_many`` (e.g. the
+        stateless default, which issues one ``litellm.batch_completion``
+        covering every task/component) are batched; implementations that only
+        provide ``reflect()`` are called once per task. When an adapter
+        proposer or custom proposer owns the call, fall back to one invocation
+        per task — their batching, if any, is their concern.
         """
         if (
             self.adapter.propose_new_texts is not None
@@ -151,7 +158,11 @@ class ReflectiveMutationProposer:
         ):
             return [self.propose_new_texts(cand, refds, comps) for cand, refds, comps in jobs]
 
-        results = self._reflection_lm.reflect_many(jobs)
+        reflect_many = getattr(self._reflection_lm, "reflect_many", None)
+        if reflect_many is not None:
+            results = reflect_many(jobs)
+        else:
+            results = [self._reflection_lm.reflect(cand, refds, comps) for cand, refds, comps in jobs]
         return [(proposal.new_texts, proposal.prompts, proposal.raw_lm_outputs) for proposal, _next_lm in results]
 
     def _propose_texts_batch_safe(

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -448,7 +448,45 @@ class ReflectiveMutationProposer:
             return []
 
         child_items = [(c[1], c[0].minibatch) for _, c in valid_children]
+
+        # Fire evaluation start callbacks for each child candidate (parity with
+        # the pre-batch sequential path, which emitted these around the new
+        # candidate's minibatch evaluation; candidate_idx is None because the
+        # child is not in the candidate pool yet)
+        for _, (task, _new_candidate, _eval_curr, _meta) in valid_children:
+            notify_callbacks(
+                self.callbacks,
+                "on_evaluation_start",
+                EvaluationStartEvent(
+                    iteration=i,
+                    candidate_idx=None,
+                    batch_size=len(task.minibatch),
+                    capture_traces=True,
+                    parent_ids=[task.parent_idx],
+                    inputs=task.minibatch,
+                    is_seed_candidate=False,
+                ),
+            )
+
         child_evals = self._batch_evaluate(child_items)
+
+        # Fire evaluation end callbacks for each child candidate
+        for (_, (task, _new_candidate, _eval_curr, _meta)), child_eval in zip(valid_children, child_evals, strict=True):
+            notify_callbacks(
+                self.callbacks,
+                "on_evaluation_end",
+                EvaluationEndEvent(
+                    iteration=i,
+                    candidate_idx=None,
+                    scores=child_eval.scores,
+                    has_trajectories=bool(child_eval.trajectories),
+                    parent_ids=[task.parent_idx],
+                    outputs=child_eval.outputs,
+                    trajectories=child_eval.trajectories,
+                    objective_scores=child_eval.objective_scores,
+                    is_seed_candidate=False,
+                ),
+            )
 
         total_child_evals = sum(
             e.num_metric_calls if e.num_metric_calls is not None else len(child_items[idx][1])

--- a/tests/test_parallel_proposals.py
+++ b/tests/test_parallel_proposals.py
@@ -3,9 +3,12 @@
 
 """Tests for batch-based parallel proposals."""
 
+from itertools import pairwise
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from conftest import create_mocked_lms_context
 
 from gepa.core.adapter import EvaluationBatch, default_batch_evaluate
 from gepa.core.state import GEPAState, ValsetEvaluation
@@ -185,13 +188,154 @@ class TestDefaultBatchEvaluate:
         assert adapter.evaluate.call_count == 2
 
 
+class _EventLog:
+    """Records every callback event GEPA emits, in order."""
+
+    def __init__(self):
+        self.events: list[tuple[str, dict]] = []
+
+    def __getattr__(self, name):
+        if name.startswith("on_"):
+
+            def _record(event, _name=name):
+                self.events.append((_name, dict(event)))
+
+            return _record
+        raise AttributeError(name)
+
+    def names(self) -> list[str]:
+        return [n for n, _ in self.events]
+
+    def of(self, name: str) -> list[dict]:
+        return [e for n, e in self.events if n == name]
+
+
+_AIME_CACHE_DIR = Path(__file__).parent / "test_aime_prompt_optimization"
+_AIME_SEED_PROMPT = (
+    "You are a helpful assistant. You are given a question and you need to answer it. "
+    "The answer should be given at the end of your response in exactly the format '### <final answer>'"
+)
+
+
+@pytest.fixture(scope="module")
+def aime_lms():
+    """Replay LMs backed by the recorded AIME run (fails on any unseen LM input)."""
+    yield from create_mocked_lms_context(_AIME_CACHE_DIR)
+
+
+def _run_recorded_optimization(aime_lms, sampling_strategy=None, selection_strategy=None):
+    import gepa
+    from gepa.adapters.default_adapter.default_adapter import DefaultAdapter
+
+    task_lm, reflection_lm = aime_lms
+    trainset, valset, _ = gepa.examples.aime.init_dataset()
+    log = _EventLog()
+    result = gepa.optimize(
+        seed_candidate={"system_prompt": _AIME_SEED_PROMPT},
+        trainset=trainset[:10],
+        valset=valset[:10],
+        adapter=DefaultAdapter(model=task_lm),
+        max_metric_calls=30,
+        reflection_lm=reflection_lm,
+        callbacks=[log],
+        display_progress_bar=False,
+        sampling_strategy=sampling_strategy,
+        selection_strategy=selection_strategy,
+    )
+    return result, log
+
+
+@pytest.fixture(scope="module")
+def default_run(aime_lms):
+    """The default path (sampling/selection strategies left unset)."""
+    return _run_recorded_optimization(aime_lms)
+
+
+@pytest.fixture(scope="module")
+def explicit_run(aime_lms):
+    """Same run with the documented defaults passed explicitly."""
+    return _run_recorded_optimization(
+        aime_lms,
+        sampling_strategy=SingleMutationSampling(),
+        selection_strategy=AllImprovements(),
+    )
+
+
 class TestDefaultStrategiesRetainBehavior:
-    """Verify that default strategies produce the expected behavior."""
+    """Pin the default path against a fully cached, pre-#369 GEPA run.
 
-    def test_single_mutation_is_default_sampling(self):
-        strategy = SingleMutationSampling()
-        assert hasattr(strategy, "sample_tasks")
+    The replay fixture hard-fails on any LM input that is not in the recorded
+    cache, so these tests only pass if the default
+    SingleMutationSampling + AllImprovements path reproduces the recorded run's
+    exact LM request stream. On top of that we pin the final result, the budget
+    ledger, and the callback-event stream.
+    """
 
-    def test_all_improvements_is_default_selection(self):
-        strategy = AllImprovements()
-        assert hasattr(strategy, "select")
+    def test_default_path_reproduces_recorded_run(self, default_run):
+        result, _ = default_run
+        golden = (_AIME_CACHE_DIR / "optimized_prompt.txt").read_text()
+        assert result.best_candidate["system_prompt"] == golden
+
+    def test_budget_ledger_is_consistent(self, default_run):
+        result, log = default_run
+        budget = log.of("on_budget_updated")
+        assert budget, "expected at least one on_budget_updated event"
+        assert all(e["metric_calls_delta"] > 0 for e in budget)
+        used = [e["metric_calls_used"] for e in budget]
+        assert used == sorted(used), "metric_calls_used must be monotonic"
+        # Every event's absolute counter must agree with the previous one plus
+        # its own delta (no unaccounted increments once the hook is live).
+        for prev, cur in pairwise(budget):
+            assert cur["metric_calls_used"] == prev["metric_calls_used"] + cur["metric_calls_delta"]
+        # The only increment that predates hook registration is the seed's
+        # full-valset evaluation (10 examples in the recorded run).
+        assert used[0] - budget[0]["metric_calls_delta"] == 10
+        assert used[-1] == result.total_metric_calls
+
+    def test_explicit_defaults_identical_to_implicit_defaults(self, default_run, explicit_run):
+        d_result, d_log = default_run
+        e_result, e_log = explicit_run
+        assert e_result.best_candidate == d_result.best_candidate
+        assert e_result.total_metric_calls == d_result.total_metric_calls
+        assert e_log.names() == d_log.names()
+
+    def test_proposal_event_ordering(self, default_run):
+        _, log = default_run
+        names = log.names()
+        for earlier, later in [
+            ("on_candidate_selected", "on_minibatch_sampled"),
+            ("on_minibatch_sampled", "on_reflective_dataset_built"),
+            ("on_reflective_dataset_built", "on_proposal_start"),
+            ("on_proposal_start", "on_proposal_end"),
+        ]:
+            assert earlier in names and later in names, f"missing {earlier}/{later}"
+            assert names.index(earlier) < names.index(later)
+
+    def test_budget_event_granularity_contract(self, default_run):
+        """Each completed proposal emits separate parent-eval and child-eval
+        budget events (finer granularity than pre-#369; totals unchanged), and
+        each *accepted* candidate's full-valset evaluation emits one more (the
+        seed's valset eval precedes budget-hook registration, so it produces an
+        on_valset_evaluated event but no budget event). Pin the composition so
+        any future change to budget-event granularity is made consciously."""
+        _, log = default_run
+        n_proposals = len(log.of("on_proposal_end"))
+        n_budget = len(log.of("on_budget_updated"))
+        n_accepted = len(log.of("on_candidate_accepted"))
+        assert n_budget == 2 * n_proposals + n_accepted, (
+            f"budget-event composition changed: {n_budget} events for "
+            f"{n_proposals} proposals + {n_accepted} accepted candidates"
+        )
+
+    def test_child_evaluation_events_are_emitted(self, default_run):
+        """Parity with the pre-#369 sequential path: every completed proposal
+        produces an evaluation start/end pair for the parent minibatch eval AND
+        one for the new candidate's minibatch eval (child pairs carry
+        candidate_idx=None because the child is not in the pool yet)."""
+        _, log = default_run
+        starts = log.of("on_evaluation_start")
+        ends = log.of("on_evaluation_end")
+        n_proposals = len(log.of("on_proposal_end"))
+        assert len(starts) == len(ends) == 2 * n_proposals
+        child_ends = [e for e in ends if e["candidate_idx"] is None]
+        assert len(child_ends) == n_proposals

--- a/tests/test_reflection_lm.py
+++ b/tests/test_reflection_lm.py
@@ -146,3 +146,69 @@ def test_per_component_template_dict_and_missing_warning():
     lm.reflect(candidate, reflective_dataset, ["a", "b"])
     missing_warnings = [m for m in logger.messages if "No reflection_prompt_template found for parameter 'b'" in m]
     assert len(missing_warnings) == 1
+
+
+# ---------------------------------------------------------------------------
+# reflection_strategy injection seam (#329 Phase 2 entry point)
+# ---------------------------------------------------------------------------
+
+
+class _ReflectOnlyLM:
+    """A ReflectionLM implementation that provides only reflect() — no reflect_many."""
+
+    def __init__(self):
+        self.calls: list[list[str]] = []
+
+    def reflect(self, candidate, reflective_dataset, components_to_update):
+        self.calls.append(list(components_to_update))
+        proposal = ReflectionProposal(new_texts={c: f"new_{c}" for c in components_to_update})
+        return proposal, self
+
+
+def _make_proposer(**overrides):
+    from unittest.mock import MagicMock
+
+    from gepa.proposer.reflective_mutation.reflective_mutation import ReflectiveMutationProposer
+
+    adapter = MagicMock()
+    adapter.propose_new_texts = None
+    kwargs = {
+        "logger": MagicMock(),
+        "trainset": [{"q": 1}, {"q": 2}],
+        "adapter": adapter,
+        "candidate_selector": MagicMock(),
+        "module_selector": MagicMock(),
+        "batch_sampler": MagicMock(),
+        "perfect_score": None,
+        "skip_perfect_score": False,
+        "experiment_tracker": MagicMock(),
+        "reflection_lm": None,
+        "custom_candidate_proposer": None,
+    }
+    kwargs.update(overrides)
+    return ReflectiveMutationProposer(**kwargs)
+
+
+def test_injected_reflection_strategy_takes_precedence_over_stateless_default():
+    stub = _ReflectOnlyLM()
+    proposer = _make_proposer(reflection_strategy=stub, reflection_lm=RecordingLM())
+    assert proposer._reflection_lm is stub
+
+
+def test_without_injection_stateless_default_is_built():
+    proposer = _make_proposer(reflection_lm=RecordingLM())
+    assert isinstance(proposer._reflection_lm, StatelessReflectionLM)
+
+
+def test_reflect_only_strategy_used_per_task_in_batch_path():
+    """A ReflectionLM without reflect_many must be called once per job by
+    _propose_texts_batch (the seam a ComBEE-style reflector plugs into)."""
+    stub = _ReflectOnlyLM()
+    proposer = _make_proposer(reflection_strategy=stub)
+    jobs = [
+        ({"c": "old1"}, {"c": [{"feedback": "f1"}]}, ["c"]),
+        ({"c": "old2"}, {"c": [{"feedback": "f2"}]}, ["c"]),
+    ]
+    results = proposer._propose_texts_batch(jobs)
+    assert stub.calls == [["c"], ["c"]]
+    assert [r[0] for r in results] == [{"c": "new_c"}, {"c": "new_c"}]


### PR DESCRIPTION
Stacked on #369 (base: `feat/reflection-lm-protocol-phase1`). Three focused commits addressing review findings:

## 1. `fix`: restore `on_evaluation_start`/`on_evaluation_end` for child candidate evals
The batch `propose()` pipeline emitted evaluation events only around the **parent** minibatch evaluation; the pre-batch sequential path on `main` emits them at both the parent and the child (new candidate) sites. This restores the child-side events with the same payload shape as `main` (`candidate_idx=None`, `parent_ids=[parent_idx]`) — same family as the `on_evaluation_skipped` regression already fixed in `f8b7f56e`.

Also replaces the `hasattr`-only `TestDefaultStrategiesRetainBehavior` with real behavior pins against the recorded AIME replay run (`tests/test_aime_prompt_optimization/`). Because the replay fixture hard-fails on any unseen LM input, a passing run proves the default `SingleMutationSampling`+`AllImprovements` path reproduces the recorded (pre-#369) run's exact LM request stream. New pins:
- default path reproduces the golden optimized prompt
- budget-ledger consistency: monotonic, self-consistent deltas; only the seed valset eval precedes budget-hook registration; final == `result.total_metric_calls`
- explicit default strategies are event-for-event identical to implicit defaults
- proposal event ordering
- pinned budget-event composition (2 per completed proposal + 1 per accepted candidate) and child-evaluation event parity — so any future change to event granularity is made consciously

**On budget-event granularity:** iterations now emit separate parent-eval and child-eval `on_budget_updated` events instead of one combined event. Totals are unchanged (verified by the pins above); no in-repo consumer counts events (trackers don't subscribe; stoppers/progress read `state.total_num_evals` directly); and per-stage deltas are required once sampling strategies produce n>1 proposals. Documented in the new guide rather than reverted.

## 2. `feat`: `reflection_strategy` injection seam
Adds `reflection_strategy: ReflectionLM | None` to `ReflectiveMutationProposer` and `gepa.optimize()`: any `ReflectionLM` implementation can own how reflective mutation calls the reflection model, taking precedence over the stateless default. Implementations providing only `reflect()` are called per task in the batch path (`getattr` fallback, same pattern as `adapter.batch_evaluate`); `reflect_many` remains the batching fast path.

This is the #329 Phase 2 entry point: session-based reflectors, coding-agent reflectors, and aggregating reflectors — **specifically ComBEE (#307), which maps onto this seam as a single `ComBEEReflectionLM` with internal map/reduce fan-out** — plug in without touching the proposer pipeline.

## 3. `docs`: parallel-proposals guide
New `docs/guides/parallel-proposals.md` covering the sampling/selection strategies (the surface replacing `num_parallel_proposals`), the optional `adapter.batch_evaluate` seam and its sequential fallback, budget-event granularity, and the `reflection_strategy` seam. Registered in mkdocs nav.

## Test plan
- [x] `tests/test_aime_prompt_optimization` replay passes on this branch (empirical behavior-identity check)
- [x] 358 tests pass locally (optional-dependency suites excluded, covered by CI)
- [x] ruff clean on all changed files (remaining findings pre-exist on the base branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)