### PR TITLE
docs(blog): writing fixes for the parallel-proposals post

### DIFF
--- a/docs/docs/blog/posts/2026-07-30-parallel-proposals/index.md
+++ b/docs/docs/blog/posts/2026-07-30-parallel-proposals/index.md
@@ -27,12 +27,12 @@ citation_keywords: "text optimization, prompt optimization, program optimization
 
 <figure markdown="span">
   ![Two scatter plots of held-out test performance against optimization wall-clock time. In each, a purple dot labeled Parallel Proposals (P×N) sits above and left of an orange diamond labeled Sequential, inside a shaded region of results that are both faster and better; a dashed line marks the unoptimized baseline, and two arrows from the diamond point up (Better than single mutation) and left (Faster than single mutation). LiveBench-Math: 71.6% in 2.5 hours against 68.9% in 7.7 hours. HoVer: 55.0% in 15 minutes against 49.0% in 47 minutes.](images/throughput.png){ style="width: 100%;" }
-  <figcaption>Figure 1. At the same metric-call budget, parallel proposals are faster and better than single mutation.</figcaption>
+  <figcaption>Figure 1. At the same metric-call budget, parallel proposals are faster and better than single mutation — up to about 3–4× faster while scoring up to 11 points higher on the held-out test set.</figcaption>
 </figure>
 
 Running GEPA on a task can take hours because each optimization step waits for a proposal and its evaluation before the next step begins. The loop samples a parent, proposes a mutation, evaluates it on a mini-batch, and, if it improves on its parent, evaluates it on the full validation set.
 
-This release adds batched parallel proposals. Instead of advancing one proposal at a time, a step can propose several candidates and dispatch their evaluations concurrently. In our experiments, this reduced wall-clock time substantially. We found that most batched settings also achieved higher held-out test scores.
+This release adds batched parallel proposals. Instead of advancing one proposal at a time, a step can propose several candidates and dispatch their evaluations concurrently. In our experiments, this reduced wall-clock time substantially — most batched runs finished in half the wall-clock time or less, and the fastest in about a quarter to a third — while at the same time generating candidates that achieved significantly higher held-out test scores (68.9% to 72.1% on LiveBench-Math and 49.0% to 60.0% on HoVer).
 
 ## How parallel proposals work
 
@@ -85,7 +85,7 @@ We evaluated parallel proposals on [LiveBench-Math](https://livebench.ai/) and [
 
 ### Batching cuts the wall-clock time
 
-The measured runs align with the runtime model above. For example, on LiveBench-Math, moving from single mutation to 2×2 cut the number of iterations by 4.9× (219 to 45), but the fraction of iterations that triggered full validation rose from 17% to 53%, so the run gained a 1.9× speedup (7.7 to 4.1 hours) rather than the full 4.9×. Across the whole sweep, Figure 3 shows the measured runtimes tracking the model's predicted curve. When scaling up to 16-way parallelism, the speedup is about 3 to 4×.
+The measured runs align with the runtime model above. For example, on LiveBench-Math, moving from single mutation to 2×2 cut the number of iterations by 4.9× (219 to 45), but the fraction of iterations that triggered full validation rose from 17% to 53%, so the run gained a 1.9× speedup (7.7 to 4.1 hours). Across the whole sweep, Figure 3 shows the measured runtimes tracking the model's predicted curve. When scaling up to 16-way parallelism, the speedup is about 3 to 4×.
 
 <figure markdown="span">
   ![Two dual-axis line charts across the nine settings from single to 8×2: an orange line with held-out test performance on the left axis, a purple line with optimization time on the right axis, a dashed lighter-purple curve with the optimization time predicted by the finite-worker model, and a dotted baseline. Measured time falls from 7.7 hours to about 2 on LiveBench-Math and from 47 to 14 minutes on HoVer, and the predicted curve tracks it, flattening near 2.2 hours and 15 minutes. Test performance ranges from 66.7 to 72.1 on LiveBench-Math and from 49.0 to 60.0 on HoVer against single mutation's 68.9 and 49.0.](images/scaling_lines.png){ style="width: 100%;" }
@@ -102,7 +102,7 @@ We also probed how efficiently each setting spends its budget during the run. He
 
 #### More quality per metric call
 
-On the held-out test sets, 2×4 won 3.0pp over single mutation on LiveBench-Math, and 8×1 won 11.0pp on HoVer. On LiveBench-Math, single mutation actually scored higher on the validation set, but the batched settings transferred better to the test set. Single mutation dropped nine points from validation to test and 8×1 dropped six, matching the weaker transfer of P-heavy settings described above, while 2×4 dropped only two.
+On the held-out test sets, 2×4 won 3.0pp over single mutation on LiveBench-Math, and 8×1 won 11.0pp on HoVer. On LiveBench-Math, single mutation actually scored higher on the validation set, but the batched settings transferred better to the test set. This drop from validation to test — the generalization gap — was smallest for the batched settings: single mutation dropped nine points and 8×1 dropped six, matching the weaker transfer of P-heavy settings described above, while 2×4 dropped only two. This is consistent with the hypothesis above, that committing to more proposals before adapting to the validation set transfers better beyond it.
 
 Batched settings dominate small budgets: on LiveBench-Math both batched settings reach validation scores that single mutation needs about 2,000 calls to match, and on HoVer they lead at every budget. Single mutation raises validation scores later in the budget, but scores the lowest on the held-out test set on both tasks.
 
@@ -113,7 +113,7 @@ Batched settings dominate small budgets: on LiveBench-Math both batched settings
 
 #### More quality per dollar
 
-By measuring the total LLM spend (sum of solver calls and reflection calls), we found that batched settings are also more cost-efficient, reaching strong validation scores within the first few dollars. On LiveBench-Math, 8×1 reaches a 0.73 validation score within about $2.5 of spend, and on HoVer it reaches its selected program for $2.65. The total spend varies with how long each run's candidates make the solver's outputs (per-call output tokens order the totals on both tasks), but stays comparable across settings, within the $12 to $18 range.
+By measuring the total LLM spend during optimization (solver and reflection calls made over the whole run, not the cost of running the optimized program afterward), we found that batched settings are also more cost-efficient, reaching strong validation scores within the first few dollars. On LiveBench-Math, 8×1 reaches a 0.73 validation score within about $2.5 of spend, and on HoVer it reaches its selected program for $2.65. The total spend varies with how long each run's candidates make the solver's outputs (per-call output tokens order the totals on both tasks), but stays comparable across settings, within the $12 to $18 range.
 
 <figure markdown="span">
   ![Two Pareto curves of best validation quality against cumulative LLM dollars for single mutation, 2×4, and 8×1. Left, LiveBench-Math: single mutation reaches 0.783 by about $5.5 and ends at $13.2; 2×4 ends at 0.740 for $12.4 and 8×1 at 0.760 for $18.1. Right, HoVer: 8×1 jumps to 0.727 by $2.65 and ends at $14.2; 2×4 ends at 0.716 for $15.3 and single mutation at 0.709 for $13.4. Test stars match Figure 4.](images/pareto_cost.png){ style="width: 100%;" }
@@ -122,7 +122,7 @@ By measuring the total LLM spend (sum of solver calls and reflection calls), we 
 
 ## Getting started
 
-Parallel proposals are available in [gepa](https://github.com/gepa-ai/gepa). Opt in with a simple setting change below. The sampling strategy says how many candidates to propose per step, and the selection strategy says which of the improved candidates to keep. For example, two parents with two mutations each gives four candidates per step.
+Parallel proposals are available in [gepa](https://github.com/gepa-ai/gepa) since v0.1.4. Opt in with a simple setting change below. The sampling strategy says how many candidates to propose per step, and the selection strategy says which of the improved candidates to keep. For example, two parents with two mutations each gives four candidates per step.
 
 ```python
 from gepa.optimize_anything import optimize_anything, OptimizeAnythingConfig
@@ -147,7 +147,7 @@ result = optimize_anything(
 )
 ```
 
-GEPA by default calls your `evaluate` function in parallel, so all you need is to set the maximum number of workers through `max_concurrency`. Optionally, you may provide a custom `batch_evaluate` function via the `batch_evaluator` argument. Since the GEPA engine remains single-threaded and dependency-free, you may use any inference backend that supports batch completion to run reflections in parallel. You may also choose or define other sampling and selection strategies. See the [API reference](https://gepa-ai.github.io/gepa/api/) for more details. 
+GEPA by default calls your `evaluate` function in parallel, so all you need is to set the maximum number of workers through `max_concurrency`. Optionally, you may provide a custom `batch_evaluate` function via the `batch_evaluator` argument. Since the GEPA engine remains single-threaded and dependency-free, the parallelism is entirely yours to choose: you can plug in any concurrency or distributed-execution framework — Ray, Slurm, Modal, Daytona, and the like — to run your evaluations, and any inference backend that supports batch completion to run reflections in parallel, with no changes to GEPA itself. You may also choose or define other sampling and selection strategies. See the [API reference](https://gepa-ai.github.io/gepa/api/) for more details. 
 
 ## Appendix: Axes of parallel scaling
 


### PR DESCRIPTION
Writing-only fixes to the parallel-proposals blog draft, applied on top of `jialin-blog`. These are the suggestions from Lakshya (across the review meetings + Slack) that don't need any new experiments or results — prose, captions, and framing only. No numbers were invented; every added figure is already reported elsewhere in the post/frontmatter.

### Changes
- **Intro** — fuse the "faster" and "better" claims into one sentence and lead with the headline test-score gains (68.9→72.1 on LiveBench-Math, 49.0→60.0 on HoVer), plus the "half the wall-clock or less / fastest ~a quarter to a third" framing that already lives in the frontmatter `description`.
- **Figure 1 caption** — add the concrete magnitudes (~3–4× faster, up to 11 points higher on the held-out test set) so the opening figure carries the takeaway on its own.
- **Wall-clock section** — drop the defensive "rather than the full 4.9×"; the 1.9× speedup stands on its own.
- **"More quality per metric call"** — name the *generalization gap* explicitly and tie the val→test drops back to the earlier transfer hypothesis, so the paragraph reads as one argument.
- **"More quality per dollar"** — disambiguate what the spend measures: optimization cost (solver + reflection calls over the whole run), *not* the cost of running the optimized program afterward.
- **Getting started** — note that parallel proposals ship since **v0.1.4**.
- **Getting started** — surface that the concurrency layer is plug-and-play (Ray, Slurm, Modal, Daytona, …) with no changes to GEPA itself.

Intentionally **not** included (need experiments/data, per the ask): the best-of-N independent-GEPA baseline, any results-forward structural restructure, and re-adding the removed HoVer baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)