### PR TITLE
Add Atlas Cloud LM helper

### DIFF
--- a/docs/docs/api/index.md
+++ b/docs/docs/api/index.md
@@ -34,6 +34,7 @@ Configuration for the built-in GEPA engine (`engine="gepa"`). These classes are 
 - [`get_log_context`](optimize_anything/get_log_context.md)
 - [`set_log_context`](optimize_anything/set_log_context.md)
 - [`make_litellm_lm`](optimize_anything/make_litellm_lm.md)
+- [`make_atlascloud_lm`](optimize_anything/make_atlascloud_lm.md)
 
 ## Core
 

--- a/docs/docs/api/optimize_anything/make_atlascloud_lm.md
+++ b/docs/docs/api/optimize_anything/make_atlascloud_lm.md
@@ -1,0 +1,15 @@
+# make_atlascloud_lm
+
+::: gepa.gepa_launcher.make_atlascloud_lm
+    handler: python
+    options:
+        show_source: true
+        show_root_heading: true
+        heading_level: 2
+        docstring_style: google
+        show_root_full_path: true
+        show_object_full_path: false
+        separate_signature: false
+        inherited_members: true
+        members_order: source
+        show_signature_annotations: true

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
             - get_log_context: api/optimize_anything/get_log_context.md
             - set_log_context: api/optimize_anything/set_log_context.md
             - make_litellm_lm: api/optimize_anything/make_litellm_lm.md
+            - make_atlascloud_lm: api/optimize_anything/make_atlascloud_lm.md
         - Core:
             - optimize: api/core/optimize.md
             - GEPAAdapter: api/core/GEPAAdapter.md

--- a/docs/scripts/generate_api_docs.py
+++ b/docs/scripts/generate_api_docs.py
@@ -44,6 +44,7 @@ API_MAPPING = {
         ("gepa.gepa_launcher", "get_log_context", "get_log_context"),
         ("gepa.gepa_launcher", "set_log_context", "set_log_context"),
         ("gepa.gepa_launcher", "make_litellm_lm", "make_litellm_lm"),
+        ("gepa.gepa_launcher", "make_atlascloud_lm", "make_atlascloud_lm"),
     ],
     "core": [
         ("gepa.api", "optimize", "optimize"),
@@ -137,7 +138,7 @@ CATEGORY_INFO = {
     },
     "gepa_engine": {
         "title": "GEPA Engine",
-        "description": "Configuration for the built-in GEPA engine (`engine=\"gepa\"`). These classes are passed via `OptimizeAnythingConfig(engine_config={...})` to control GEPA-specific behavior.",
+        "description": 'Configuration for the built-in GEPA engine (`engine="gepa"`). These classes are passed via `OptimizeAnythingConfig(engine_config={...})` to control GEPA-specific behavior.',
         "dir": "optimize_anything",
     },
     "core": {

--- a/src/gepa/gepa_launcher.py
+++ b/src/gepa/gepa_launcher.py
@@ -107,6 +107,7 @@ Public API:
       :class:`RefinerConfig`, :class:`MergeConfig`, :class:`TrackingConfig`
     - :func:`log`, :func:`get_log_context`, :func:`set_log_context` — in-evaluator logging
     - :func:`make_litellm_lm` — convert a model name string to a callable
+    - :func:`make_atlascloud_lm` — build an Atlas Cloud OpenAI-compatible callable
     - :class:`Image` — wrapper for including images in side_info (VLM reflection)
 """
 
@@ -986,6 +987,44 @@ def make_litellm_lm(model_name: str, **kwargs: Any) -> LanguageModel:
     from gepa.lm import LM
 
     return LM(model_name, **kwargs)
+
+
+def make_atlascloud_lm(model_name: str = "qwen/qwen3.5-flash", **kwargs: Any) -> LanguageModel:
+    """Create an Atlas Cloud OpenAI-compatible :class:`LanguageModel` callable.
+
+    Atlas Cloud exposes an OpenAI-compatible chat completions API, so this helper
+    builds the same lightweight :class:`gepa.lm.LM` wrapper as
+    :func:`make_litellm_lm` while preconfiguring the Atlas Cloud endpoint.
+
+    By default, the helper reads ``ATLASCLOUD_API_KEY`` for authentication and
+    ``ATLASCLOUD_API_BASE`` for endpoint overrides. Explicit ``api_key``,
+    ``api_base``, or ``base_url`` keyword arguments take precedence.
+
+    Args:
+        model_name: Atlas Cloud model identifier, for example
+            ``"qwen/qwen3.5-flash"`` or ``"deepseek-ai/deepseek-v4-pro"``.
+        **kwargs: Extra keyword arguments forwarded to ``litellm.completion``
+            (for example ``temperature=0.7`` or ``max_tokens=4096``).
+    """
+    from gepa.lm import LM
+
+    api_key = kwargs.pop("api_key", None) or os.getenv("ATLASCLOUD_API_KEY")
+    api_base = (
+        kwargs.pop("api_base", None)
+        or kwargs.pop("base_url", None)
+        or os.getenv("ATLASCLOUD_API_BASE")
+        or "https://api.atlascloud.ai/v1"
+    )
+
+    completion_kwargs = {
+        "api_base": api_base,
+        "custom_llm_provider": "openai",
+        **kwargs,
+    }
+    if api_key:
+        completion_kwargs["api_key"] = api_key
+
+    return LM(model_name, **completion_kwargs)
 
 
 class EvaluatorWrapper:

--- a/tests/test_evaluator_wrapper.py
+++ b/tests/test_evaluator_wrapper.py
@@ -599,6 +599,60 @@ class TestMakeLitellmLm:
 
 
 # ---------------------------------------------------------------------------
+# make_atlascloud_lm
+# ---------------------------------------------------------------------------
+
+
+class TestMakeAtlascloudLm:
+    """Tests for the Atlas Cloud OpenAI-compatible LM helper."""
+
+    def test_defaults_read_atlascloud_environment(self, monkeypatch):
+        from gepa.lm import LM
+
+        monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlas-env-key")
+        monkeypatch.delenv("ATLASCLOUD_API_BASE", raising=False)
+
+        lm = oa.make_atlascloud_lm()
+
+        assert isinstance(lm, LM)
+        assert lm.model == "qwen/qwen3.5-flash"
+        assert lm.completion_kwargs["api_key"] == "atlas-env-key"
+        assert lm.completion_kwargs["api_base"] == "https://api.atlascloud.ai/v1"
+        assert lm.completion_kwargs["custom_llm_provider"] == "openai"
+
+    def test_explicit_kwargs_override_environment(self, monkeypatch):
+        monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlas-env-key")
+        monkeypatch.setenv("ATLASCLOUD_API_BASE", "https://env.example/v1")
+
+        lm = oa.make_atlascloud_lm(
+            "deepseek-ai/deepseek-v4-pro",
+            api_key="atlas-explicit-key",
+            api_base="https://proxy.example/v1",
+            temperature=0.2,
+            max_tokens=4096,
+        )
+
+        assert lm.model == "deepseek-ai/deepseek-v4-pro"
+        assert lm.completion_kwargs == {
+            "api_key": "atlas-explicit-key",
+            "api_base": "https://proxy.example/v1",
+            "custom_llm_provider": "openai",
+            "temperature": 0.2,
+            "max_tokens": 4096,
+        }
+
+    def test_base_url_alias_configures_api_base(self, monkeypatch):
+        monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+        monkeypatch.delenv("ATLASCLOUD_API_BASE", raising=False)
+
+        lm = oa.make_atlascloud_lm(base_url="https://atlas-proxy.example/v1")
+
+        assert "api_key" not in lm.completion_kwargs
+        assert lm.completion_kwargs["api_base"] == "https://atlas-proxy.example/v1"
+        assert lm.completion_kwargs["custom_llm_provider"] == "openai"
+
+
+# ---------------------------------------------------------------------------
 # ThreadLocalStreamCapture
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add `make_atlascloud_lm`, a small helper that configures GEPA's existing LiteLLM-backed `LM` wrapper for Atlas Cloud's OpenAI-compatible endpoint.
- Read `ATLASCLOUD_API_KEY` and optional `ATLASCLOUD_API_BASE` by default while preserving explicit `api_key`, `api_base`, and `base_url` overrides.
- Add focused tests and include the helper in the generated API docs mapping/navigation.

## Validation
- `uv run --with pytest --with pytest-asyncio --with 'litellm>=1.83,<1.92' pytest tests/test_evaluator_wrapper.py -q` (49 passed)
- `uv run --with ruff ruff check src/gepa/gepa_launcher.py tests/test_evaluator_wrapper.py docs/scripts/generate_api_docs.py`
- `python3 -m compileall src/gepa/gepa_launcher.py tests/test_evaluator_wrapper.py docs/scripts/generate_api_docs.py`
- `git diff --check`
- Confirmed Atlas Cloud live model catalog includes `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`

No README changes.
