### PR TITLE
feat: first-class vLLM / Hugging Face local-model support (#359)

### DIFF
--- a/docs/docs/guides/local-models-vllm.md
+++ b/docs/docs/guides/local-models-vllm.md
@@ -1,0 +1,117 @@
+# Local Models with vLLM & Hugging Face
+
+You can run GEPA entirely against **local, open-weight models** — no paid API keys — by serving a Hugging Face model through [vLLM](https://docs.vllm.ai)'s OpenAI-compatible endpoint and pointing GEPA's `LM` at it.
+
+GEPA reaches the server over plain HTTP (via LiteLLM), so **core GEPA stays dependency-free**: `vllm`/`transformers` only need to be installed on the machine *serving* the model, never in the GEPA process. The local path is fully optional and does not change any default behaviour — hosted-provider workflows keep working unchanged.
+
+## 1. Serve a model with vLLM
+
+Install vLLM in the serving environment (GPU recommended). vLLM is heavy and
+GPU/platform-specific, so it is **not** bundled into GEPA — install it directly
+on the machine that will serve the model:
+
+```bash
+pip install vllm
+```
+
+In your **GEPA / client** environment you only need GEPA's LiteLLM client (GEPA
+reaches the server over HTTP and never imports `vllm`):
+
+```bash
+pip install "gepa[vllm]"    # == gepa[full]; the LiteLLM client used to call the endpoint
+```
+
+Start an OpenAI-compatible server:
+
+```bash
+python -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct \
+    --served-model-name qwen2.5-7b-instruct \
+    --host 0.0.0.0 \
+    --port 8000
+```
+
+`--served-model-name` is the name GEPA will refer to; `--model` is the Hugging Face repo to load.
+
+## 2. Point GEPA at the endpoint
+
+Use the `make_vllm_lm` helper:
+
+```python
+from gepa.lm import make_vllm_lm
+
+lm = make_vllm_lm(
+    "qwen2.5-7b-instruct",              # the --served-model-name
+    api_base="http://localhost:8000/v1",  # include the /v1 suffix
+    api_key="EMPTY",                     # ignored by vLLM, required by the client
+)
+
+print(lm("Say hello in one word."))
+```
+
+`make_vllm_lm` is a thin convenience wrapper. The equivalent explicit form is:
+
+```python
+from gepa.lm import LM
+
+lm = LM("openai/qwen2.5-7b-instruct", api_base="http://localhost:8000/v1", api_key="EMPTY")
+```
+
+The `openai/` provider prefix routes LiteLLM to the OpenAI-compatible endpoint; `make_vllm_lm` adds it for you when it's missing.
+
+## 3. Optimize with local models
+
+The returned `LM` is a plain callable, so it works as **both** the task model and the reflection model — and you can mix local and hosted models freely:
+
+```python
+import gepa
+from gepa.lm import make_vllm_lm
+
+local_lm = make_vllm_lm("qwen2.5-7b-instruct")
+
+trainset = [
+    {"input": "What is 2+2?", "additional_context": {}, "answer": "4"},
+    {"input": "Capital of France?", "additional_context": {}, "answer": "Paris"},
+]
+
+result = gepa.optimize(
+    seed_candidate={"system_prompt": "Answer concisely."},
+    trainset=trainset,
+    task_lm=local_lm,          # vLLM-served task model
+    reflection_lm=local_lm,    # vLLM-served reflection model
+    max_metric_calls=20,
+)
+print("Best prompt:", result.best_candidate["system_prompt"])
+```
+
+**Mixed setups** work too — e.g. a local task model with a stronger hosted reflection model:
+
+```python
+result = gepa.optimize(
+    seed_candidate={"system_prompt": "Answer concisely."},
+    trainset=trainset,
+    task_lm=make_vllm_lm("qwen2.5-7b-instruct"),   # local
+    reflection_lm="openai/gpt-4o",                  # hosted (needs OPENAI_API_KEY)
+    max_metric_calls=20,
+)
+```
+
+A runnable end-to-end example lives in [`examples/vllm_huggingface/`](https://github.com/gepa-ai/gepa/tree/main/examples/vllm_huggingface).
+
+## Cost & token tracking
+
+vLLM does not report USD pricing, so `LM.total_cost` will be `0.0` for local calls. Token counts (`total_tokens_in` / `total_tokens_out`) are still populated from the server's usage response. See [Cost & Token Tracking](cost-tracking.md).
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `litellm.NotFoundError` / model not found | `LM(model=...)` must match `--served-model-name` exactly. With `make_vllm_lm`, pass the served name (the `openai/` prefix is added for you). |
+| Connection refused / 404 | Check the `/v1` suffix on `api_base` (`http://localhost:8000/v1`, not `:8000`), and that the server is up on that host/port. |
+| CUDA out of memory | Use a smaller model, lower `--gpu-memory-utilization`, or serve a quantized checkpoint (e.g. AWQ/GPTQ). |
+| 401 / gated model on server start | Authenticate to Hugging Face on the serving box (`huggingface-cli login`) for gated repos. |
+| Chat template / tokenizer errors | Pass `--chat-template` to vLLM for base models lacking a built-in template. |
+| Timeouts / overload under load | Lower adapter concurrency (`max_litellm_workers` / `max_workers`) or pass `timeout=...` through to `make_vllm_lm`. |
+
+!!! note
+    Any OpenAI-compatible server (Ollama's `/v1`, LM Studio, TGI, SGLang, …) works the same way — point `api_base` at it and use `make_vllm_lm` / `LM("openai/<name>", ...)`.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
     - Guides:
         - Guides Overview: guides/index.md
         - Quick Start: guides/quickstart.md
+        - Local Models (vLLM & Hugging Face): guides/local-models-vllm.md
         - FAQ: guides/faq.md
         - Creating Adapters: guides/adapters.md
         - Confidence-Aware Classification: guides/confidence-adapter.md

--- a/examples/vllm_huggingface/README.md
+++ b/examples/vllm_huggingface/README.md
@@ -1,0 +1,43 @@
+# GEPA with vLLM + Hugging Face (local, open-weight models)
+
+Run GEPA end-to-end against a **local** Hugging Face model served by
+[vLLM](https://docs.vllm.ai) — no paid API keys. GEPA talks to the server over
+HTTP via LiteLLM, so core GEPA stays dependency-free; `vllm` only needs to be
+installed where the model is served.
+
+See the full guide: [`docs/docs/guides/local-models-vllm.md`](../../docs/docs/guides/local-models-vllm.md).
+
+## 1. Start a vLLM server
+
+In one terminal (GPU recommended). Install vLLM directly on the serving box — it
+is heavy/GPU-specific and is deliberately **not** bundled into GEPA:
+
+```bash
+pip install vllm
+
+python -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct \
+    --served-model-name qwen2.5-7b-instruct \
+    --host 0.0.0.0 \
+    --port 8000
+```
+
+## 2. Run the example
+
+In another terminal:
+
+```bash
+uv run python examples/vllm_huggingface/main.py \
+    --served-model-name qwen2.5-7b-instruct \
+    --api-base http://localhost:8000/v1
+```
+
+Flags (all optional, sensible defaults shown):
+
+- `--served-model-name` — must match vLLM's `--served-model-name` (default `qwen2.5-7b-instruct`)
+- `--api-base` — the server's OpenAI-compatible base URL, **including `/v1`** (default `http://localhost:8000/v1`)
+- `--reflection-model` — override the reflection model (default: same local model). Pass a hosted string like `openai/gpt-4o` for a mixed setup.
+- `--max-metric-calls` — optimization budget (default `20`)
+
+The script optimizes a tiny system prompt on a toy QA task and prints the best
+prompt and score. Swap in your own `trainset` / seed prompt to adapt it.

--- a/examples/vllm_huggingface/main.py
+++ b/examples/vllm_huggingface/main.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""Optimize a prompt with GEPA using a local Hugging Face model served by vLLM.
+
+Start a vLLM OpenAI-compatible server first (see this directory's README), then::
+
+    uv run python examples/vllm_huggingface/main.py \
+        --served-model-name qwen2.5-7b-instruct \
+        --api-base http://localhost:8000/v1
+
+Core GEPA is dependency-free: this script only needs a reachable
+OpenAI-compatible endpoint. ``vllm`` itself runs in the serving process, not here.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import gepa
+from gepa.lm import make_vllm_lm
+
+# A tiny toy task for the built-in DefaultAdapter. Each example is a dict with
+# `input`, `additional_context`, and `answer` (substring-matched).
+TRAINSET = [
+    {"input": "What is 2 + 2?", "additional_context": {}, "answer": "4"},
+    {"input": "What is the capital of France?", "additional_context": {}, "answer": "Paris"},
+    {"input": "What color do you get by mixing blue and yellow?", "additional_context": {}, "answer": "green"},
+    {"input": "How many days are in a week?", "additional_context": {}, "answer": "7"},
+]
+
+SEED_PROMPT = {"system_prompt": "You are a helpful assistant. Answer the question."}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--served-model-name", default="qwen2.5-7b-instruct",
+                        help="Must match vLLM's --served-model-name.")
+    parser.add_argument("--api-base", default="http://localhost:8000/v1",
+                        help="OpenAI-compatible base URL, including the /v1 suffix.")
+    parser.add_argument("--api-key", default="EMPTY", help="Ignored by vLLM; required by the client.")
+    parser.add_argument("--reflection-model", default=None,
+                        help="Override reflection model (e.g. 'openai/gpt-4o' for a mixed setup). "
+                             "Defaults to the same local vLLM model.")
+    parser.add_argument("--max-metric-calls", type=int, default=20, help="Optimization budget.")
+    args = parser.parse_args()
+
+    task_lm = make_vllm_lm(args.served_model_name, api_base=args.api_base, api_key=args.api_key)
+    # Reflection can be the same local model, or a hosted string for a mixed setup.
+    reflection_lm = args.reflection_model or make_vllm_lm(
+        args.served_model_name, api_base=args.api_base, api_key=args.api_key
+    )
+
+    print(f"Task model:       {task_lm!r}")
+    print(f"Reflection model: {reflection_lm!r}")
+
+    result = gepa.optimize(
+        seed_candidate=SEED_PROMPT,
+        trainset=TRAINSET,
+        # An LM is a plain callable, so it slots into both roles. (Pyright sees a
+        # nominal Protocol param-name nuance here; the call is runtime-safe.)
+        task_lm=task_lm,  # type: ignore[arg-type]
+        reflection_lm=reflection_lm,
+        max_metric_calls=args.max_metric_calls,
+    )
+
+    print("\n=== Result ===")
+    best = result.best_candidate
+    print("Best prompt:", best["system_prompt"] if isinstance(best, dict) else best)
+    print("Best score: ", result.val_aggregate_scores[result.best_idx])
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,17 @@ langchain = [
     "tqdm>=4.66",
 ]
 
+# Client-side requirements for driving a local Hugging Face model served by
+# vLLM (or any OpenAI-compatible endpoint). GEPA only ever talks to the server
+# over HTTP via LiteLLM, so it never imports `vllm`/`torch` in-process — this
+# extra is intentionally lean and adds no heavy (torch/CUDA) footprint to the
+# lockfile. Install the server itself separately, on the serving box:
+#     pip install vllm
+# See docs/docs/guides/local-models-vllm.md.
+vllm = [
+    "gepa[full]",
+]
+
 [project.urls]
 "Homepage" = "https://github.com/gepa-ai/gepa"
 "Bug Tracker" = "https://github.com/gepa-ai/gepa/issues"

--- a/src/gepa/lm.py
+++ b/src/gepa/lm.py
@@ -187,6 +187,66 @@ class LM:
         return f"LM({', '.join(params)})"
 
 
+def make_vllm_lm(
+    model: str,
+    api_base: str = "http://localhost:8000/v1",
+    api_key: str = "EMPTY",
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+    num_retries: int = 3,
+    **kwargs: Any,
+) -> LM:
+    """Build an :class:`LM` backed by a local vLLM (or any OpenAI-compatible) server.
+
+    vLLM serves Hugging Face models behind an OpenAI-compatible endpoint::
+
+        python -m vllm.entrypoints.openai.api_server \\
+            --model Qwen/Qwen2.5-7B-Instruct \\
+            --served-model-name qwen2.5-7b-instruct \\
+            --port 8000
+
+    This helper points GEPA's LiteLLM-backed :class:`LM` at that endpoint. It is a
+    thin convenience wrapper — the equivalent explicit form is
+    ``LM("openai/<served-model-name>", api_base=..., api_key="EMPTY")``.
+
+    **No import-time dependency is added:** ``vllm``/``transformers`` only need to be
+    installed on the machine *serving* the model, never in the GEPA process. LiteLLM
+    (already an optional GEPA dependency, imported lazily) does the HTTP call. The
+    returned :class:`LM` is a plain ``LanguageModel`` callable, usable as either the
+    task model or the ``reflection_lm``, and mixes freely with hosted providers.
+
+    Args:
+        model: The vLLM ``--served-model-name`` (e.g. ``"qwen2.5-7b-instruct"``).
+            A LiteLLM provider prefix is prepended automatically when missing
+            (``"openai/"``), so pass the served name as-is. To force a specific
+            route, prefix it yourself (e.g. ``"hosted_vllm/qwen2.5-7b-instruct"``);
+            an existing ``openai/`` or ``hosted_vllm/`` prefix is left untouched.
+        api_base: The server's OpenAI-compatible base URL, **including** the ``/v1``
+            suffix. Defaults to ``"http://localhost:8000/v1"``.
+        api_key: Ignored by vLLM but required by the OpenAI client contract; defaults
+            to ``"EMPTY"``.
+        temperature: Optional sampling temperature.
+        max_tokens: Optional maximum tokens to generate.
+        num_retries: Retries on transient failures (default 3).
+        **kwargs: Extra keyword arguments forwarded to ``litellm.completion``
+            (e.g. ``top_p``, ``timeout``).
+
+    Returns:
+        An :class:`LM` instance targeting the local endpoint.
+    """
+    if not model.startswith(("openai/", "hosted_vllm/")):
+        model = f"openai/{model}"
+    return LM(
+        model,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        num_retries=num_retries,
+        api_base=api_base,
+        api_key=api_key,
+        **kwargs,
+    )
+
+
 class TrackingLM:
     """Wraps an arbitrary callable to track estimated token usage.
 

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -58,6 +58,7 @@ from gepa.gepa_launcher import (
     make_litellm_lm,
     set_log_context,
 )
+from gepa.lm import make_vllm_lm
 from gepa.oa.budget import BudgetExhausted, BudgetTracker
 from gepa.oa.config import OptimizeAnythingConfig
 from gepa.oa.engine import Engine, Result
@@ -426,6 +427,7 @@ __all__ = [
     "list_tasks",
     "log",
     "make_litellm_lm",
+    "make_vllm_lm",
     "optimize_adaptive_sequential",
     "optimize_adaptive_sequential_with_server",
     "optimize_anything",

--- a/tests/test_vllm_lm.py
+++ b/tests/test_vllm_lm.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""Tests for make_vllm_lm — the local vLLM / Hugging Face convenience helper.
+
+These verify GEPA-side configuration and argument forwarding only; they never
+require a running vLLM server (litellm is mocked).
+"""
+
+from unittest.mock import MagicMock, patch
+
+from gepa.lm import LM, make_vllm_lm
+
+
+class TestMakeVllmLMConfig:
+    """Construction: prefixing, defaults, and argument forwarding."""
+
+    def test_returns_lm_instance(self):
+        lm = make_vllm_lm("qwen2.5-7b-instruct")
+        assert isinstance(lm, LM)
+
+    def test_adds_openai_prefix_when_missing(self):
+        lm = make_vllm_lm("qwen2.5-7b-instruct")
+        assert lm.model == "openai/qwen2.5-7b-instruct"
+
+    def test_preserves_existing_openai_prefix(self):
+        lm = make_vllm_lm("openai/qwen2.5-7b-instruct")
+        assert lm.model == "openai/qwen2.5-7b-instruct"
+
+    def test_preserves_hosted_vllm_prefix(self):
+        lm = make_vllm_lm("hosted_vllm/qwen2.5-7b-instruct")
+        assert lm.model == "hosted_vllm/qwen2.5-7b-instruct"
+
+    def test_served_name_with_slash_is_prefixed(self):
+        # A served name that itself contains "/" (e.g. the HF repo id) still gets
+        # the provider prefix; litellm splits provider on the first "/".
+        lm = make_vllm_lm("Qwen/Qwen2.5-7B-Instruct")
+        assert lm.model == "openai/Qwen/Qwen2.5-7B-Instruct"
+
+    def test_default_api_base_and_key(self):
+        lm = make_vllm_lm("qwen2.5-7b-instruct")
+        assert lm.completion_kwargs["api_base"] == "http://localhost:8000/v1"
+        assert lm.completion_kwargs["api_key"] == "EMPTY"
+
+    def test_custom_api_base_and_key_forwarded(self):
+        lm = make_vllm_lm("m", api_base="http://gpu-box:9000/v1", api_key="sk-abc")
+        assert lm.completion_kwargs["api_base"] == "http://gpu-box:9000/v1"
+        assert lm.completion_kwargs["api_key"] == "sk-abc"
+
+    def test_sampling_params_forwarded(self):
+        lm = make_vllm_lm("m", temperature=0.3, max_tokens=256, top_p=0.9)
+        assert lm.completion_kwargs["temperature"] == 0.3
+        assert lm.completion_kwargs["max_tokens"] == 256
+        assert lm.completion_kwargs["top_p"] == 0.9
+
+    def test_num_retries_forwarded(self):
+        lm = make_vllm_lm("m", num_retries=7)
+        assert lm.num_retries == 7
+        # num_retries is an LM constructor arg, not a completion kwarg.
+        assert "num_retries" not in lm.completion_kwargs
+
+
+class TestMakeVllmLMCall:
+    """Runtime: api_base / api_key actually reach litellm."""
+
+    @patch("litellm.completion")
+    def test_call_forwards_endpoint(self, mock_completion):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "hi"
+        mock_response.choices[0].finish_reason = "stop"
+        mock_completion.return_value = mock_response
+
+        lm = make_vllm_lm("qwen2.5-7b-instruct", api_base="http://localhost:8000/v1")
+        result = lm("hello")
+
+        assert result == "hi"
+        _, kwargs = mock_completion.call_args
+        assert kwargs["model"] == "openai/qwen2.5-7b-instruct"
+        assert kwargs["api_base"] == "http://localhost:8000/v1"
+        assert kwargs["api_key"] == "EMPTY"
+        assert kwargs["messages"] == [{"role": "user", "content": "hello"}]
+
+    @patch("litellm.batch_completion")
+    def test_batch_complete_forwards_endpoint(self, mock_batch):
+        def _resp(text):
+            r = MagicMock()
+            r.choices = [MagicMock()]
+            r.choices[0].message.content = text
+            r.choices[0].finish_reason = "stop"
+            return r
+
+        mock_batch.return_value = [_resp("a"), _resp("b")]
+
+        lm = make_vllm_lm("qwen2.5-7b-instruct", api_base="http://gpu:8000/v1")
+        results = lm.batch_complete([[{"role": "user", "content": "x"}], [{"role": "user", "content": "y"}]])
+
+        assert results == ["a", "b"]
+        _, kwargs = mock_batch.call_args
+        assert kwargs["model"] == "openai/qwen2.5-7b-instruct"
+        assert kwargs["api_base"] == "http://gpu:8000/v1"
+        assert kwargs["api_key"] == "EMPTY"
+
+
+def test_reexported_from_optimize_anything():
+    import gepa.optimize_anything as oa
+
+    assert hasattr(oa, "make_vllm_lm")
+    assert oa.make_vllm_lm is make_vllm_lm

--- a/uv.lock
+++ b/uv.lock
@@ -1125,6 +1125,20 @@ test = [
     { name = "tqdm" },
     { name = "wandb" },
 ]
+vllm = [
+    { name = "cloudpickle" },
+    { name = "datasets", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "datasets", version = "4.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "litellm" },
+    { name = "mlflow", marker = "python_full_version < '3.14'" },
+    { name = "mlflow-skinny", marker = "python_full_version >= '3.14'" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pyarrow", version = "23.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "tiktoken", version = "0.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "tqdm" },
+    { name = "wandb" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1137,6 +1151,7 @@ requires-dist = [
     { name = "gepa", extras = ["build"], marker = "extra == 'dev'" },
     { name = "gepa", extras = ["full"], marker = "extra == 'gskill'" },
     { name = "gepa", extras = ["full"], marker = "extra == 'test'" },
+    { name = "gepa", extras = ["full"], marker = "extra == 'vllm'" },
     { name = "gepa", extras = ["test"], marker = "extra == 'dev'" },
     { name = "langchain", marker = "extra == 'langchain'", specifier = ">=1.0" },
     { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=1.0" },
@@ -1168,7 +1183,7 @@ requires-dist = [
     { name = "wandb", marker = "python_full_version < '3.14' and extra == 'full'" },
     { name = "wheel", marker = "extra == 'build'" },
 ]
-provides-extras = ["full", "confidence", "dspy", "test", "build", "dev", "gskill", "langchain"]
+provides-extras = ["full", "confidence", "dspy", "test", "build", "dev", "gskill", "langchain", "vllm"]
 
 [[package]]
 name = "gitdb"


### PR DESCRIPTION
Closes #359.

Adds an **optional, opt-in** path for running GEPA against local open-weight models served by [vLLM](https://docs.vllm.ai) (or any OpenAI-compatible endpoint). Core GEPA stays dependency-free and no default changes.

### What's here
- **`gepa.lm.make_vllm_lm(model, api_base="http://localhost:8000/v1", api_key="EMPTY", ...)`** — a thin convenience wrapper that auto-prefixes the `openai/` provider and returns an `LM`. Works as **both** the task and reflection model. Adds **no import-time dependency** (litellm stays lazy); GEPA reaches the server over HTTP and never imports `vllm` in-process.
- **Re-exported from `gepa.optimize_anything`** next to `make_litellm_lm` for discoverability. **Deliberately not surfaced at top-level `gepa`** — this is an added feature, not the default route.
- **Docs:** new guide `guides/local-models-vllm.md` (serve → call → optimize, mixed local/hosted setups, cost/token notes, troubleshooting) + mkdocs nav entry.
- **Example:** runnable `examples/vllm_huggingface/` (README + `main.py`).
- **Tests:** `tests/test_vllm_lm.py` — 12 tests covering provider prefixing, defaults, and `api_base`/`api_key`/sampling forwarding. **litellm is mocked; no server or model download.**

### On the `vllm` extra (design note)
The optional `vllm` extra is intentionally **lean** (`gepa[full]` — the LiteLLM client used to call the endpoint). The heavy, GPU/platform-specific vLLM **server** is installed separately on the serving box (`pip install vllm`), matching the architecture (GEPA talks to it over HTTP). This keeps **zero torch/CUDA footprint** out of the core and the lockfile — the `uv.lock` change is a single flattened extra entry, not the torch/CUDA/ray universe. Happy to bundle the server into the extra instead if you'd prefer the one-command install; it's a one-line change (at the cost of ~1.5k lines of heavy lockfile churn).

### Verification
- `uv lock --check` ✅ (lock consistent for CI `--locked`)
- `ruff check` ✅
- `pyright` on `src/` ✅ and on the example ✅
- `pytest tests/test_vllm_lm.py` ✅ 12 passed; existing lm/optimize_anything tests ✅ 115 passed / 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)