### PR TITLE
fix: remove 3 dead unpacked variables (RUF059) flagged by real lint gate

### DIFF
--- a/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
+++ b/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
@@ -553,13 +553,13 @@ class OptimizeAnythingAdapter(GEPAAdapter):
         refiner_prompt = candidate.get("refiner_prompt", "")
 
         # 1. Evaluate original candidate
-        original_score, original_output, original_side_info = self._call_evaluator(candidate, example)
+        original_score, _original_output, original_side_info = self._call_evaluator(candidate, example)
 
         # Update best evals with original evaluation
         self._update_best_example_evals(example, original_score, original_side_info)
 
         # 2. Refine and evaluate
-        best_refined_score, best_refined_candidate, best_refined_side_info, all_attempts = self._refine_and_evaluate(
+        best_refined_score, best_refined_candidate, _best_refined_side_info, all_attempts = self._refine_and_evaluate(
             candidate, example, refiner_prompt, original_score, original_side_info
         )
 
@@ -799,7 +799,7 @@ class OptimizeAnythingAdapter(GEPAAdapter):
 
                 # Reconstruct full candidate: refined params + original refiner_prompt
                 refined_candidate_dict = {**parsed_refined, "refiner_prompt": candidate.get("refiner_prompt", "")}
-                refined_score, refined_output, refined_eval_side_info = self._call_evaluator(
+                refined_score, _refined_output, refined_eval_side_info = self._call_evaluator(
                     refined_candidate_dict, example
                 )
 


### PR DESCRIPTION
## What
Removes 3 unused tuple-unpack targets in `optimize_anything_adapter.py` (`original_output`, `best_refined_side_info`, `refined_output`), prefixing them with `_`.

## Why
These are pre-existing dead code from #346. They're invisible to the repo's locked ruff 0.12.10, but **RUF059** ("unpacked variable never used") in newer ruff flags them. `chartboost/ruff-action@v1` bundles a floating ruff (currently 0.15.22), so once #404 turns the lint gate into a real `ruff check`, these 3 fail CI. This clears them.

## Note on the gate itself
#404's failure is the version skew between the floating action ruff and the locked 0.12.10 (dev + the `fix` job). Recommend the lint gate run the *locked* ruff — `run: uv run -p .venv ruff check` — so local == CI and no future ruff release can spontaneously break main. This PR makes the tree clean under **both** versions either way.

## Verification
- `ruff check` clean under 0.12.10 **and** 0.15.22
- pyright: 0 errors
- 147 adapter tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)