### PR TITLE
Fix P1/P2 review findings + batch-eval edge cases

### DIFF
--- a/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
+++ b/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
@@ -555,8 +555,14 @@ class OptimizeAnythingAdapter(GEPAAdapter):
         # 1. Evaluate original candidate
         original_score, _original_output, original_side_info = self._call_evaluator(candidate, example)
 
-        # Update best evals with original evaluation
-        self._update_best_example_evals(example, original_score, original_side_info)
+        # Update best evals with original evaluation. Skip synthetic
+        # whole-batch failures (raise_on_exception=False): with only a
+        # batch_evaluator, ``_resolve_pair`` routes this singleton through it,
+        # so a transient infra error surfaces here as a placeholder 0.0 that
+        # would otherwise poison the warm-start pool (mirror of
+        # ``_assemble_no_refiner_batch``).
+        if not (isinstance(original_side_info, dict) and original_side_info.get("_gepa_transient_failure")):
+            self._update_best_example_evals(example, original_score, original_side_info)
 
         # 2. Refine and evaluate
         best_refined_score, best_refined_candidate, _best_refined_side_info, all_attempts = self._refine_and_evaluate(
@@ -695,6 +701,13 @@ class OptimizeAnythingAdapter(GEPAAdapter):
         # Package outputs as (score, candidate, side_info) tuples.
         eval_output = [(score, (score, candidate, side_info), side_info) for score, _, side_info in raw_results]
         for example, (score, _, side_info) in zip(batch, eval_output, strict=True):
+            # Synthetic whole-batch failure results (raise_on_exception=False)
+            # carry a placeholder 0.0 score; feeding them into the best-evals
+            # history would poison the warm-start pool with fake zero-score
+            # entries. They are excluded from the eval cache for the same
+            # reason (see ``_resolve_pair_cached``).
+            if isinstance(side_info, dict) and side_info.get("_gepa_transient_failure"):
+                continue
             self._update_best_example_evals(example, score, side_info)
 
         scores = [score for score, _, _ in eval_output]

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -653,19 +653,29 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
 
         # 4) Add each selected candidate to the pool, in order.
         any_accepted = False
-        for proposal, (valset_evaluation, num_actual_evals) in zip(selected, valset_evals, strict=True):
+        for k, (proposal, (valset_evaluation, num_actual_evals)) in enumerate(
+            zip(selected, valset_evals, strict=True)
+        ):
             new_sum = sum(proposal.subsample_scores_after or [])
             self.logger.log(
                 f"Iteration {iteration}: Accepted candidate (subsample score "
                 f"{sum(proposal.subsample_scores_before or [])} -> {new_sum}); running full eval."
             )
+            # Each accepted candidate in a batch needs its own on-disk anchor.
+            # The first keeps the iteration's id (back-compat: agents still find
+            # the primary accepted candidate at ``iterations/<iteration_id>/``);
+            # the rest get suffixed ids so their ``outputs/`` and
+            # ``trajectories/`` no longer overwrite one another under the shared
+            # id. ``_save_iteration_dirs`` reads these back from
+            # ``iteration_ids_by_candidate_idx`` to emit one dir per candidate.
+            candidate_iteration_id = iteration_id if k == 0 else f"{iteration_id}-{k}"
             new_idx, _ = self._add_evaluated_program(
                 new_program=proposal.candidate,
                 state=state,
                 parent_program_idx=proposal.parent_program_ids,
                 valset_evaluation=valset_evaluation,
                 num_actual_evals=num_actual_evals,
-                iteration_id=iteration_id,
+                iteration_id=candidate_iteration_id,
             )
             self._log_proposal_lm_calls(iteration, proposal, candidate_idx=new_idx)
             notify_callbacks(
@@ -964,6 +974,16 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                                 self.merge_proposer.merges_due -= 1
                                 self.merge_proposer.total_merges_tested += 1
                                 proposal_accepted = True
+
+                                # Stamp the trace entry so the agent-state
+                                # writer archives the merged candidate under
+                                # this iteration's dir. Unlike the reflective
+                                # path, the merge path never set this flag, so
+                                # ``_save_iteration_dirs`` saw ``accepted=None``
+                                # and skipped the merged candidate's components
+                                # and val_scores.
+                                if self.write_agent_state:
+                                    state.full_program_trace[-1]["proposal_accepted"] = True
 
                                 # Notify merge accepted
                                 notify_callbacks(

--- a/src/gepa/core/state.py
+++ b/src/gepa/core/state.py
@@ -508,18 +508,37 @@ class GEPAState(Generic[RolloutOutput, DataId]):
                 self.prog_candidate_val_subscores[0],
             )
 
-        # One dir per loop-trace entry (accepted and rejected proposals).
+        # One dir per accepted candidate (plus one per rejected proposal). A
+        # single loop iteration can accept more than one candidate when a
+        # multi-proposal sampling strategy is in use; each accepted candidate
+        # gets its own anchor (see ``_run_reflective_batch``), so we archive one
+        # dir per candidate rather than only the last.
         for entry in self.full_program_trace:
             trace_i = entry.get("i")
             if trace_i is None:
                 continue
-            # Every loop slot is stamped with its anchor at creation time.
-            iter_id = entry["iteration_id"]
-            base = f"iterations/{iter_id}"
-            if os.path.exists(os.path.join(run_dir, base, "meta.json")):
-                continue
             accepted = entry.get("proposal_accepted")
-            candidate_idx = entry.get("new_program_idx") if accepted else None
+
+            # Resolve the accepted candidate indices for this entry. Prefer the
+            # per-candidate list; fall back to the singular field for entries
+            # written before it existed (or by the merge path).
+            candidate_indices: list[int] = []
+            if accepted:
+                indices = entry.get("new_program_indices")
+                if not indices:
+                    single = entry.get("new_program_idx")
+                    indices = [single] if single is not None else []
+                candidate_indices = [ci for ci in indices if ci is not None]
+
+            # Each (dir id, candidate_idx) target: one per accepted candidate,
+            # anchored at that candidate's own iteration id; a rejected entry
+            # yields a single dir at the entry's anchor with no candidate.
+            entry_iter_id = entry["iteration_id"]
+            if candidate_indices:
+                targets = [(cand_to_iter.get(ci, entry_iter_id), ci) for ci in candidate_indices]
+            else:
+                targets = [(entry_iter_id, None)]
+
             parent_candidate_idx = entry.get("selected_program_candidate")
             parent_iter_ids = (
                 [cand_to_iter[parent_candidate_idx]]
@@ -527,43 +546,48 @@ class GEPAState(Generic[RolloutOutput, DataId]):
                 else []
             )
 
-            # The candidate text to archive under components/: for accepted
-            # iterations this is the newly accepted program; for rejected
-            # iterations it's the proposed (now discarded) candidate.
-            components: dict[str, str] | None = None
-            if accepted and candidate_idx is not None and candidate_idx < len(self.program_candidates):
-                components = self.program_candidates[candidate_idx]
-            elif "proposed_candidate" in entry and isinstance(entry["proposed_candidate"], dict):
-                components = entry["proposed_candidate"]
+            for iter_id, candidate_idx in targets:
+                base = f"iterations/{iter_id}"
+                if os.path.exists(os.path.join(run_dir, base, "meta.json")):
+                    continue
 
-            meta: dict[str, Any] = {
-                "iteration_id": iter_id,
-                "trace_i": trace_i,
-                "accepted": bool(accepted) if accepted is not None else None,
-                "parent_iteration_ids": parent_iter_ids,
-                "candidate_idx": candidate_idx,
-                "subsample_ids": entry.get("subsample_ids"),
-                "subsample_scores_before": entry.get("subsample_scores"),
-                "subsample_scores_after": entry.get("new_subsample_scores"),
-            }
-            val_subscores: dict[DataId, float] | None = None
-            if accepted and candidate_idx is not None and candidate_idx < len(self.prog_candidate_val_subscores):
-                avg_score, coverage = self.get_program_average_val_subset(candidate_idx)
-                meta["avg_val_score"] = avg_score
-                meta["num_val_scored"] = coverage
-                obj_scores = self.prog_candidate_objective_scores[candidate_idx]
-                if obj_scores:
-                    meta["objective_scores"] = obj_scores
-                metric_calls = (
-                    self.num_metric_calls_by_discovery[candidate_idx]
-                    if candidate_idx < len(self.num_metric_calls_by_discovery)
-                    else None
-                )
-                if metric_calls is not None:
-                    meta["metric_calls_to_discover"] = metric_calls
-                val_subscores = self.prog_candidate_val_subscores[candidate_idx]
+                # The candidate text to archive under components/: for accepted
+                # iterations this is the newly accepted program; for rejected
+                # iterations it's the proposed (now discarded) candidate.
+                components: dict[str, str] | None = None
+                if candidate_idx is not None and candidate_idx < len(self.program_candidates):
+                    components = self.program_candidates[candidate_idx]
+                elif "proposed_candidate" in entry and isinstance(entry["proposed_candidate"], dict):
+                    components = entry["proposed_candidate"]
 
-            write(base, meta, components, val_subscores)
+                meta: dict[str, Any] = {
+                    "iteration_id": iter_id,
+                    "trace_i": trace_i,
+                    "accepted": bool(accepted) if accepted is not None else None,
+                    "parent_iteration_ids": parent_iter_ids,
+                    "candidate_idx": candidate_idx,
+                    "subsample_ids": entry.get("subsample_ids"),
+                    "subsample_scores_before": entry.get("subsample_scores"),
+                    "subsample_scores_after": entry.get("new_subsample_scores"),
+                }
+                val_subscores: dict[DataId, float] | None = None
+                if candidate_idx is not None and candidate_idx < len(self.prog_candidate_val_subscores):
+                    avg_score, coverage = self.get_program_average_val_subset(candidate_idx)
+                    meta["avg_val_score"] = avg_score
+                    meta["num_val_scored"] = coverage
+                    obj_scores = self.prog_candidate_objective_scores[candidate_idx]
+                    if obj_scores:
+                        meta["objective_scores"] = obj_scores
+                    metric_calls = (
+                        self.num_metric_calls_by_discovery[candidate_idx]
+                        if candidate_idx < len(self.num_metric_calls_by_discovery)
+                        else None
+                    )
+                    if metric_calls is not None:
+                        meta["metric_calls_to_discover"] = metric_calls
+                    val_subscores = self.prog_candidate_val_subscores[candidate_idx]
+
+                write(base, meta, components, val_subscores)
 
     def _save_components_dir(self, run_dir: str, base: str, components: dict[str, str]) -> None:
         """Write ``<base>/components/<stem>.txt`` plus ``_index.json``."""
@@ -748,8 +772,12 @@ class GEPAState(Generic[RolloutOutput, DataId]):
             # candidates -> their legacy (trace_i + 1) slot id.
             mapping: dict[int, str] = {0: SEED_ITERATION_ID}
             for entry in d.get("full_program_trace", []):
-                if not entry.get("proposal_accepted"):
-                    continue
+                # Key off ``new_program_idx``, not ``proposal_accepted``:
+                # pre-schema-6 trace entries never wrote a ``proposal_accepted``
+                # flag, but every accepted iteration stamped ``new_program_idx``
+                # (rejected iterations left it unset). Gating on the missing
+                # flag skipped every legacy candidate, mapping them all to the
+                # sentinel ``"-1"`` on resume.
                 cand_idx = entry.get("new_program_idx")
                 trace_i = entry.get("i")
                 if cand_idx is None or trace_i is None:

--- a/src/gepa/oa/engines/best_of_n.py
+++ b/src/gepa/oa/engines/best_of_n.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from gepa.lm import LM
+from gepa.oa.budget import BudgetExhausted
 from gepa.oa.engine import Result
 from gepa.oa.task import seed_as_text
 
@@ -167,14 +168,29 @@ class BestOfNEngine:
                 )
                 continue
 
-            if task.has_dataset and task.train_set:
-                scores = []
-                for ex in task.train_set:
-                    s, _info = server.evaluate(candidate, ex)
-                    scores.append(s)
-                score = sum(scores) / len(scores) if scores else float("-inf")
-            else:
-                score, _info = server.evaluate(candidate)
+            # Score the candidate on whatever dataset defines the task. Prefer
+            # the train_set; fall back to the val_set for val-only tasks (a
+            # dataset evaluator needs an example, so the no-example branch below
+            # would raise a TypeError inside the evaluator). Only when the task
+            # carries no per-example data at all do we evaluate example-free.
+            examples = task.train_set or task.val_set
+            try:
+                if examples:
+                    scores = []
+                    for ex in examples:
+                        s, _info = server.evaluate(candidate, ex)
+                        scores.append(s)
+                    score = sum(scores) / len(scores) if scores else float("-inf")
+                else:
+                    score, _info = server.evaluate(candidate)
+            except BudgetExhausted:
+                # Budget ran out mid-evaluation. Discard this partially scored
+                # candidate and stop — returning the best fully evaluated
+                # candidate so far. Letting BudgetExhausted escape would hand
+                # control to the api's fallback, which reports the server's
+                # single highest per-example score (``server.best_score``)
+                # rather than this engine's candidate-aggregate best.
+                break
 
             if score > best_score:
                 best_score = score

--- a/src/gepa/oa/eval_server.py
+++ b/src/gepa/oa/eval_server.py
@@ -458,11 +458,18 @@ class EvalServer:
     def _register_candidate(self, candidate: str) -> int:
         # Tolerate non-str candidates (e.g. a legacy dict) — key by a stable dump.
         key = candidate if isinstance(candidate, str) else json.dumps(candidate, sort_keys=True)
-        if key in self._candidate_registry:
-            return self._candidate_registry[key]
-        cid = self._next_candidate_id
-        self._next_candidate_id += 1
-        self._candidate_registry[key] = cid
+        # Allocate the id and mutate the registry under the lock: log_progress
+        # can be called concurrently (HTTP handlers, batched valset evals), and
+        # an unlocked read-modify-write of ``_next_candidate_id`` /
+        # ``_candidate_registry`` could hand out duplicate ids or corrupt the
+        # dict. The lock is released before the (separately ``_io_lock``-guarded)
+        # file append, so no locks nest and there is no ordering hazard.
+        with self._lock:
+            if key in self._candidate_registry:
+                return self._candidate_registry[key]
+            cid = self._next_candidate_id
+            self._next_candidate_id += 1
+            self._candidate_registry[key] = cid
         if self.output_dir is not None:
             with self._io_lock:
                 with open(self.output_dir / "candidates.jsonl", "a") as f:

--- a/src/gepa/oa/proposers/claude_code_agent.py
+++ b/src/gepa/oa/proposers/claude_code_agent.py
@@ -230,7 +230,7 @@ class ClaudeCodeAgentProposer:
         scratch dir name lines up 1:1 with ``iterations/<iteration_id>/``; falls
         back to ``YYYYmmddTHHMMSS-<pid>-<uuid8>`` otherwise. ``iteration_id`` is
         already a unique random id, so it disambiguates parallel proposals
-        (``num_parallel_proposals > 1``) on its own.
+        (a multi-proposal ``SamplingStrategy``) on its own.
         """
         self.run_dir.mkdir(parents=True, exist_ok=True)
         base = self.run_dir / self.subdir_prefix

--- a/tests/test_batch_evaluator_user_fn.py
+++ b/tests/test_batch_evaluator_user_fn.py
@@ -336,6 +336,53 @@ def test_duplicate_pairs_deduplicated_within_grouped_call_when_cached():
     assert sum(len(c) for c in fn.calls) == 3, f"duplicate pair not deduped: {fn.calls}"
 
 
+def test_transient_batch_failure_does_not_poison_warm_start():
+    """A transient whole-batch failure (raise_on_exception=False) must not be
+    folded into the best-evals warm-start history: its placeholder 0.0 would
+    otherwise become a fake ``best`` example eval steered at future proposals."""
+    state = {"fail": True}
+
+    def flaky(pairs):
+        if state["fail"]:
+            raise RuntimeError("transient outage")
+        return [(0.9, {"note": "real"}) for _ in pairs]
+
+    adapter = OptimizeAnythingAdapter(evaluator=None, parallel=False, cache_mode="off", batch_evaluator=flaky)
+    adapter._batch_evaluator = BatchEvaluatorWrapper(flaky, raise_on_exception=False)
+
+    example = {"x": 1}
+    adapter.batch_evaluate([({"bias": "0"}, [example])])
+    # The failed eval produced a 0.0 placeholder but must NOT be recorded.
+    assert adapter._get_best_example_evals(example) == [], "transient 0.0 poisoned warm-start history"
+
+    # A subsequent real success is recorded normally.
+    state["fail"] = False
+    adapter.batch_evaluate([({"bias": "0"}, [example])])
+    best = adapter._get_best_example_evals(example)
+    assert [e["score"] for e in best] == [0.9]
+
+
+def test_transient_failure_does_not_poison_warm_start_on_refiner_path():
+    """Same guard on the refiner path: with only a batch_evaluator, the refiner
+    resolves each singleton pair through it, so a transient failure surfaces as
+    a 0.0 that must be excluded from the warm-start history there too."""
+    from gepa.gepa_launcher import RefinerConfig
+
+    def flaky(pairs):
+        raise RuntimeError("transient outage")
+
+    adapter = OptimizeAnythingAdapter(
+        evaluator=None,
+        batch_evaluator=BatchEvaluatorWrapper(flaky, raise_on_exception=False),
+        refiner_config=RefinerConfig(refiner_lm=lambda prompt: "no-op refinement", max_refinements=1),
+        parallel=False,
+        cache_mode="off",
+    )
+    example = {"x": 2}
+    adapter.batch_evaluate([({"refiner_prompt": "seed"}, [example])])
+    assert adapter._get_best_example_evals(example) == [], "transient 0.0 poisoned warm-start on refiner path"
+
+
 def test_capture_stdio_without_evaluator_warns():
     import warnings as _warnings
 

--- a/tests/test_best_of_n_engine.py
+++ b/tests/test_best_of_n_engine.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""Regression tests for the best_of_n engine's dataset scoring.
+
+Two bugs, both in the ``run()`` eval block:
+
+1. Over-reporting on budget exhaustion. When the eval budget ran out
+   *mid-dataset-loop*, ``BudgetExhausted`` escaped ``run()`` and the api
+   fallback reported ``server.best_score`` — the single highest *per-example*
+   score — instead of the engine's candidate-aggregate (mean-over-dataset)
+   best. A run that never had one candidate clear the whole dataset could
+   still report a per-example max it never achieved as an aggregate.
+
+2. Crash on a val-only task. A task with a ``val_set`` but no ``train_set``
+   took the no-example ``server.evaluate(candidate)`` branch, which calls the
+   dataset evaluator with no example and raises ``TypeError``.
+"""
+
+from __future__ import annotations
+
+import gepa.oa.engines.best_of_n as bon
+from gepa.oa.budget import BudgetTracker
+from gepa.oa.config import OptimizeAnythingConfig
+from gepa.oa.eval_server import EvalServer
+from gepa.oa.task import Task
+
+
+class _FakeLM:
+    """Stand-in for ``gepa.lm.LM``: returns a distinct fenced candidate per
+    call and carries a ``total_cost`` attribute (read by the engine)."""
+
+    def __init__(self, *args, **kwargs):
+        self.total_cost = 0.0
+        self._n = 0
+
+    def __call__(self, prompt):
+        self._n += 1
+        return f"```\ncandidate-{self._n}\n```"
+
+
+def _engine(monkeypatch, *, max_evals, engine_config):
+    monkeypatch.setattr(bon, "LM", _FakeLM)
+    config = OptimizeAnythingConfig(
+        engine="best_of_n",
+        max_evals=max_evals,
+        engine_config=engine_config,
+    )
+    return bon.BestOfNEngine(config)
+
+
+def test_budget_exhaustion_reports_aggregate_not_per_example_max(monkeypatch):
+    """When the budget runs out mid-dataset, the engine must return the best
+    fully-evaluated candidate's *aggregate* score — never the server's single
+    highest per-example score."""
+    train = [{"id": f"e{i}"} for i in range(4)]
+    task = Task(name="bon-budget", seed_candidate="seed", train_set=train)
+
+    # e0 scores 1.0, the rest 0.0 → per-example max = 1.0, dataset mean = 0.25.
+    def eval_fn(candidate, example):
+        return (1.0 if example["id"] == "e0" else 0.0), {}
+
+    # 6 evals: candidate 1 scores the whole set (4 evals, mean 0.25); candidate
+    # 2 exhausts mid-loop (evals 5 and 6, then check() raises on the 3rd ex).
+    budget = BudgetTracker(max_evals=6)
+    server = EvalServer(task, evaluate=eval_fn, budget=budget)
+    engine = _engine(monkeypatch, max_evals=6, engine_config={"max_n": 10})
+
+    result = engine.run(task, server)
+
+    assert server.best_score == 1.0  # the server did see a 1.0 per-example
+    assert result.best_score == 0.25  # but the engine reports the aggregate best
+    assert budget.used == 6  # budget was actually exhausted
+
+
+def test_val_only_task_scores_over_val_set(monkeypatch):
+    """A task with only a ``val_set`` (no ``train_set``) must be scored over the
+    val examples, not routed through the no-example evaluate() branch (which
+    would raise TypeError in a dataset evaluator)."""
+    val = [{"v": 0.2}, {"v": 0.8}]
+    task = Task(name="bon-valonly", seed_candidate="seed", val_set=val)
+
+    def eval_fn(candidate, example):
+        return float(example["v"]), {}
+
+    budget = BudgetTracker(max_evals=100)
+    server = EvalServer(task, evaluate=eval_fn, budget=budget)
+    engine = _engine(monkeypatch, max_evals=100, engine_config={"max_n": 3})
+
+    result = engine.run(task, server)
+
+    # eval_fn ignores the candidate, so every sample scores mean(0.2, 0.8)=0.5.
+    assert result.best_score == 0.5
+    assert budget.used == 3 * len(val)  # 3 samples × 2 val examples, no crash

--- a/tests/test_eval_server_register.py
+++ b/tests/test_eval_server_register.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""Concurrency regression for ``EvalServer._register_candidate``.
+
+``log_progress`` can be called from many threads at once (HTTP handlers,
+batched valset evals). Id allocation used to be an unlocked read-modify-write
+of ``_next_candidate_id`` / ``_candidate_registry``, which under contention
+could hand out duplicate ids or drop registry entries. Allocation now happens
+under ``self._lock``.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from gepa.oa.budget import BudgetTracker
+from gepa.oa.eval_server import EvalServer
+from gepa.oa.task import Task
+
+
+def _server():
+    task = Task(name="reg", seed_candidate="seed")
+    return EvalServer(task, evaluate=lambda candidate: (0.0, {}), budget=BudgetTracker(max_evals=None))
+
+
+def _run_concurrently(fns):
+    barrier = threading.Barrier(len(fns))
+
+    def wrapped(fn):
+        barrier.wait()  # maximize the overlap window
+        fn()
+
+    threads = [threading.Thread(target=wrapped, args=(fn,)) for fn in fns]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+
+def test_distinct_candidates_get_unique_contiguous_ids():
+    server = _server()
+    n = 64
+    results: list[int] = []
+    results_lock = threading.Lock()
+
+    def register(i):
+        def go():
+            cid = server._register_candidate(f"candidate-{i}")
+            with results_lock:
+                results.append(cid)
+
+        return go
+
+    _run_concurrently([register(i) for i in range(n)])
+
+    # No duplicate ids, and the id space is exactly 0..n-1 (no gaps, no
+    # clobbered registry entries).
+    assert len(results) == n
+    assert sorted(results) == list(range(n))
+    assert server._next_candidate_id == n
+
+
+def test_same_candidate_registered_concurrently_gets_one_id():
+    server = _server()
+    n = 64
+    results: list[int] = []
+    results_lock = threading.Lock()
+
+    def register():
+        cid = server._register_candidate("the-one-candidate")
+        with results_lock:
+            results.append(cid)
+
+    _run_concurrently([register for _ in range(n)])
+
+    # Every concurrent registration of the same candidate resolves to a single
+    # shared id; exactly one id was ever allocated.
+    assert len(results) == n
+    assert set(results) == {0}
+    assert server._next_candidate_id == 1

--- a/tests/test_multi_proposal_invariants.py
+++ b/tests/test_multi_proposal_invariants.py
@@ -18,6 +18,7 @@ Invariants:
   I7 determinism: identical config -> identical outcome
 """
 
+import json
 import re
 from collections import defaultdict
 from itertools import pairwise
@@ -229,6 +230,62 @@ def test_multi_proposal_determinism(tmp_path):
     assert r1.best_candidate == r2.best_candidate
     assert r1.total_metric_calls == r2.total_metric_calls
     assert len(r1.candidates) == len(r2.candidates)
+
+
+def test_write_agent_state_multi_accept_one_dir_per_candidate(tmp_path):
+    """A multi-accept iteration must archive EVERY accepted candidate, not just
+    the last. Before the fix, all accepted candidates in one iteration shared a
+    single ``iterations/<id>/`` anchor, so their meta/components/val_scores and
+    outputs/trajectories overwrote one another and only the last survived.
+    """
+    run_dir = tmp_path / "multi_accept_agent_state"
+    adapter = SyntheticAdapter()
+    result = gepa.optimize(
+        seed_candidate={"system_prompt": "LEVEL=0"},
+        trainset=TRAIN,
+        valset=TRAIN,
+        adapter=adapter,
+        reflection_lm=SyntheticReflectionLM(),
+        max_metric_calls=400,
+        # SameParent(n=4) + AllImprovements → several accepts share one iteration.
+        sampling_strategy=SameParentSampling(n=4),
+        selection_strategy=AllImprovements(),
+        run_dir=str(run_dir),
+        write_agent_state=True,
+        seed=0,
+        display_progress_bar=False,
+    )
+
+    n_accepted = len(result.candidates) - 1  # excludes the seed
+    assert n_accepted >= 2, "test needs an iteration that accepts >1 candidate"
+
+    # Collect every accepted candidate dir (candidate_idx set, accepted True).
+    iters_dir = run_dir / "iterations"
+    accepted_idxs: list[int] = []
+    dirs_by_candidate: dict[int, list[str]] = defaultdict(list)
+    for meta_path in iters_dir.glob("*/meta.json"):
+        meta = json.loads(meta_path.read_text())
+        if meta.get("is_seed"):
+            continue
+        if meta.get("accepted") and meta.get("candidate_idx") is not None:
+            ci = meta["candidate_idx"]
+            accepted_idxs.append(ci)
+            dirs_by_candidate[ci].append(meta_path.parent.name)
+            # Accepted candidates archive their program + val scores.
+            assert (meta_path.parent / "components").is_dir()
+            assert (meta_path.parent / "val_scores.json").exists()
+
+    # One dir per accepted candidate: every accepted index present exactly once,
+    # each under a distinct anchor (no overwrite/collision).
+    assert sorted(accepted_idxs) == list(range(1, len(result.candidates)))
+    assert all(len(dirs) == 1 for dirs in dirs_by_candidate.values())
+    all_dir_names = [name for names in dirs_by_candidate.values() for name in names]
+    assert len(all_dir_names) == len(set(all_dir_names))
+
+    # Sanity: the state's per-candidate iteration ids match the on-disk dirs.
+    state = GEPAState.load(str(run_dir))
+    for ci in accepted_idxs:
+        assert (iters_dir / state.iteration_ids_by_candidate_idx[ci]).is_dir()
 
 
 class ConstantReflectionLM:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -609,6 +609,37 @@ def test_upgrade_state_dict_adds_missing_fields():
     assert [e["iteration_id"] for e in d["full_program_trace"]] == ["4", "5"]
 
 
+def test_upgrade_state_dict_maps_legacy_candidates_without_accepted_flag():
+    """Real pre-schema-6 trace entries never wrote ``proposal_accepted``.
+
+    The migration must key off ``new_program_idx`` (stamped on every accepted
+    iteration by the old engine) rather than the absent ``proposal_accepted``
+    flag; otherwise every legacy candidate collapses to the ``"-1"`` sentinel.
+    """
+    d = {
+        "program_candidates": [{"a": "seed"}, {"a": "c1"}, {"a": "c2"}],
+        "prog_candidate_objective_scores": [{}, {}, {}],
+        "objective_pareto_front": {},
+        "program_at_pareto_front_objectives": {},
+        "frontier_type": "instance",
+        "pareto_front_cartesian": {},
+        "program_at_pareto_front_cartesian": {},
+        "evaluation_cache": None,
+        "full_program_trace": [
+            # Accepted iterations as the OLD engine wrote them: new_program_idx
+            # is present, but there is no proposal_accepted key at all.
+            {"i": 0, "new_program_idx": 1},
+            {"i": 1},  # rejected iteration: no new_program_idx
+            {"i": 2, "new_program_idx": 2},
+        ],
+    }
+    state_mod.GEPAState._upgrade_state_dict(d)
+    # candidate 1 discovered at trace i=0 → "1"; candidate 2 at i=2 → "3".
+    # Neither should fall back to the "-1" sentinel.
+    assert d["iteration_ids_by_candidate_idx"] == ["seed", "1", "3"]
+    assert "-1" not in d["iteration_ids_by_candidate_idx"]
+
+
 def test_existing_adapters_lack_adapter_state_methods():
     """DefaultAdapter doesn't define get/set_adapter_state — duck typing is safe."""
     from gepa.adapters.default_adapter.default_adapter import DefaultAdapter


### PR DESCRIPTION
Surgical fixes for the P1/P2 findings from the review of `cdfcc8fb → HEAD`, plus a few closely-related batch-eval edge cases. Each fix ships with a regression test. No behavior change on the default (non-`write_agent_state`, single-proposal) path.

## `write_agent_state` (opt-in artifact tree)

- **P1 — state migration.** `_upgrade_state_dict` keyed the legacy candidate→iteration map off `proposal_accepted`, but pre-schema-6 traces never wrote that flag. Every legacy candidate was skipped and mapped to the sentinel `"-1"` on resume. Now keyed off `new_program_idx` (which every accepted iteration stamped).
- **P2 — multi-accept archival (bigger than it looks, but still correctly P2).** A multi-proposal iteration can accept more than one candidate, but `_save_iteration_dirs` anchored them all at a single `iterations/<id>/`, so their `meta`/`components`/`val_scores`/`outputs` overwrote each other and only the last survived. Now emits **one dir per accepted candidate** — the first keeps the iteration id (back-compat: agents still find the primary accepted candidate at `iterations/<iteration_id>/`), the rest get suffixed ids — and each accepted candidate gets its own anchor in the accept loop.
- **P2 — merge-accepted path.** The merge path never stamped `proposal_accepted` on the trace entry, so the agent-state writer saw `accepted=None` and skipped the merged candidate's `components`/`val_scores`.

**Severity note on `write_agent_state`:** these are real bugs but correctly **P2, not major** — the feature is opt-in (default OFF), only the multi-accept case needs the non-default multi-proposal path, and none of this corrupts returned optimization results — only the debug artifact tree.

## `best_of_n` engine

- **P1 — over-reporting on budget exhaustion.** When the eval budget ran out mid-dataset-loop, `BudgetExhausted` escaped `run()` and the api fallback reported `server.best_score` (the single highest *per-example* score) instead of the engine's candidate-aggregate (mean-over-dataset) best. Now caught: discard the partial candidate, return the best fully-evaluated one.
- **val-only task crash.** A task with a `val_set` but no `train_set` took the no-example `server.evaluate(candidate)` branch, which calls the dataset evaluator with no example → `TypeError`. Now scores over `train_set or val_set`.

## `eval_server`

- **Unlocked candidate-id allocation.** `_register_candidate` did an unlocked read-modify-write of `_next_candidate_id` / `_candidate_registry`. `log_progress` can be called concurrently (HTTP handlers, batched valset evals), so this could hand out duplicate ids or corrupt the registry. Allocation now happens under `self._lock`; file I/O stays outside the lock (own `_io_lock`), so no locks nest and there's no ordering hazard — downside-free.

## `optimize_anything` adapter

- **Transient-failure warm-start poison.** A transient whole-batch failure (`raise_on_exception=False`) records a placeholder `0.0`. That was folded into the best-evals warm-start history, seeding future proposals with a fake zero-score "best" example. Now skipped on **both** poison sites: the no-refiner batch path (`_assemble_no_refiner_batch`) and the refiner singleton path (`_evaluate_single_with_refinement`, reachable when only a `batch_evaluator` exists).

## Cleanup / notes (no functional change)

- Docstring in `claude_code_agent` dropped its `num_parallel_proposals > 1` reference — that knob was removed and fully superseded by the multi-proposal `SamplingStrategy` machinery (`IndependentSampling(n)` is the verbatim replacement). No shim needed; it's fully redundant.

## Tests

New regression tests: `test_best_of_n_engine.py` (budget over-report + val-only), `test_eval_server_register.py` (concurrent id allocation uniqueness + idempotency), warm-start poison on both paths (`test_batch_evaluator_user_fn.py`), migration without the accepted flag (`test_state.py`), and one-dir-per-accepted-candidate (`test_multi_proposal_invariants.py`).

Full suite: **608 passed, 4 skipped**. `ruff` and `pyright` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)