### PR TITLE
fix(oa): avoid AutoResearch subprocess deadlocks

### DIFF
--- a/src/gepa/oa/engines/autoresearch.py
+++ b/src/gepa/oa/engines/autoresearch.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import signal
 import subprocess
 import tempfile
 import time
@@ -99,6 +100,74 @@ _RALPH_SAFETY_ITERATION_CAP = 1000
 _BUDGET_EXHAUSTION_GRACE_SECONDS = 120.0
 
 _BUDGET_EXHAUSTED_MARKER = "BUDGET_EXHAUSTED"
+
+
+@dataclass
+class _RunningClaudeProcess:
+    proc: subprocess.Popen[str]
+    stdout_file: Any
+    stderr_file: Any
+
+
+def _start_claude_process(cmd: list[str], work_dir: Path, env: dict[str, str]) -> _RunningClaudeProcess:
+    stdout_file = tempfile.TemporaryFile(mode="w+t", encoding="utf-8")
+    stderr_file = tempfile.TemporaryFile(mode="w+t", encoding="utf-8")
+    popen_kwargs: dict[str, Any] = {
+        "cwd": str(work_dir),
+        "env": env,
+        "stdout": stdout_file,
+        "stderr": stderr_file,
+        "text": True,
+    }
+    if os.name == "posix":
+        popen_kwargs["start_new_session"] = True
+    try:
+        proc = subprocess.Popen(cmd, **popen_kwargs)
+    except BaseException:
+        stdout_file.close()
+        stderr_file.close()
+        raise
+    return _RunningClaudeProcess(proc, stdout_file, stderr_file)
+
+
+def _collect_claude_output(running: _RunningClaudeProcess) -> tuple[str, str]:
+    try:
+        running.stdout_file.seek(0)
+        running.stderr_file.seek(0)
+        stdout = running.stdout_file.read()
+        stderr = running.stderr_file.read()
+    finally:
+        running.stdout_file.close()
+        running.stderr_file.close()
+    if (stdout or stderr) or hasattr(running.proc, "wait"):
+        return stdout, stderr
+    stdout, stderr = running.proc.communicate()
+    return stdout or "", stderr or ""
+
+
+def _signal_claude_process(proc: subprocess.Popen[str], sig: int) -> None:
+    if os.name == "posix" and getattr(proc, "pid", None) is not None:
+        try:
+            os.killpg(proc.pid, sig)
+        except ProcessLookupError:
+            pass
+        return
+    if sig == signal.SIGTERM:
+        proc.terminate()
+    else:
+        proc.kill()
+
+
+def _terminate_claude_process(running: _RunningClaudeProcess) -> tuple[str, str]:
+    proc = running.proc
+    _signal_claude_process(proc, signal.SIGTERM)
+    if hasattr(proc, "wait"):
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            _signal_claude_process(proc, signal.SIGKILL)
+            proc.wait()
+    return _collect_claude_output(running)
 
 
 EVAL_SCRIPT_SINGLE = """\
@@ -605,14 +674,8 @@ class AutoResearchEngine:
             cmd.extend(["--max-budget-usd", f"{remaining:.6f}"])
         cmd.append(prompt)
 
-        proc = subprocess.Popen(
-            cmd,
-            cwd=str(work_dir),
-            env=env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
+        running = _start_claude_process(cmd, work_dir, env)
+        proc = running.proc
         exhausted_since: float | None = None
         last_eval_used = budget.used
         last_eval_time = time.monotonic()
@@ -621,12 +684,7 @@ class AutoResearchEngine:
                 last_eval_used = budget.used
                 last_eval_time = time.monotonic()
             if self.max_no_eval_seconds is not None and time.monotonic() - last_eval_time >= self.max_no_eval_seconds:
-                proc.terminate()
-                try:
-                    stdout, stderr = proc.communicate(timeout=5)
-                except subprocess.TimeoutExpired:
-                    proc.kill()
-                    stdout, stderr = proc.communicate()
+                stdout, stderr = _terminate_claude_process(running)
                 stderr = (
                     (stderr or "")
                     + f"\nNO_EVAL_PROGRESS: terminated Claude Code after {self.max_no_eval_seconds:.1f}s without eval progress.\n"
@@ -636,19 +694,14 @@ class AutoResearchEngine:
                 if exhausted_since is None:
                     exhausted_since = time.monotonic()
                 elif time.monotonic() - exhausted_since >= _BUDGET_EXHAUSTION_GRACE_SECONDS:
-                    proc.terminate()
-                    try:
-                        stdout, stderr = proc.communicate(timeout=5)
-                    except subprocess.TimeoutExpired:
-                        proc.kill()
-                        stdout, stderr = proc.communicate()
+                    stdout, stderr = _terminate_claude_process(running)
                     stderr = (
                         stderr or ""
                     ) + "\nBUDGET_EXHAUSTED: terminated Claude Code after eval budget was exhausted.\n"
                     return subprocess.CompletedProcess(cmd, proc.returncode, stdout or "", stderr)
             time.sleep(1.0)
 
-        stdout, stderr = proc.communicate()
+        stdout, stderr = _collect_claude_output(running)
         return subprocess.CompletedProcess(cmd, proc.returncode, stdout or "", stderr or "")
 
     def _has_budget_headroom(self, server: EvalServer, adapter_cost: float) -> bool:

--- a/tests/test_optimize_anything_autoresearch_engine.py
+++ b/tests/test_optimize_anything_autoresearch_engine.py
@@ -1,4 +1,10 @@
 import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import patch
 
@@ -44,6 +50,168 @@ class _FakePopen:
 
     def kill(self) -> None:
         pass
+
+
+class _HangingFakePopen(_FakePopen):
+    def __init__(self, stdout: str = "", stderr: str = "") -> None:
+        super().__init__(-15, stdout, stderr)
+        self._running = True
+
+    def poll(self) -> int | None:
+        return None if self._running else self.returncode
+
+    def terminate(self) -> None:
+        self._running = False
+
+    def kill(self) -> None:
+        self._running = False
+
+
+def _engine_with_no_eval_watchdog(seconds: float) -> AutoResearchEngine:
+    return AutoResearchEngine(
+        OptimizeAnythingConfig(
+            engine="autoresearch",
+            sandbox=False,
+            engine_config={"ralph": False, "max_no_eval_seconds": seconds},
+        )
+    )
+
+
+def _run_once(engine: AutoResearchEngine, work_dir: Path, budget: BudgetTracker) -> subprocess.CompletedProcess[str]:
+    return engine._run_claude(
+        work_dir=work_dir,
+        session_id="test-session",
+        prompt="test prompt",
+        budget=budget,
+        adapter_cost=0.0,
+        resume=False,
+        env=dict(os.environ),
+    )
+
+
+def _fast_sleep(monkeypatch: pytest.MonkeyPatch) -> Callable[[float], None]:
+    real_sleep = time.sleep
+    monkeypatch.setattr("gepa.oa.engines.autoresearch.time.sleep", lambda _: real_sleep(0.01))
+    return real_sleep
+
+
+def test_autoresearch_drains_large_stdout_and_stderr_while_running(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output_size = 256 * 1024
+    original_popen = subprocess.Popen
+    child_command = [
+        sys.executable,
+        "-c",
+        (
+            "import sys; "
+            f"sys.stdout.write('o' * {output_size}); sys.stdout.flush(); "
+            f"sys.stderr.write('e' * {output_size}); sys.stderr.flush()"
+        ),
+    ]
+
+    def launch_child(_: list[str], **kwargs: object) -> subprocess.Popen[str]:
+        return original_popen(child_command, **kwargs)
+
+    _fast_sleep(monkeypatch)
+    engine = _engine_with_no_eval_watchdog(1.0)
+    with patch("gepa.oa.engines.autoresearch.subprocess.Popen", side_effect=launch_child):
+        completed = _run_once(engine, tmp_path, BudgetTracker(max_evals=1))
+
+    assert completed.returncode == 0, (len(completed.stdout), len(completed.stderr))
+    assert completed.stdout == "o" * output_size
+    assert completed.stderr == "e" * output_size
+
+
+@pytest.mark.skipif(os.name != "posix", reason="process-group signalling is POSIX-specific")
+def test_autoresearch_watchdog_terminates_posix_process_group(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    grandchild_pid_file = tmp_path / "grandchild.pid"
+    grandchild_alive_file = tmp_path / "grandchild.alive"
+    original_popen = subprocess.Popen
+    grandchild_command = [
+        sys.executable,
+        "-c",
+        (
+            "import pathlib, time; "
+            "time.sleep(1); "
+            f"pathlib.Path({str(grandchild_alive_file)!r}).write_text('alive'); "
+            "time.sleep(30)"
+        ),
+    ]
+    child_command = [
+        sys.executable,
+        "-c",
+        (
+            "import pathlib, subprocess, sys, time; "
+            f"pid = subprocess.Popen({grandchild_command!r}).pid; "
+            f"pathlib.Path({str(grandchild_pid_file)!r}).write_text(str(pid)); "
+            "time.sleep(30)"
+        ),
+    ]
+
+    def launch_child(_: list[str], **kwargs: object) -> subprocess.Popen[str]:
+        proc = original_popen(child_command, **kwargs)
+        deadline = time.monotonic() + 2.0
+        while not grandchild_pid_file.exists() and time.monotonic() < deadline:
+            real_sleep(0.01)
+        return proc
+
+    real_sleep = _fast_sleep(monkeypatch)
+    engine = _engine_with_no_eval_watchdog(0.1)
+    try:
+        started = time.monotonic()
+        with patch("gepa.oa.engines.autoresearch.subprocess.Popen", side_effect=launch_child):
+            completed = _run_once(engine, tmp_path, BudgetTracker(max_evals=1))
+        elapsed = time.monotonic() - started
+        assert grandchild_pid_file.exists()
+        assert completed.returncode != 0
+        assert elapsed < 2.0
+        real_sleep(1.1)
+        assert not grandchild_alive_file.exists()
+    finally:
+        if grandchild_pid_file.exists():
+            try:
+                os.kill(int(grandchild_pid_file.read_text()), signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+
+def test_autoresearch_no_eval_watchdog_preserves_reason_string(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = _engine_with_no_eval_watchdog(0.0)
+    _fast_sleep(monkeypatch)
+    with patch("gepa.oa.engines.autoresearch.subprocess.Popen", return_value=_HangingFakePopen()):
+        completed = _run_once(engine, tmp_path, BudgetTracker(max_evals=1))
+
+    assert "NO_EVAL_PROGRESS" in completed.stderr
+
+
+def test_autoresearch_budget_watchdog_preserves_reason_string(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    budget = BudgetTracker(max_evals=1)
+    budget.record(0.0)
+    engine = _engine_with_no_eval_watchdog(60.0)
+    _fast_sleep(monkeypatch)
+    monkeypatch.setattr("gepa.oa.engines.autoresearch._BUDGET_EXHAUSTION_GRACE_SECONDS", 0.0)
+    with patch("gepa.oa.engines.autoresearch.subprocess.Popen", return_value=_HangingFakePopen()):
+        completed = _run_once(engine, tmp_path, budget)
+
+    assert "BUDGET_EXHAUSTED" in completed.stderr
+
+
+def test_autoresearch_uses_direct_process_fallback_on_windows(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = _engine_with_no_eval_watchdog(0.0)
+    fake = _HangingFakePopen()
+    captured_kwargs: dict[str, object] = {}
+
+    def capture_popen(_: list[str], **kwargs: object) -> _HangingFakePopen:
+        captured_kwargs.update(kwargs)
+        return fake
+
+    _fast_sleep(monkeypatch)
+    monkeypatch.setattr("gepa.oa.engines.autoresearch.os.name", "nt")
+    with patch("gepa.oa.engines.autoresearch.subprocess.Popen", side_effect=capture_popen):
+        _run_once(engine, tmp_path, BudgetTracker(max_evals=1))
+
+    assert "start_new_session" not in captured_kwargs
 
 
 def test_autoresearch_engine_ralph_resumes_with_remaining_budget(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- prevent AutoResearch agent subprocesses from deadlocking when stdout or stderr exceeds the OS pipe buffer
- terminate the whole POSIX subprocess group when the no-eval or exhausted-budget watchdog fires
- preserve captured output and existing watchdog reason markers
- retain direct-process termination as the Windows fallback

## Root cause

`AutoResearchEngine._run_claude` launched the agent with `stdout=PIPE` and
`stderr=PIPE`, but did not drain either stream until `poll()` reported that the
process had exited. A sufficiently verbose agent could therefore fill a pipe,
block before exiting, and leave the parent polling forever.

The watchdog paths also terminated only the immediate `claude` process. Child
processes could survive the watchdog and continue running after the engine had
returned.

## Implementation

Agent output is redirected into temporary files, removing pipe backpressure
without adding reader threads. On POSIX, the agent starts in a new session and
watchdog termination signals its process group, escalating from `SIGTERM` to
`SIGKILL` after the existing grace period. Windows keeps direct
`terminate()`/`kill()` behavior.

## Validation

- `python -m pytest -q tests/test_optimize_anything_autoresearch_engine.py`
  - 11 passed
- `python -m pytest -q tests/test_optimize_anything_*.py`
  - 39 passed
- `python -m ruff check src/gepa/oa/engines/autoresearch.py tests/test_optimize_anything_autoresearch_engine.py`
  - passed
- `python -m pyright src/gepa/oa/engines/autoresearch.py`
  - 0 errors

The new regression coverage exercises:

- simultaneous 256 KiB stdout and stderr output
- POSIX descendant-process termination
- preserved no-eval and budget-exhaustion diagnostics
- the Windows direct-process fallback
