### PR TITLE
feat: add configurable multi-step Best-of-N evolution

### DIFF
--- a/src/gepa/adapters/dspy_adapter/dspy_adapter.py
+++ b/src/gepa/adapters/dspy_adapter/dspy_adapter.py
@@ -19,6 +19,10 @@ from dspy.teleprompt.bootstrap_trace import FailedPrediction, TraceData
 
 from gepa import EvaluationBatch, GEPAAdapter
 from gepa.core.adapter import ProposalFn
+from gepa.proposer.reflective_mutation.reflection_lm import (
+    build_textual_gradient_selection_prompt,
+    extract_best_textual_gradient_index,
+)
 from gepa.strategies.instruction_proposal import InstructionProposalSignature
 
 logger = logging.getLogger(__name__)
@@ -101,6 +105,8 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
         warn_on_score_mismatch: bool = True,
         enable_tool_optimization: bool = False,
         reflection_minibatch_size: int | None = None,
+        best_of_n: int = 1,
+        num_iterations: int = 1,
     ):
         self.student = student_module
         self.metric_fn = metric_fn
@@ -114,6 +120,15 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
         self.warn_on_score_mismatch = warn_on_score_mismatch
         self.enable_tool_optimization = enable_tool_optimization
         self.reflection_minibatch_size = reflection_minibatch_size
+        self.configure_textual_gradient_search(best_of_n=best_of_n, num_iterations=num_iterations)
+
+    def configure_textual_gradient_search(self, *, best_of_n: int = 1, num_iterations: int = 1) -> None:
+        if best_of_n < 1:
+            raise ValueError("best_of_n must be >= 1.")
+        if num_iterations < 1:
+            raise ValueError("num_iterations must be >= 1.")
+        self.best_of_n = best_of_n
+        self.num_iterations = num_iterations
 
     def propose_new_texts(
         self,
@@ -146,33 +161,145 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
         results: dict[str, str] = {}
 
         with dspy.context(lm=reflection_lm):
-            # Handle regular instruction components
             if instruction_components:
                 for name in instruction_components:
+                    if name not in candidate or name not in reflective_dataset:
+                        continue
                     base_instruction = candidate[name]
                     dataset_with_feedback = reflective_dataset[name]
-                    results[name] = InstructionProposalSignature.run(
-                        lm=(lambda x: self.stripped_lm_call(x)[0]),
-                        input_dict={
-                            "current_instruction_doc": base_instruction,
-                            "dataset_with_feedback": dataset_with_feedback,
-                        },
-                    )["new_instruction"]
+                    results[name] = self._run_instruction_iterations(
+                        name=name,
+                        base_instruction=base_instruction,
+                        dataset_with_feedback=dataset_with_feedback,
+                        reflection_lm=reflection_lm,
+                    )
 
-            # Handle ReAct modules
             if tool_components:
                 from gepa.adapters.dspy_adapter.instruction_proposal import ToolProposer
 
                 tool_proposer = ToolProposer()
-                results.update(
-                    tool_proposer(
-                        candidate=candidate,
-                        reflective_dataset=reflective_dataset,
-                        components_to_update=tool_components,
+                for module_key in tool_components:
+                    if module_key not in candidate or module_key not in reflective_dataset:
+                        continue
+                    current_config = candidate[module_key]
+                    dataset_for_module = reflective_dataset[module_key]
+                    results[module_key] = self._run_tool_iterations(
+                        module_key=module_key,
+                        base_config=current_config,
+                        dataset_for_module=dataset_for_module,
+                        tool_proposer=tool_proposer,
+                        reflection_lm=reflection_lm,
                     )
-                )
 
         return results
+
+    def _run_instruction_iterations(
+        self,
+        name: str,
+        base_instruction: str,
+        dataset_with_feedback: list[ReflectiveExample],
+        reflection_lm,
+    ) -> str:
+        instruction = base_instruction
+        for _ in range(self.num_iterations):
+            proposals = [
+                InstructionProposalSignature.run(
+                    lm=(lambda x: self._call_reflection_model(reflection_lm, x)),
+                    input_dict={
+                        "current_instruction_doc": instruction,
+                        "dataset_with_feedback": dataset_with_feedback,
+                    },
+                )["new_instruction"]
+                for _ in range(self.best_of_n)
+            ]
+            instruction = self._select_best_candidate(
+                component_name=name,
+                component_type="instruction",
+                previous_text=instruction,
+                dataset_with_feedback=dataset_with_feedback,
+                proposals=proposals,
+                reflection_lm=reflection_lm,
+            )
+        return instruction
+
+    def _run_tool_iterations(
+        self,
+        module_key: str,
+        base_config: str,
+        dataset_for_module: list[ReflectiveExample],
+        tool_proposer,
+        reflection_lm,
+    ) -> str:
+        config = base_config
+        for _ in range(self.num_iterations):
+            proposals = [
+                tool_proposer(
+                    candidate={module_key: config},
+                    reflective_dataset={module_key: dataset_for_module},
+                    components_to_update=[module_key],
+                ).get(module_key, config)
+                for _ in range(self.best_of_n)
+            ]
+            config = self._select_best_candidate(
+                component_name=module_key,
+                component_type="tool configuration",
+                previous_text=config,
+                dataset_with_feedback=dataset_for_module,
+                proposals=proposals,
+                reflection_lm=reflection_lm,
+            )
+        return config
+
+    def _select_best_candidate(
+        self,
+        component_name: str,
+        component_type: str,
+        previous_text: str,
+        dataset_with_feedback: list[ReflectiveExample],
+        proposals: list[str],
+        reflection_lm,
+    ) -> str:
+        proposals = [proposal for proposal in proposals if proposal is not None]
+        if not proposals:
+            return previous_text
+        if len(proposals) == 1 or self.best_of_n == 1:
+            return proposals[0]
+        if reflection_lm is None:
+            logger.warning(
+                "best_of_n>1 requested for component '%s', but no reflection_lm is available. "
+                "Falling back to the first candidate.",
+                component_name,
+            )
+            return proposals[0]
+
+        prompt = build_textual_gradient_selection_prompt(
+            component_name=component_name,
+            component_type=component_type,
+            previous_text=previous_text,
+            dataset_with_feedback=dataset_with_feedback,
+            proposals=proposals,
+        )
+        try:
+            response_text = self._call_reflection_model(reflection_lm, prompt)
+            best_index = extract_best_textual_gradient_index(response_text, len(proposals))
+        except Exception as exc:
+            logger.warning(
+                "Failed to pick best candidate for %s due to %s. Defaulting to the first proposal.",
+                component_name,
+                exc,
+            )
+            best_index = 1
+        return proposals[best_index - 1]
+
+    @staticmethod
+    def _call_reflection_model(reflection_lm, prompt: str | list[dict[str, Any]]) -> str:
+        raw_outputs = reflection_lm(prompt)
+        if isinstance(raw_outputs, str):
+            return raw_outputs
+        first = raw_outputs[0] if raw_outputs else ""
+        if isinstance(first, dict):
+            return first.get("text") or first.get("content") or json.dumps(first)
+        return str(first)
 
     def build_program(self, candidate: dict[str, str]):
         new_prog = self.student.deepcopy()
@@ -477,6 +604,8 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
     # Even when it returns a dict with e.g., "text" and "reasoning" fields
     def stripped_lm_call(self, x: str) -> list[str]:
         raw_outputs = self.reflection_lm(x)
+        if isinstance(raw_outputs, str):
+            raw_outputs = [raw_outputs]
         outputs = []
         for raw_output in raw_outputs:
             if type(raw_output) == str:

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -62,6 +62,8 @@ def optimize(
     perfect_score: float = 1.0,
     reflection_prompt_template: str | dict[str, str] | None = None,
     custom_candidate_proposer: ProposalFn | None = None,
+    bon: int = 1,
+    itr: int = 1,
     # Component selection configuration
     module_selector: ReflectionComponentSelector | str = "round_robin",
     # Merge-based configuration
@@ -157,6 +159,8 @@ def optimize(
     - perfect_score: The perfect score to achieve.
     - reflection_prompt_template: The prompt template to use for reflection. Can be either a string (applied to all components) or a dict mapping component names to their specific templates. If not provided, GEPA will use the default prompt template (see [InstructionProposalSignature](src/gepa/strategies/instruction_proposal.py)). Each prompt template must contain the following placeholders, which will be replaced with actual values: `<curr_param>` (will be replaced by the instructions/component to evolve) and `<side_info>` (replaced with the inputs, outputs, and feedback generated with current instruction). When using a dict, components without a specified template will use the default template. This will be ignored if the adapter provides its own `propose_new_texts` method.
     - custom_candidate_proposer: Optional custom function for proposing new candidates. If provided, this will be used instead of the default LLM-based reflection approach. Cannot be used if adapter provides `propose_new_texts`. Signature: `(candidate, reflective_dataset, components_to_update) -> dict[str, str]`.
+    - bon: Best-of-N textual evolution count per reflected component. GEPA samples `bon` candidate text updates and asks the reflection LM to select the best one before returning or continuing to the next inner evolution step. Defaults to 1.
+    - itr: Number of sequential textual evolution steps to run inside one reflective mutation proposal. When greater than 1, the selected update from one step becomes the current text for the next step. Defaults to 1.
 
     # Component selection configuration
     - module_selector: Component selection strategy. Can be a ReflectionComponentSelector instance or a string ('round_robin', 'all'). Defaults to 'round_robin'. The 'round_robin' strategy cycles through components in order. The 'all' strategy selects all components for modification in every GEPA iteration.
@@ -198,6 +202,10 @@ def optimize(
     # Validate seed_candidate is not None or empty
     if seed_candidate is None or not seed_candidate:
         raise ValueError("seed_candidate must contain at least one component text.")
+    if bon < 1:
+        raise ValueError("bon must be >= 1.")
+    if itr < 1:
+        raise ValueError("itr must be >= 1.")
 
     active_adapter: GEPAAdapter[DataInst, Trajectory, RolloutOutput] | None = None
     if adapter is None:
@@ -228,6 +236,17 @@ def optimize(
             "Please use only one custom proposal method."
         )
 
+    if (bon != 1 or itr != 1) and (adapter_has_propose or custom_candidate_proposer is not None):
+        adapter_configurator = getattr(active_adapter, "configure_textual_gradient_search", None)
+        if adapter_has_propose and callable(adapter_configurator):
+            adapter_configurator(best_of_n=bon, num_iterations=itr)
+        else:
+            owner = "adapter.propose_new_texts" if adapter_has_propose else "custom_candidate_proposer"
+            raise ValueError(
+                f"bon/itr cannot be applied because {owner} owns proposal generation. "
+                "Use the default reflection_lm path or implement configure_textual_gradient_search on the adapter."
+            )
+
     if not adapter_has_propose and custom_candidate_proposer is None:
         assert reflection_lm is not None or reflection_strategy is not None, (
             f"reflection_lm was not provided. The adapter used '{active_adapter!s}' does not provide a propose_new_texts method, "
@@ -245,7 +264,9 @@ def optimize(
     elif reflection_lm is not None:
         from gepa.lm import TrackingLM
 
-        reflection_lm_callable = TrackingLM(reflection_lm) if not hasattr(reflection_lm, "total_cost") else reflection_lm
+        reflection_lm_callable = (
+            TrackingLM(reflection_lm) if not hasattr(reflection_lm, "total_cost") else reflection_lm
+        )
     else:
         reflection_lm_callable = None
 
@@ -413,6 +434,8 @@ def optimize(
         callbacks=callbacks,
         sampling_strategy=sampling_strategy,
         reflection_strategy=reflection_strategy,
+        best_of_n=bon,
+        num_iterations=itr,
     )
 
     def evaluator_fn(

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -476,15 +476,15 @@ class EngineConfig:
 
     # Strategy selection for the engine
     val_evaluation_policy: EvaluationPolicy | Literal["full_eval"] = "full_eval"
-    candidate_selection_strategy: CandidateSelector | Literal[
-        "pareto", "current_best", "epsilon_greedy", "top_k_pareto"
-    ] = "pareto"
+    candidate_selection_strategy: (
+        CandidateSelector | Literal["pareto", "current_best", "epsilon_greedy", "top_k_pareto"]
+    ) = "pareto"
     frontier_type: FrontierType = "hybrid"
 
     # Acceptance criterion for reflective mutation proposals
-    acceptance_criterion: AcceptanceCriterion | Literal[
-        "strict_improvement", "improvement_or_equal"
-    ] = "strict_improvement"
+    acceptance_criterion: AcceptanceCriterion | Literal["strict_improvement", "improvement_or_equal"] = (
+        "strict_improvement"
+    )
 
     # Parallelization settings for evaluation
     parallel: bool = True
@@ -607,8 +607,8 @@ Based on your analysis, propose an improved version that:
     sections.append("""
 ## Output Format
 
-Provide ONLY the improved version within ``` blocks. The output must be a complete, 
-drop-in replacement for the current component (whether it's a prompt, configuration, 
+Provide ONLY the improved version within ``` blocks. The output must be a complete,
+drop-in replacement for the current component (whether it's a prompt, configuration,
 code, or any other parameter type).
 Do not include explanations, commentary, or markdown outside the ``` blocks.""")
 
@@ -641,9 +641,7 @@ def _build_seed_generation_prompt(
         examples = dataset[:3]
         example_lines = [f"- Example {i}: {ex}" for i, ex in enumerate(examples, 1)]
         sections.append(
-            "\n## Sample Inputs\n\n"
-            "The candidate will be evaluated on inputs like these:\n\n"
-            + "\n".join(example_lines)
+            "\n## Sample Inputs\n\nThe candidate will be evaluated on inputs like these:\n\n" + "\n".join(example_lines)
         )
 
     sections.append(
@@ -727,6 +725,11 @@ class ReflectionConfig:
     targeted improvements on that subset.  Over iterations, all examples get
     attention, and the Pareto frontier preserves specialized gains across
     iterations rather than averaging them away.
+
+    ``bon`` and ``itr`` control inner textual-gradient search. ``bon`` samples
+    multiple candidate evolutions per component and asks the reflection LM to
+    pick the best; ``itr`` repeats that evolution step sequentially before the
+    candidate is evaluated.
     """
 
     skip_perfect_score: bool = False
@@ -747,6 +750,8 @@ class ReflectionConfig:
     Ignored when ``reflection_lm`` is already a callable."""
     reflection_prompt_template: str | dict[str, str] | None = optimize_anything_reflection_prompt_template
     custom_candidate_proposer: ProposalFn | None = None
+    bon: int = 1
+    itr: int = 1
 
 
 @dataclass
@@ -1631,6 +1636,8 @@ def optimize_anything(
         callbacks=config.callbacks,
         sampling_strategy=config.engine.sampling_strategy,
         reflection_strategy=config.reflection.reflection_strategy,
+        best_of_n=config.reflection.bon,
+        num_iterations=config.reflection.itr,
     )
 
     # Define evaluator function for merge proposer

--- a/src/gepa/proposer/reflective_mutation/reflection_lm.py
+++ b/src/gepa/proposer/reflective_mutation/reflection_lm.py
@@ -12,6 +12,8 @@ become additional implementations in later phases.
 
 from __future__ import annotations
 
+import json
+import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
@@ -43,6 +45,64 @@ class ReflectionProposal:
     # reaches on_proposal_end consumers, experiment trackers, and the run
     # manifest without a future protocol break.
     metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class _TextualGradientDraft:
+    text: str
+    prompt: str | list[dict[str, Any]]
+    raw_output: str
+
+
+def format_reflective_examples_for_textual_gradient_prompt(
+    dataset_with_feedback: Sequence[Mapping[str, Any]],
+) -> str:
+    """Render reflective feedback records for a text-only ranking prompt."""
+    parts = []
+    for idx, example in enumerate(dataset_with_feedback, start=1):
+        parts.append(f"Example {idx}:\n{json.dumps(example, indent=2, default=str)}")
+    return "\n".join(parts) or "(no feedback records)"
+
+
+def build_textual_gradient_selection_prompt(
+    *,
+    component_name: str,
+    component_type: str,
+    previous_text: str,
+    dataset_with_feedback: Sequence[Mapping[str, Any]],
+    proposals: Sequence[str],
+) -> str:
+    dataset_text = format_reflective_examples_for_textual_gradient_prompt(dataset_with_feedback)
+    candidate_block = "\n\n".join(f"Candidate {idx + 1}:\n{proposal.strip()}" for idx, proposal in enumerate(proposals))
+    return (
+        f"You are ranking candidate {component_type} updates for the GEPA component '{component_name}'.\n"
+        "Consider the current version, the execution feedback, and each candidate update. "
+        "Select the option that best addresses the feedback while preserving useful behavior.\n\n"
+        f"Current {component_type}:\n{previous_text}\n\n"
+        f"Feedback from recent executions:\n{dataset_text}\n\n"
+        f"Candidates:\n{candidate_block}\n\n"
+        "Reply on the first two lines using the template:\n"
+        "BEST_INDEX: <number>\n"
+        "REASON: <short explanation>\n"
+        "Do not include any other structured text before these lines."
+    )
+
+
+def extract_best_textual_gradient_index(response_text: str, max_index: int) -> int:
+    """Parse a 1-indexed BEST_INDEX response."""
+    match = re.search(r"best_index\s*[:=]\s*(\d+)", response_text, flags=re.IGNORECASE)
+    if match:
+        idx = int(match.group(1))
+        if 1 <= idx <= max_index:
+            return idx
+
+    fallback_numbers = re.findall(r"\d+", response_text)
+    for number in fallback_numbers:
+        idx = int(number)
+        if 1 <= idx <= max_index:
+            return idx
+
+    raise ValueError(f"Could not parse BEST_INDEX from response: {response_text!r}")
 
 
 @runtime_checkable
@@ -80,7 +140,13 @@ class BatchReflectionLM(ReflectionLM, Protocol):
 
 
 class StatelessReflectionLM:
-    """Default reflection LM: one stateless LM call per component (or one batched call covering all tasks/components when the underlying LM provides ``batch_complete``).
+    """Default reflection LM.
+
+    The default path makes one stateless LM call per component, or one batched
+    call covering all tasks/components when the underlying LM provides
+    ``batch_complete``. ``best_of_n`` samples several textual evolutions and
+    uses the reflection LM to rank them. ``num_iterations`` applies that
+    evolution loop repeatedly before returning the final text.
 
     For each component with feedback, render the instruction-proposal prompt
     (honoring a global or per-component template) and parse the new instruction.
@@ -92,10 +158,18 @@ class StatelessReflectionLM:
         lm: LanguageModel,
         reflection_prompt_template: str | dict[str, str] | None = None,
         logger: Any | None = None,
+        best_of_n: int = 1,
+        num_iterations: int = 1,
     ):
+        if best_of_n < 1:
+            raise ValueError("best_of_n must be >= 1.")
+        if num_iterations < 1:
+            raise ValueError("num_iterations must be >= 1.")
         self.lm = lm
         self.reflection_prompt_template = reflection_prompt_template
         self.logger = logger
+        self.best_of_n = best_of_n
+        self.num_iterations = num_iterations
         # Components already warned about a missing per-component template (warn once).
         self._missing_template_warnings: set[str] = set()
 
@@ -152,27 +226,108 @@ class StatelessReflectionLM:
         return self.reflect_many([(candidate, reflective_dataset, components_to_update)])[0]
 
     def reflect_many(self, jobs: list[ReflectionJob]) -> list[tuple[ReflectionProposal, StatelessReflectionLM]]:
-        # Flatten every (job, component) with feedback into one list of rendered
-        # prompts, issue them as a single batched completion, then scatter the
-        # parsed results back into one ReflectionProposal per job.
-        rendered: list[tuple[int, str, Any, list[dict[str, Any]]]] = []
-        for job_idx, (candidate, reflective_dataset, components_to_update) in enumerate(jobs):
-            for name in components_to_update:
-                # Gracefully handle a selected component with no data in the reflective dataset.
-                if name not in reflective_dataset or not reflective_dataset.get(name):
-                    self._log(f"Component '{name}' is not in reflective dataset. Skipping.")
-                    continue
-                prompt, messages = self._render(candidate[name], reflective_dataset[name], self._resolve_template(name))
-                rendered.append((job_idx, name, prompt, messages))
-
-        raw_outputs = self._batch_complete([r[2] for r in rendered], [r[3] for r in rendered])
-
+        # Each textual-gradient iteration depends on the text selected by the
+        # previous iteration, so iterations are sequential. Within one iteration,
+        # all jobs, components, and Best-of-N samples are still batched together.
         proposals = [ReflectionProposal(new_texts={}, prompts={}, raw_lm_outputs={}) for _ in jobs]
-        for (job_idx, name, prompt, _messages), raw_output in zip(rendered, raw_outputs, strict=True):
-            new_instruction = InstructionProposalSignature.output_extractor(raw_output.strip())["new_instruction"]
-            proposals[job_idx].new_texts[name] = new_instruction
-            proposals[job_idx].prompts[name] = prompt
-            proposals[job_idx].raw_lm_outputs[name] = raw_output
+        current_candidates = [dict(candidate) for candidate, _reflective_dataset, _components in jobs]
+
+        for iteration_idx in range(self.num_iterations):
+            rendered: list[tuple[int, str, str | list[dict[str, Any]], list[dict[str, Any]]]] = []
+            for job_idx, (_candidate, reflective_dataset, components_to_update) in enumerate(jobs):
+                for name in components_to_update:
+                    # Gracefully handle a selected component with no data in the reflective dataset.
+                    if name not in reflective_dataset or not reflective_dataset.get(name):
+                        if iteration_idx == 0:
+                            self._log(f"Component '{name}' is not in reflective dataset. Skipping.")
+                        continue
+                    prompt, messages = self._render(
+                        current_candidates[job_idx][name],
+                        reflective_dataset[name],
+                        self._resolve_template(name),
+                    )
+                    for _sample_idx in range(self.best_of_n):
+                        rendered.append((job_idx, name, prompt, messages))
+
+            raw_outputs = self._batch_complete([r[2] for r in rendered], [r[3] for r in rendered])
+
+            drafts_by_component: dict[tuple[int, str], list[_TextualGradientDraft]] = {}
+            for (job_idx, name, prompt, _messages), raw_output in zip(rendered, raw_outputs, strict=True):
+                new_instruction = InstructionProposalSignature.output_extractor(raw_output.strip())["new_instruction"]
+                drafts_by_component.setdefault((job_idx, name), []).append(
+                    _TextualGradientDraft(text=new_instruction, prompt=prompt, raw_output=raw_output)
+                )
+
+            selected: dict[
+                tuple[int, str],
+                tuple[int, list[_TextualGradientDraft], _TextualGradientDraft, str | None, str | None],
+            ] = {}
+            selection_requests: list[tuple[int, str, str, list[dict[str, str]], list[_TextualGradientDraft]]] = []
+            for (job_idx, name), drafts in drafts_by_component.items():
+                if len(drafts) == 1 or self.best_of_n == 1:
+                    selected[(job_idx, name)] = (1, drafts, drafts[0], None, None)
+                    continue
+
+                _candidate, reflective_dataset, _components_to_update = jobs[job_idx]
+                selection_prompt = build_textual_gradient_selection_prompt(
+                    component_name=name,
+                    component_type="instruction",
+                    previous_text=current_candidates[job_idx][name],
+                    dataset_with_feedback=reflective_dataset[name],
+                    proposals=[draft.text for draft in drafts],
+                )
+                selection_requests.append(
+                    (job_idx, name, selection_prompt, [{"role": "user", "content": selection_prompt}], drafts)
+                )
+
+            selection_outputs = self._batch_complete(
+                [request[2] for request in selection_requests],
+                [request[3] for request in selection_requests],
+            )
+            for (job_idx, name, selection_prompt, _messages, drafts), selection_raw_output in zip(
+                selection_requests, selection_outputs, strict=True
+            ):
+                try:
+                    selected_index = extract_best_textual_gradient_index(selection_raw_output, len(drafts))
+                except Exception as exc:
+                    self._log(
+                        f"Failed to pick best candidate for {name} due to {exc}. Defaulting to the first proposal."
+                    )
+                    selected_index = 1
+                selected[(job_idx, name)] = (
+                    selected_index,
+                    drafts,
+                    drafts[selected_index - 1],
+                    selection_prompt,
+                    selection_raw_output,
+                )
+
+            for (job_idx, name), (
+                selected_index,
+                drafts,
+                selected_draft,
+                selection_prompt,
+                selection_raw_output,
+            ) in selected.items():
+                current_candidates[job_idx][name] = selected_draft.text
+                proposals[job_idx].new_texts[name] = selected_draft.text
+                proposals[job_idx].prompts[name] = selected_draft.prompt
+                proposals[job_idx].raw_lm_outputs[name] = selected_draft.raw_output
+
+                if self.best_of_n > 1 or self.num_iterations > 1:
+                    iteration_record: dict[str, Any] = {
+                        "iteration": iteration_idx + 1,
+                        "proposal_texts": [draft.text for draft in drafts],
+                        "proposal_raw_lm_outputs": [draft.raw_output for draft in drafts],
+                        "selected_index": selected_index,
+                    }
+                    if selection_prompt is not None:
+                        iteration_record["selection_prompt"] = selection_prompt
+                    if selection_raw_output is not None:
+                        iteration_record["selection_raw_lm_output"] = selection_raw_output
+                    proposals[job_idx].metadata.setdefault(f"textual_gradient:{name}:iterations", []).append(
+                        iteration_record
+                    )
 
         # Stateless: the next LM is this same object (no carried context).
         return [(proposal, self) for proposal in proposals]

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -74,7 +74,13 @@ class ReflectiveMutationProposer:
         callbacks: list[GEPACallback] | None = None,
         sampling_strategy: SamplingStrategy | None = None,
         reflection_strategy: ReflectionLM | None = None,
+        best_of_n: int = 1,
+        num_iterations: int = 1,
     ):
+        if best_of_n < 1:
+            raise ValueError("best_of_n must be >= 1.")
+        if num_iterations < 1:
+            raise ValueError("num_iterations must be >= 1.")
         self.logger = logger
         self.trainset = ensure_loader(trainset)
         self.adapter = adapter
@@ -88,6 +94,8 @@ class ReflectiveMutationProposer:
         self.custom_candidate_proposer = custom_candidate_proposer
         self.callbacks = callbacks
         self.sampling_strategy: SamplingStrategy = sampling_strategy or SingleMutationSampling()
+        self.best_of_n = best_of_n
+        self.num_iterations = num_iterations
 
         self.reflection_prompt_template = reflection_prompt_template
 
@@ -101,13 +109,17 @@ class ReflectiveMutationProposer:
             adapter.propose_new_texts is not None or custom_candidate_proposer is not None
         ):
             owner = (
-                "adapter.propose_new_texts"
-                if adapter.propose_new_texts is not None
-                else "custom_candidate_proposer"
+                "adapter.propose_new_texts" if adapter.propose_new_texts is not None else "custom_candidate_proposer"
             )
             raise ValueError(
                 f"reflection_strategy was provided, but {owner} owns proposal generation "
                 "and the reflection strategy would be silently ignored. Remove one of the two."
+            )
+
+        if reflection_strategy is not None and (best_of_n != 1 or num_iterations != 1):
+            raise ValueError(
+                "best_of_n/num_iterations are implemented by the default StatelessReflectionLM. "
+                "When reflection_strategy is provided, implement multi-step or Best-of-N behavior inside that strategy."
             )
 
         # Reflection LM (#329 Phase 1); None when an adapter/custom proposer owns
@@ -116,7 +128,13 @@ class ReflectiveMutationProposer:
         # reflectors (#329 Phase 2/3) — takes precedence over the stateless
         # default built from the raw reflection_lm callable.
         self._reflection_lm: ReflectionLM | None = reflection_strategy or (
-            StatelessReflectionLM(reflection_lm, reflection_prompt_template, logger)
+            StatelessReflectionLM(
+                reflection_lm,
+                reflection_prompt_template,
+                logger,
+                best_of_n=best_of_n,
+                num_iterations=num_iterations,
+            )
             if reflection_lm is not None
             else None
         )
@@ -183,9 +201,7 @@ class ReflectiveMutationProposer:
         if reflect_many is not None:
             results = list(reflect_many(jobs))
             if len(results) != len(jobs):
-                raise ValueError(
-                    f"ReflectionLM.reflect_many returned {len(results)} results for {len(jobs)} jobs"
-                )
+                raise ValueError(f"ReflectionLM.reflect_many returned {len(results)} results for {len(jobs)} jobs")
         else:
             results = []
             for cand, refds, comps in jobs:
@@ -215,7 +231,9 @@ class ReflectiveMutationProposer:
         except Exception as e:
             self.logger.log(f"Batched reflection failed ({e}); retrying per task.")
             self.logger.log(traceback.format_exc())
-            out: list[tuple[dict[str, str], dict[str, str | list[dict[str, Any]]], dict[str, str], dict[str, Any]] | None] = []
+            out: list[
+                tuple[dict[str, str], dict[str, str | list[dict[str, Any]]], dict[str, str], dict[str, Any]] | None
+            ] = []
             for cand, refds, comps in jobs:
                 try:
                     out.append(self.propose_new_texts(cand, refds, comps))
@@ -475,9 +493,7 @@ class ReflectiveMutationProposer:
                 # would be byte-identical to its parent: don't burn minibatch
                 # metric calls evaluating it or emit proposal/rejection events
                 # for a proposal that never happened.
-                self.logger.log(
-                    f"Iteration {i}: Reflection returned no text updates; skipping proposal for this task."
-                )
+                self.logger.log(f"Iteration {i}: Reflection returned no text updates; skipping proposal for this task.")
                 children.append(None)
                 continue
 

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import pytest
 
 from gepa import optimize
+from gepa.core.adapter import EvaluationBatch
 
 
 def test_reflection_prompt_template():
@@ -177,6 +178,47 @@ def test_empty_seed_candidate():
             max_metric_calls=2,
             reflection_minibatch_size=1,
         )
+
+
+def test_bon_itr_forwarded_to_configurable_adapter():
+    """Adapters with their own proposer can opt in to optimize()'s bon/itr knobs."""
+
+    class ConfigurableAdapter:
+        def __init__(self):
+            self.configured = None
+
+        def configure_textual_gradient_search(self, *, best_of_n: int, num_iterations: int):
+            self.configured = (best_of_n, num_iterations)
+
+        def evaluate(self, batch, candidate, capture_traces=False):
+            return EvaluationBatch(
+                outputs=["out"] * len(batch),
+                scores=[0.0] * len(batch),
+                trajectories=[{"trace": "t"} for _ in batch] if capture_traces else None,
+                objective_scores=None,
+                num_metric_calls=len(batch),
+            )
+
+        def make_reflective_dataset(self, candidate, eval_batch, components_to_update):
+            return {component: [{"Feedback": "f"}] for component in components_to_update}
+
+        def propose_new_texts(self, candidate, reflective_dataset, components_to_update):
+            return {component: f"{candidate[component]} improved" for component in components_to_update}
+
+    adapter = ConfigurableAdapter()
+    optimize(
+        seed_candidate={"instructions": "initial"},
+        trainset=[{"input": "x"}],
+        valset=[{"input": "x"}],
+        adapter=adapter,
+        max_metric_calls=3,
+        skip_perfect_score=False,
+        use_merge=False,
+        bon=2,
+        itr=3,
+    )
+
+    assert adapter.configured == (2, 3)
 
 
 def test_none_seed_candidate():

--- a/tests/test_reflection_lm.py
+++ b/tests/test_reflection_lm.py
@@ -148,6 +148,72 @@ def test_per_component_template_dict_and_missing_warning():
     assert len(missing_warnings) == 1
 
 
+def test_best_of_n_selects_ranked_candidate():
+    """best_of_n samples multiple evolutions and uses BEST_INDEX to pick one."""
+
+    class BestOfNLM:
+        def __init__(self):
+            self.calls = 0
+            self.prompts = []
+
+        def __call__(self, prompt):
+            self.prompts.append(prompt)
+            if "BEST_INDEX" in prompt:
+                return "BEST_INDEX: 2\nREASON: candidate 2 handles the feedback best."
+            self.calls += 1
+            return f"```\nproposal-{self.calls}\n```"
+
+    fake = BestOfNLM()
+    lm = StatelessReflectionLM(fake, best_of_n=3)
+    proposal, _ = lm.reflect({"a": "old"}, _reflective_dataset(["a"]), ["a"])
+
+    assert proposal.new_texts == {"a": "proposal-2"}
+    assert proposal.raw_lm_outputs["a"] == "```\nproposal-2\n```"
+    assert len(fake.prompts) == 4
+    assert "Candidate 1:\nproposal-1" in fake.prompts[-1]
+    assert "Candidate 2:\nproposal-2" in fake.prompts[-1]
+    assert proposal.metadata["textual_gradient:a:iterations"][0]["selected_index"] == 2
+
+
+def test_textual_gradient_iterations_chain_selected_text():
+    """The selected draft from one inner iteration becomes the next current text."""
+
+    class QueueLM:
+        def __init__(self):
+            self.responses = [
+                "```\nfirst-a\n```",
+                "```\nfirst-b\n```",
+                "BEST_INDEX: 2",
+                "```\nsecond-a\n```",
+                "```\nsecond-b\n```",
+                "BEST_INDEX: 1",
+            ]
+            self.prompts = []
+
+        def __call__(self, prompt):
+            self.prompts.append(prompt)
+            return self.responses.pop(0)
+
+    fake = QueueLM()
+    lm = StatelessReflectionLM(fake, best_of_n=2, num_iterations=2)
+    proposal, _ = lm.reflect({"a": "seed"}, _reflective_dataset(["a"]), ["a"])
+
+    assert proposal.new_texts == {"a": "second-a"}
+    # The proposal prompts for iteration 2 should contain the selected text from iteration 1.
+    assert "first-b" in fake.prompts[3]
+    iteration_records = proposal.metadata["textual_gradient:a:iterations"]
+    assert [record["selected_index"] for record in iteration_records] == [2, 1]
+
+
+def test_stateless_reflection_lm_rejects_invalid_textual_gradient_config():
+    import pytest
+
+    with pytest.raises(ValueError, match="best_of_n must be >= 1"):
+        StatelessReflectionLM(RecordingLM(), best_of_n=0)
+    with pytest.raises(ValueError, match="num_iterations must be >= 1"):
+        StatelessReflectionLM(RecordingLM(), num_iterations=0)
+
+
 # ---------------------------------------------------------------------------
 # reflection_strategy injection seam (#329 Phase 2 entry point)
 # ---------------------------------------------------------------------------
@@ -262,9 +328,7 @@ def _make_propose_harness(reflection_strategy):
 def _make_state():
     from gepa.core.state import GEPAState, ValsetEvaluation
 
-    base_eval = ValsetEvaluation(
-        outputs_by_val_id={0: "o"}, scores_by_val_id={0: 0.5}, objective_scores_by_val_id=None
-    )
+    base_eval = ValsetEvaluation(outputs_by_val_id={0: "o"}, scores_by_val_id={0: 0.5}, objective_scores_by_val_id=None)
     state = GEPAState({"c": "seed"}, base_eval, track_best_outputs=False)
     # Set by the engine's seed initialization in real runs (state.py:704).
     state.total_num_evals = 1
@@ -301,6 +365,8 @@ def test_reflection_config_accepts_reflection_strategy():
     stub = _ReflectOnlyLM()
     assert ReflectionConfig(reflection_strategy=stub).reflection_strategy is stub
     assert ReflectionConfig().reflection_strategy is None
+    assert ReflectionConfig(bon=2, itr=3).bon == 2
+    assert ReflectionConfig(bon=2, itr=3).itr == 3
 
 
 # ---------------------------------------------------------------------------
@@ -383,15 +449,27 @@ def test_trace_records_every_task_not_just_the_first():
     class TwoTaskSampling:
         def sample_tasks(self, state, candidate_selector, batch_sampler, trainset):
             return [
-                ProposalTask(parent_idx=0, parent_candidate=dict(state.program_candidates[0]), minibatch_ids=[0], minibatch=[{"q": 0}]),
-                ProposalTask(parent_idx=0, parent_candidate=dict(state.program_candidates[0]), minibatch_ids=[1], minibatch=[{"q": 1}]),
+                ProposalTask(
+                    parent_idx=0,
+                    parent_candidate=dict(state.program_candidates[0]),
+                    minibatch_ids=[0],
+                    minibatch=[{"q": 0}],
+                ),
+                ProposalTask(
+                    parent_idx=0,
+                    parent_candidate=dict(state.program_candidates[0]),
+                    minibatch_ids=[1],
+                    minibatch=[{"q": 1}],
+                ),
             ]
 
     adapter = MagicMock()
     adapter.propose_new_texts = None
     adapter.batch_evaluate = MagicMock(
         side_effect=lambda items: [
-            EvaluationBatch(outputs=["o"], scores=[0.4], trajectories=[{"step": 1}], objective_scores=None, num_metric_calls=1)
+            EvaluationBatch(
+                outputs=["o"], scores=[0.4], trajectories=[{"step": 1}], objective_scores=None, num_metric_calls=1
+            )
             for _ in items
         ]
     )


### PR DESCRIPTION
## Description

This PR lets GEPA try several possible prompt/text improvements at each reflection step, pick the best-looking one, and optionally repeat that process multiple times before evaluating the final candidate.

GEPA generally produce one textual evolution per component per reflection step. With this change, users can configure:
  - `bon`: how many candidate textual evolutions to generate per step
  - `itr`: how many sequential inner evolution steps to run before evaluation
  For example, `bon=3, itr=2` means GEPA generates 3 possible updates, asks the reflection LM to choose the best one, then uses that selected update as the starting point for another round of 3 updates.

  ## What Changed
  - Added `bon` and `itr` to `gepa.optimize(...)`.
  - Added `bon` and `itr` to `optimize_anything.ReflectionConfig`.
  - Implemented multi-step Best-of-N textual evolution in the modern `StatelessReflectionLM` path.
  - Preserved support for the standalone DSPy adapter proposal path.
  - Added metadata for inner textual-gradient iterations.
  - Added validation for invalid `bon` / `itr` values.
  - Added tests covering Best-of-N selection, chained inner iterations,
  config forwarding, and validation.

  ## Validation
  Ran the repository checks from `CONTRIBUTING.md`:
  - `uv sync --extra dev --python 3.11`
  - `uv run pre-commit run --files ...`
  - `uv run pytest tests/`
    - `564 passed, 4 skipped`
  - `uv run pyright`
    - `0 errors, 0 warnings`