### PR TITLE
docs: add LanceDB handwritten-OCR blog to use-cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ Finally:
     - [comet-ml/opik adds support for GEPA](https://www.comet.com/docs/opik/agent_optimization/algorithms/gepa_optimizer)
     - [Tuning small models (Gemma3-1B) for writing fiction](https://meandnotes.substack.com/p/i-taught-a-small-llm-to-write-fiction?triedRedirect=true)
     - [Cut OCR Error Rates by upto 38% across model classes (Gemini 2.5 Pro, 2.5 Flash, 2.0 Flash)](https://www.intrinsic-labs.ai/research/ocr-gepa-v1.pdf)
+    - [LanceDB: Handwritten Medical-Notes OCR Pipeline with DSPy + GEPA — normalized OCR match 54.1% → 59.4%, avg edit distance 1.01 → 0.87 on Gemini 3.1 Flash Lite, ~15 min run on a laptop](https://www.lancedb.com/blog/make-handwritten-notes-searchable-optimizing-an-ocr-pipeline-with-lancedb)
     - [Optimizing a Data Analysis coding agent with GEPA, using execution-guided feedback on real-world workloads](https://medium.com/firebird-technologies/context-engineering-improving-ai-coding-agents-using-dspy-gepa-df669c632766)
     - [Generating Naruto (Anime) style dialogues with GPT-4o-mini using GEPA](https://zenn.dev/cybernetics/articles/39fb763aca746c)
     - [Augmenting RL-tuned models with GEPA: Achieving +142% student performance improvement by augmenting a RL-tuned teacher with GEPA](https://www.arc.computer/blog/supercharging-rl-with-online-optimization)

--- a/docs/docs/guides/use-cases.md
+++ b/docs/docs/guides/use-cases.md
@@ -378,6 +378,20 @@ Discover how organizations and researchers are using GEPA to optimize AI systems
 
     [:material-arrow-right: Resources page](https://www.intrinsic-labs.ai/resources/prompt-optimized-ocr-for-production)
 
+-   **LanceDB: Handwritten Medical-Notes OCR Pipeline**
+
+    ---
+
+    Prashanth Rao (LanceDB) uses **DSPy + GEPA** to optimize the prompt for a handwritten-medicine-name OCR reader on top of `gemini-3.1-flash-lite`, keeping the same low-cost student model and using `gemini-3.1-pro-preview` as the reflection LM. A ~15-minute optimization run on a laptop lifts held-out results on 780 test images:
+
+    - **Normalized OCR match:** 54.1% → **59.4%**
+    - **Average edit distance:** 1.01 → **0.87**
+    - No fine-tuning, no bigger model — the discovered instruction alone (trailing-letters, casing, punctuation, pharmacological tie-breakers) drives the lift.
+
+    The post also walks through metric design pitfalls specific to GEPA (why edit distance shouldn't dominate the objective and how validation-set sizing trades off against exploration budget).
+
+    [:material-arrow-right: Read the blog post](https://www.lancedb.com/blog/make-handwritten-notes-searchable-optimizing-an-ocr-pipeline-with-lancedb)
+
 -   **Market Research AI Personas**
 
     ---


### PR DESCRIPTION
## Summary

Adds Prashanth Rao's [LanceDB blog post](https://www.lancedb.com/blog/make-handwritten-notes-searchable-optimizing-an-ocr-pipeline-with-lancedb) — an OCR pipeline for handwritten medical notes optimized with DSPy + GEPA — to `docs/docs/guides/use-cases.md` and `README.md`.

Concrete numbers reported by the author (held-out test split, 780 images):

- **Normalized OCR match:** 54.1% → **59.4%**
- **Average edit distance:** 1.01 → **0.87**
- Student model unchanged (`gemini-3.1-flash-lite`); reflection LM is `gemini-3.1-pro-preview`; ~15-minute run on a laptop.

Placement:

- `docs/docs/guides/use-cases.md` — new card under **Domain-Specific Applications**, immediately after the Intrinsic Labs OCR entry (same subdomain).
- `README.md` — one-liner in the "GEPA uses" list, directly after the Intrinsic Labs OCR line.

Tone check: the post frames GEPA positively — "prompt optimization is a great lever" — and includes an honest ceiling caveat about prompts-alone on very hard OCR (engineering nuance, not criticism). It also credits GEPA-specific metric-design considerations (why edit distance shouldn't dominate the objective; validation-set sizing trades off against exploration budget).

## Test plan

- [ ] Verify the new card renders in the mkdocs site under `guides/use-cases.md` → **Domain-Specific Applications**.
- [ ] Verify the README bullet renders on GitHub with the correct arrow character (`→`).
- [ ] Confirm the blog URL is reachable.