### PR TITLE
fix(oa): persist final cost summary

### DIFF
--- a/src/gepa/oa/engines/autoresearch.py
+++ b/src/gepa/oa/engines/autoresearch.py
@@ -540,7 +540,8 @@ class AutoResearchEngine:
 
         adapter_cost = 0.0
         ralph_iterations = 1
-        invocations: list[dict[str, float | int | None]] = []
+        invocations: list[dict[str, float | int | str | None]] = []
+        adapter_cost_statuses: list[str] = []
 
         proc = self._run_claude(
             work_dir=work_dir,
@@ -563,10 +564,12 @@ class AutoResearchEngine:
                 f"stdout_tail={_tail_text(proc.stdout)!r} "
                 f"stderr_tail={_tail_text(proc.stderr)!r}"
             )
-        iter_cost = _extract_claude_cost(proc.stdout)
+        iter_cost, iter_status = _extract_claude_cost_and_status(proc.stdout)
         adapter_cost += iter_cost
-        invocations.append({"cost": iter_cost, "score": server.best_score, "returncode": proc.returncode})
-
+        adapter_cost_statuses.append(iter_status)
+        invocations.append(
+            {"cost": iter_cost, "status": iter_status, "score": server.best_score, "returncode": proc.returncode}
+        )
         if self.ralph:
             while ralph_iterations < _RALPH_SAFETY_ITERATION_CAP:
                 if _saw_budget_exhausted(proc):
@@ -590,9 +593,17 @@ class AutoResearchEngine:
                     resume=True,
                     env=env,
                 )
-                iter_cost = _extract_claude_cost(proc.stdout)
+                iter_cost, iter_status = _extract_claude_cost_and_status(proc.stdout)
                 adapter_cost += iter_cost
-                invocations.append({"cost": iter_cost, "score": server.best_score, "returncode": proc.returncode})
+                adapter_cost_statuses.append(iter_status)
+                invocations.append(
+                    {
+                        "cost": iter_cost,
+                        "status": iter_status,
+                        "score": server.best_score,
+                        "returncode": proc.returncode,
+                    }
+                )
                 if _saw_budget_exhausted(proc):
                     break
                 if proc.returncode != 0:
@@ -619,6 +630,7 @@ class AutoResearchEngine:
             eval_log=server.eval_log,
             metadata={
                 "adapter_cost": adapter_cost,
+                "adapter_cost_status": _combined_adapter_cost_status(adapter_cost_statuses),
                 "session_id": session_id,
                 "work_dir": str(work_dir),
                 "ralph_iterations": ralph_iterations,
@@ -798,11 +810,23 @@ def _best_aggregate_candidate(server: EvalServer) -> tuple[str, float] | None:
 
 
 def _extract_claude_cost(stdout: str) -> float:
+    return _extract_claude_cost_and_status(stdout)[0]
+
+
+def _extract_claude_cost_and_status(stdout: str) -> tuple[float, str]:
     stdout = (stdout or "").strip()
     if not stdout:
-        return 0.0
+        return 0.0, "unknown"
     try:
         payload = json.loads(stdout)
-        return float(payload.get("total_cost_usd", 0.0) or 0.0)
+        cost = float(payload.get("total_cost_usd", 0.0) or 0.0)
     except (json.JSONDecodeError, ValueError, TypeError):
-        return 0.0
+        return 0.0, "unknown"
+    status = payload.get("adapter_cost_status")
+    return cost, status if isinstance(status, str) and status else "unknown"
+
+
+def _combined_adapter_cost_status(statuses: list[str]) -> str:
+    if not statuses:
+        return "unknown"
+    return statuses[0] if all(status == statuses[0] for status in statuses) else "mixed"

--- a/src/gepa/oa/engines/meta_harness.py
+++ b/src/gepa/oa/engines/meta_harness.py
@@ -289,7 +289,7 @@ def _run_proposer(
     log_dir: Path,
     max_thinking_tokens: int | None = None,
     sandbox: bool = True,
-) -> tuple[int, float, str]:
+) -> tuple[int, float, str, str]:
     state = work_dir / "state"
     prompt = (
         f"Run iteration {iteration} of the meta-harness evolution loop. "
@@ -363,7 +363,8 @@ def _run_proposer(
             indent=2,
         )
     )
-    return proc.returncode, cost_usd, session_id
+    status = result_payload.get("adapter_cost_status")
+    return proc.returncode, cost_usd, session_id, status if isinstance(status, str) and status else "unknown"
 
 
 def _parse_proposer_result(stdout: str) -> tuple[float, dict[str, Any]]:
@@ -670,6 +671,7 @@ class MetaHarnessEngine:
         sessions_dir.mkdir(parents=True, exist_ok=True)
 
         session_ids: list[str] = []
+        adapter_cost_statuses: list[str] = []
         total_proposer_cost = 0.0
         cap = self.max_iterations if self.max_iterations is not None else 50
 
@@ -700,7 +702,7 @@ class MetaHarnessEngine:
                 pending_path.unlink()
 
             propose_start = time.time()
-            exit_code, cost, session_id = _run_proposer(
+            exit_code, cost, session_id, adapter_cost_status = _run_proposer(
                 work_dir=work_dir,
                 iteration=iteration,
                 model=self.model,
@@ -715,6 +717,7 @@ class MetaHarnessEngine:
             propose_time = time.time() - propose_start
             total_proposer_cost += cost
             session_ids.append(session_id)
+            adapter_cost_statuses.append(adapter_cost_status)
 
             _log(
                 f"  {_cyan('proposer')} exit={exit_code} cost=${cost:.3f} "
@@ -913,6 +916,7 @@ class MetaHarnessEngine:
         if best_score is None:
             best_score = server.best_score
 
+        adapter_cost_status = _combined_adapter_cost_status(adapter_cost_statuses)
         return Result(
             best_candidate=best_candidate,
             best_score=best_score if best_score is not None else server.best_score,
@@ -920,6 +924,7 @@ class MetaHarnessEngine:
             eval_log=server.eval_log,
             metadata={
                 "adapter_cost": total_proposer_cost,
+                "adapter_cost_status": adapter_cost_status,
                 "meta_harness": {
                     "iterations_run": iteration,
                     "stop_reason": stop_reason,
@@ -984,6 +989,12 @@ class MetaHarnessEngine:
 
 
 _SLUG_RE = re.compile(r"[^A-Za-z0-9-]")
+
+
+def _combined_adapter_cost_status(statuses: list[str]) -> str:
+    if not statuses:
+        return "unknown"
+    return statuses[0] if all(status == statuses[0] for status in statuses) else "mixed"
 
 
 def _claude_project_slug(cwd: Path) -> str:

--- a/src/gepa/oa/eval_server.py
+++ b/src/gepa/oa/eval_server.py
@@ -585,6 +585,30 @@ class EvalServer:
             except OSError:
                 pass
 
+    def persist_final_summary(
+        self,
+        *,
+        adapter_cost: float,
+        total_cost: float,
+        adapter_cost_status: str = "unknown",
+    ) -> None:
+        """Atomically replace the live eval summary with final run costs."""
+        if self.output_dir is None:
+            return
+        with self._lock:
+            snapshot = self._snapshot()
+        snapshot.update(
+            {
+                "eval_cost_usd": snapshot["total_cost"],
+                "adapter_cost_usd": adapter_cost,
+                "total_cost_usd": total_cost,
+                "total_cost": total_cost,
+                "adapter_cost_status": adapter_cost_status,
+            }
+        )
+        with self._io_lock:
+            self._write_summary(snapshot)
+
     def _write_eval_record(self, idx: int, entry: dict[str, Any], candidate: str, info: dict[str, Any] | None) -> None:
         assert self._evals_dir is not None
         record = {**entry, "timestamp": time.time(), "candidate": candidate, "info": info}

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -297,10 +297,19 @@ def _run_engine(server: EvalServer, engine: Engine, *, owns_server: bool) -> Res
     result.metadata["budget"] = server.budget.status()
     adapter_cost = float(result.metadata.get("adapter_cost", 0.0))
     result.metadata["total_cost"] = server.total_cost + adapter_cost
+    adapter_cost_status = result.metadata.get("adapter_cost_status", "unknown")
+    if not isinstance(adapter_cost_status, str) or not adapter_cost_status:
+        adapter_cost_status = "unknown"
+    result.metadata["adapter_cost_status"] = adapter_cost_status
     result.metadata["progress_log"] = server.progress_log
     result.metadata["engine"] = engine.name
     if server.output_dir is not None:
         result.metadata["output_dir"] = str(server.output_dir)
+        server.persist_final_summary(
+            adapter_cost=adapter_cost,
+            total_cost=result.metadata["total_cost"],
+            adapter_cost_status=adapter_cost_status,
+        )
 
     try:
         engine.process_result(result, server.output_dir)

--- a/tests/test_optimize_anything_autoresearch_engine.py
+++ b/tests/test_optimize_anything_autoresearch_engine.py
@@ -13,7 +13,9 @@ import pytest
 from gepa.oa.budget import BudgetTracker
 from gepa.oa.config import OptimizeAnythingConfig
 from gepa.oa.engines.autoresearch import AutoResearchEngine
+from gepa.oa.eval_server import EvalServer
 from gepa.oa.task import Task
+from gepa.optimize_anything import _run_engine
 
 
 @pytest.fixture(autouse=True)
@@ -338,6 +340,61 @@ def test_autoresearch_engine_counts_failed_resume_cost(tmp_path: Path) -> None:
     assert len(calls) == 2
     assert result.metadata["adapter_cost"] == 0.30000000000000004
     assert result.metadata["ralph_iterations"] == 1
+
+
+def test_autoresearch_persists_final_cost_summary_after_failed_resume(tmp_path: Path) -> None:
+    output_dir = tmp_path / "output"
+    task = Task(name="smoke", seed_candidate="seed")
+    server = EvalServer(
+        task,
+        lambda candidate: (1.0, {"cost": 0.05}),
+        BudgetTracker(max_evals=5),
+        output_dir=output_dir,
+    )
+    server.evaluate("seed")
+    calls = 0
+
+    def fake_popen(cmd: list[str], **kwargs: object) -> _FakePopen:
+        nonlocal calls
+        calls += 1
+        Path(str(kwargs["cwd"]), "best_candidate.txt").write_text("candidate")
+        if calls == 1:
+            return _FakePopen(
+                0,
+                json.dumps(
+                    {
+                        "total_cost_usd": 0.2,
+                        "adapter_cost_status": "standard_tier_upper_estimate_from_observed_usage",
+                    }
+                ),
+            )
+        return _FakePopen(
+            1,
+            json.dumps(
+                {
+                    "total_cost_usd": 0.1,
+                    "adapter_cost_status": "standard_tier_upper_estimate_from_observed_usage",
+                }
+            ),
+            stderr="failed",
+        )
+
+    engine = AutoResearchEngine(
+        OptimizeAnythingConfig(engine="autoresearch", sandbox=False, run_dir=str(tmp_path / "work"), engine_config={})
+    )
+
+    with patch("gepa.oa.engines.autoresearch.subprocess.Popen", side_effect=fake_popen):
+        result = _run_engine(server, engine, owns_server=True)
+
+    summary = json.loads((output_dir / "summary.json").read_text())
+    assert result.metadata["adapter_cost"] == pytest.approx(0.3)
+    assert result.metadata["adapter_cost_status"] == "standard_tier_upper_estimate_from_observed_usage"
+    assert result.metadata["total_cost"] == pytest.approx(0.35)
+    assert summary["eval_cost_usd"] == pytest.approx(0.05)
+    assert summary["adapter_cost_usd"] == pytest.approx(0.3)
+    assert summary["total_cost_usd"] == pytest.approx(result.metadata["total_cost"])
+    assert summary["total_cost"] == pytest.approx(result.metadata["total_cost"])
+    assert summary["adapter_cost_status"] == "standard_tier_upper_estimate_from_observed_usage"
 
 
 def test_autoresearch_engine_materializes_optimize_anything_handoff(tmp_path: Path) -> None:

--- a/tests/test_optimize_anything_meta_harness_engine.py
+++ b/tests/test_optimize_anything_meta_harness_engine.py
@@ -1,0 +1,63 @@
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gepa.oa.budget import BudgetTracker
+from gepa.oa.config import OptimizeAnythingConfig
+from gepa.oa.engines.meta_harness import MetaHarnessEngine
+from gepa.oa.eval_server import EvalServer
+from gepa.oa.task import Task
+from gepa.optimize_anything import _run_engine
+
+
+@pytest.fixture(autouse=True)
+def _skip_claude_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("gepa.oa.engines.meta_harness.preflight_claude_engine", lambda *a, **k: None)
+
+
+def test_meta_harness_persists_final_cost_summary_after_failed_proposer(tmp_path: Path) -> None:
+    output_dir = tmp_path / "output"
+    task = Task(name="smoke", seed_candidate="seed")
+    server = EvalServer(
+        task,
+        lambda candidate: (1.0, {"cost": 0.05}),
+        BudgetTracker(max_evals=5),
+        output_dir=output_dir,
+    )
+    server.evaluate("seed")
+    engine = MetaHarnessEngine(
+        OptimizeAnythingConfig(
+            engine="meta_harness",
+            sandbox=False,
+            run_dir=str(tmp_path / "work"),
+            engine_config={"max_iterations": 1},
+        )
+    )
+    failed_proposer = subprocess.CompletedProcess(
+        args=["claude"],
+        returncode=1,
+        stdout=json.dumps(
+            {
+                "total_cost_usd": 0.4,
+                "adapter_cost_status": "standard_tier_upper_estimate_from_observed_usage",
+            }
+        ),
+        stderr="failed",
+    )
+
+    with patch("gepa.oa.engines.meta_harness.subprocess.run", return_value=failed_proposer):
+        result = _run_engine(server, engine, owns_server=True)
+
+    summary = json.loads((output_dir / "summary.json").read_text())
+    assert result.metadata["adapter_cost"] == pytest.approx(0.4)
+    assert result.metadata["adapter_cost_status"] == "standard_tier_upper_estimate_from_observed_usage"
+    assert result.metadata["total_cost"] == pytest.approx(0.5)
+    assert result.metadata["meta_harness"]["stop_reason"] == "proposer_failed"
+    assert summary["eval_cost_usd"] == pytest.approx(0.1)
+    assert summary["adapter_cost_usd"] == pytest.approx(0.4)
+    assert summary["total_cost_usd"] == pytest.approx(result.metadata["total_cost"])
+    assert summary["total_cost"] == pytest.approx(result.metadata["total_cost"])
+    assert summary["adapter_cost_status"] == "standard_tier_upper_estimate_from_observed_usage"


### PR DESCRIPTION
## Summary

- persist final eval, adapter, and total costs for AutoResearch and MetaHarness
- preserve the adapter cost-estimate status in returned and persisted summaries
- write the final summary atomically

## Tests

- focused AutoResearch, MetaHarness, eval-server, and optimize-anything suites: 42 passed, 1 skipped
- Ruff on changed files (framework handler-name rules excluded)