### PR TITLE
fix(oa): return GEPAResult when optimize_anything config is omitted

### DIFF
--- a/src/gepa/oa/ensemble.py
+++ b/src/gepa/oa/ensemble.py
@@ -80,15 +80,20 @@ def optimize_anything_from_task(
         config = OptimizeAnythingConfig()
     if config.name is None:
         config = replace(config, name=task.name)
-    return optimize_anything(
-        task.seed_candidate,
-        evaluator=evaluate,
-        dataset=task.train_set,
-        valset=task.val_set,
-        objective=task.objective,
-        background=task.background,
-        test_set=task.test_set,
-        config=config,
+    # config is always a concrete OptimizeAnythingConfig here, so
+    # optimize_anything returns Result (not the GEPAResult union arm).
+    return cast(
+        Result,
+        optimize_anything(
+            task.seed_candidate,
+            evaluator=evaluate,
+            dataset=task.train_set,
+            valset=task.val_set,
+            objective=task.objective,
+            background=task.background,
+            test_set=task.test_set,
+            config=config,
+        ),
     )
 
 

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -101,7 +101,7 @@ def optimize_anything(
     background: str | None = None,
     test_set: list[Any] | None = None,
     config: OptimizeAnythingConfig | None = None,
-) -> Result:
+) -> Result | GEPAResult:
     """Optimize a text candidate (prompt, code, instructions, ...) against a score.
 
     The signature mirrors :func:`gepa.gepa_launcher.optimize_anything`
@@ -150,32 +150,32 @@ def optimize_anything(
             under ``result.metadata["test_score(s)"]`` (optimized) and
             ``result.metadata["baseline_test_score(s)"]`` (seed).
         config: Engine selection, run ``name``, budgets, output directory, and
-            engine-specific options. Defaults to ``OptimizeAnythingConfig()``;
-            at least one of ``config.max_evals`` or ``config.max_token_cost``
-            must be set. When ``config.name`` is omitted, a name is generated
-            from the engine, a short uuid, and a timestamp. A legacy
-            :class:`GEPAConfig` is also accepted and converted; the run uses
-            the gepa engine and returns the launcher's
-            :class:`~gepa.core.result.GEPAResult`.
+            engine-specific options. Defaults to ``OptimizeAnythingConfig()``
+            when omitted. Pass an explicit :class:`OptimizeAnythingConfig` to
+            get a :class:`Result`; omit ``config`` or pass a legacy
+            :class:`GEPAConfig` to get a
+            :class:`~gepa.core.result.GEPAResult`. At least one of
+            ``config.max_evals`` or ``config.max_token_cost`` must be set.
+            When ``config.name`` is omitted, a name is generated from the
+            engine, a short uuid, and a timestamp.
 
     Returns:
-        A :class:`Result` with ``best_candidate``, ``best_score``,
-        ``total_evals``, ``eval_log``, and ``metadata`` — or, when ``config``
-        is a legacy :class:`GEPAConfig`, the underlying
+        A :class:`Result` (``best_candidate``, ``best_score``, ``total_evals``,
+        ``eval_log``, ``metadata``) for an explicit
+        :class:`OptimizeAnythingConfig`, otherwise a
         :class:`~gepa.core.result.GEPAResult` (``candidates``, ``best_idx``,
-        ``val_aggregate_scores``, ...) so v0.1.x callers get the result shape
-        they were written against.
+        ``val_aggregate_scores``, ...) for the no-config / legacy path.
     """
-    legacy_config = False
+    return_gepa_result = not isinstance(config, OptimizeAnythingConfig)
+    if return_gepa_result and test_set is not None:
+        raise ValueError(
+            "test_set requires an explicit OptimizeAnythingConfig; "
+            "the GEPAResult return path has no place for held-out test scores."
+        )
     if config is None:
         config = OptimizeAnythingConfig()
-    elif not isinstance(config, OptimizeAnythingConfig):
-        if test_set is not None:
-            raise ValueError(
-                "test_set requires an OptimizeAnythingConfig; the legacy GEPAConfig API has no held-out test pass."
-            )
+    elif return_gepa_result:
         config = _from_legacy_config(config)
-        legacy_config = True
     if evaluator is None and batch_evaluator is None:
         raise ValueError("Provide evaluator=, batch_evaluator=, or both.")
     if config.max_evals is None and config.max_token_cost is None:
@@ -208,14 +208,9 @@ def optimize_anything(
         output_dir=output_dir,
     )
     result = _run_engine(server, engine, owns_server=True)
-    if legacy_config:
-        # v0.1.x callers always get the launcher's result type back — the gepa
-        # engine stashes the underlying GEPAResult in the result metadata. If
-        # the eval budget died before GEPA core saved any state (e.g. budget
-        # smaller than the valset), synthesize a single-candidate snapshot.
-        # The public signature advertises only the new API; legacy
-        # GEPAConfig-in/GEPAResult-out is a runtime affordance, so the legacy
-        # result rides out through an Any-typed local.
+    if return_gepa_result:
+        # Prefer the GEPAResult stashed by the gepa engine; if the budget died
+        # before any state was saved, synthesize a single-candidate snapshot.
         legacy_result: Any = result.metadata.get("gepa_result") or _legacy_result_from(result, seed_candidate)
         return legacy_result
     return result

--- a/tests/test_optimize_anything_gepa_config.py
+++ b/tests/test_optimize_anything_gepa_config.py
@@ -77,6 +77,71 @@ def test_legacy_gepa_config_call_returns_gepa_result():
     assert result.val_aggregate_scores
 
 
+def test_no_config_returns_gepa_result(monkeypatch):
+    """``optimize_anything(seed, evaluator=fn)`` with config omitted/None must
+    return ``GEPAResult`` so simple-API callers can use ``val_aggregate_scores``,
+    ``best_idx``, ``candidates``, and ``to_dict()`` (issue #409 finding #1)."""
+    from gepa.core.result import GEPAResult
+    from gepa.oa.engine import Result
+    from gepa.optimize_anything import optimize_anything
+
+    stashed = GEPAResult(
+        candidates=[{"current_candidate": "improved"}],
+        parents=[[None]],
+        val_aggregate_scores=[0.42],
+        val_subscores=[{}],
+        per_val_instance_best_candidates={},
+        discovery_eval_counts=[1],
+        total_metric_calls=1,
+        _str_candidate_key="current_candidate",
+    )
+
+    def _fake_run_engine(server, engine, *, owns_server):
+        return Result(
+            best_candidate="improved",
+            best_score=0.42,
+            total_evals=1,
+            metadata={"gepa_result": stashed},
+        )
+
+    monkeypatch.setattr("gepa.optimize_anything._run_engine", _fake_run_engine)
+
+    result = optimize_anything(
+        seed_candidate="short",
+        evaluator=_evaluator,
+        objective="maximize length",
+    )
+
+    assert isinstance(result, GEPAResult)
+    assert result is stashed
+    assert result.best_candidate == "improved"
+    assert result.best_idx == 0
+    assert result.candidates == [{"current_candidate": "improved"}]
+    assert result.val_aggregate_scores == [0.42]
+    assert isinstance(result.to_dict(), dict)
+
+
+def test_explicit_optimize_anything_config_still_returns_result():
+    """An explicit ``OptimizeAnythingConfig`` keeps the new ``Result`` shape."""
+    from gepa.oa.engine import Result
+    from gepa.optimize_anything import optimize_anything
+
+    result = optimize_anything(
+        seed_candidate="short",
+        evaluator=_evaluator,
+        objective="maximize length",
+        config=OptimizeAnythingConfig(
+            engine="gepa",
+            max_evals=4,
+            engine_config={"reflection": {"reflection_lm": _FakeLM()}},
+        ),
+    )
+
+    assert isinstance(result, Result)
+    assert result.best_score > 0.0
+    assert not hasattr(result, "val_aggregate_scores")
+
+
 def test_legacy_gepa_config_returns_gepa_result_even_when_budget_dies_early():
     """Budget smaller than the seed's valset pass: the engine has no GEPAResult
     to stash, so the legacy path synthesizes a single-candidate one — legacy
@@ -102,8 +167,8 @@ def test_legacy_gepa_config_returns_gepa_result_even_when_budget_dies_early():
 
 
 def test_legacy_gepa_config_rejects_test_set():
-    """``test_set`` is a new-API feature; combining it with a legacy
-    ``GEPAConfig`` fails fast instead of silently dropping the test scores."""
+    """``test_set`` needs an explicit OptimizeAnythingConfig; GEPAConfig returns
+    ``GEPAResult``, which has no place for held-out test scores."""
     from gepa.optimize_anything import GEPAConfig, optimize_anything
 
     with pytest.raises(ValueError, match="test_set"):
@@ -112,6 +177,19 @@ def test_legacy_gepa_config_rejects_test_set():
             evaluator=_evaluator,
             test_set=["x"],
             config=GEPAConfig(),
+        )
+
+
+def test_no_config_rejects_test_set():
+    """``test_set`` with config omitted also fails fast: that path returns
+    ``GEPAResult``, which has no place for held-out test scores."""
+    from gepa.optimize_anything import optimize_anything
+
+    with pytest.raises(ValueError, match="test_set"):
+        optimize_anything(
+            seed_candidate="short",
+            evaluator=_evaluator,
+            test_set=["x"],
         )
 
 


### PR DESCRIPTION
## What & why

`optimize_anything(seed, evaluator=fn)` with no config was returning the new `Result`, so `.val_aggregate_scores`, `.best_idx`, `.candidates`, and `.to_dict()` broke for v0.1.x callers (#409 finding 1). Only an explicit `GEPAConfig` took the `GEPAResult` path.

Omitted config now results in `GEPAResult` the same way, and `test_set` is rejected on that path. Explicit `OptimizeAnythingConfig` still returns `Result`.

Part of #409

## Tests

- `test_no_config_returns_gepa_result`
- `test_no_config_rejects_test_set`
- `uv run pytest tests/test_optimize_anything_gepa_config.py`