### PR TITLE
feat(oa-omni): add Codex as optional meta_harness proposer

### DIFF
--- a/.claude/skills/gepa-optimize-anything/SKILL.md
+++ b/.claude/skills/gepa-optimize-anything/SKILL.md
@@ -38,8 +38,9 @@ argument** — and the same code runs under any of them:
   is rich.
 - **`autoresearch`** — an agentic optimizer: one Claude Code subprocess iterates like a researcher in
   a work dir, scoring candidates through an HTTP eval server.
-- **`meta_harness`** — an agentic proposer (Claude subprocess) that reads the frontier/history each
-  iteration and writes new candidates for the engine to benchmark.
+- **`meta_harness`** — an agentic proposer (Claude Code by default, or Codex via
+  `engine_config={"proposer": "codex"}`) that reads the frontier/history each iteration and writes
+  new candidates for the engine to benchmark.
 
 (There is also a `best_of_n` engine — sample N independent candidates, keep the best. It is
 deliberately naive: use it as a **baseline** to compare an optimizer against, not as the optimizer.)
@@ -92,11 +93,13 @@ pip install "gepa[full]"   # [full] pulls cloudpickle — needed to pickle closu
 # that provider's key (OPENAI_API_KEY), or pass your own id (e.g. "anthropic/claude-sonnet-4-6" with
 # ANTHROPIC_API_KEY, or a Bedrock ARN with AWS creds). You can also pass any callable implementing
 # GEPA's LM protocol — a self-hosted / custom inference engine — instead of a model-id string.
-# Agentic backends (autoresearch, meta_harness) additionally need the `claude` CLI on PATH (plus
-# `jq` for the generated eval.sh):
+# Agentic backends (autoresearch, meta_harness) need a coding-agent CLI on PATH (plus `jq` for
+# autoresearch's generated eval.sh). Default is Claude Code; meta_harness can use Codex instead:
 npm install -g @anthropic-ai/claude-code   # or: curl -fsSL https://claude.ai/install.sh | bash
 #   ...then run `claude` once to authenticate.
-# On Linux they also need bubblewrap: the default sandbox=True jails the claude subprocess with
+npm install -g @openai/codex               # only if using meta_harness proposer="codex"
+#   ...then run `codex login` (or set CODEX_API_KEY).
+# On Linux they also need bubblewrap: the default sandbox=True jails the agent subprocess with
 # bwrap (`sudo apt install bubblewrap` / `sudo dnf install bubblewrap`) and the run aborts at
 # launch if it's missing. sandbox=False opts out — the agent then runs unsandboxed (loud warning).
 ```
@@ -150,7 +153,7 @@ low** — raise it and rerun.
   accuracy). The backend stops the moment a candidate reaches it instead of burning the rest of the
   budget at the optimum.
 - **`max_token_cost`** — a hard USD cap on the backend's own proposer/agent LLM spend. Especially
-  important for the agentic backends (`autoresearch`, `meta_harness`), whose Claude subprocesses
+  important for the agentic backends (`autoresearch`, `meta_harness`), whose agent subprocesses
   spend tokens between eval calls.
 - **a wall-clock `timeout`** on the process you launch (e.g. `timeout 1200 python run.py`) as a
   backstop.
@@ -241,7 +244,8 @@ These silently degrade *results* — skim before launching:
 - **`engine_config` is validated strictly per backend** — an unknown key (including a leftover key
   from a different backend after swapping `engine=`) raises `TypeError` at construction. Swapping
   `engine=` means swapping the `engine_config` block. → `references/api.md`.
-- **Agentic backends (`autoresearch`, `meta_harness`) shell out to the `claude` CLI** and abort at
+- **Agentic backends (`autoresearch`, `meta_harness`) shell out to a coding-agent CLI** (`claude` by
+  default; `codex` when `meta_harness` uses `proposer="codex"`) and abort at
   launch with install instructions if it's missing — likewise for `bwrap` (bubblewrap) on Linux,
   which the default `sandbox=True` needs. `sandbox=False` runs the agent unconfined (loud warning).
   Run `scripts/preflight.py` first; details in `references/api.md`.
@@ -254,4 +258,5 @@ These silently degrade *results* — skim before launching:
   LLM-as-judge scoring, multi-objective via `info["scores"]`, N>1 averaging, feedback design.
 - `references/tracking.md` — enabling wandb / mlflow experiment tracking and what gets logged.
 - `references/gotchas.md` — reward hacking, selection bias, the three modes, backend prerequisites.
-- `scripts/preflight.py` — validate creds / proposer LM / `claude` CLI before launching.
+- `scripts/preflight.py` — validate creds / proposer LM / agent CLI before launching
+  (`--proposer codex` for Codex).

--- a/.claude/skills/gepa-optimize-anything/references/api.md
+++ b/.claude/skills/gepa-optimize-anything/references/api.md
@@ -55,7 +55,7 @@ you want an unbiased number to report; skip it otherwise.
 | `engine` | `"gepa"` | `"gepa"` / `"autoresearch"` / `"meta_harness"` (or `"best_of_n"`, a baseline), or a constructed `Engine` instance (custom engines can be added via `gepa.oa.registry.register_engine`). |
 | `name` | `None` | run id (logging + default output dir). Auto-generated (`<engine>-<uuid>-<timestamp>`) if `None`. |
 | `max_evals` | **`100`** | server-side cap on eval calls. `None` = unlimited. Size it — the default is rarely right (see SKILL.md). |
-| `max_token_cost` | `None` | USD cap on the engine's **own** optimizer-LLM spend (reflection/agent). Enforced by the engine (gepa: `max_reflection_cost` stopper; agent engines: `--max-budget-usd`), not the eval server. |
+| `max_token_cost` | `None` | USD cap on the engine's **own** optimizer-LLM spend (reflection/agent). Enforced by the engine (gepa: `max_reflection_cost` stopper; Claude agent engines: `--max-budget-usd`), not the eval server. `meta_harness` with `proposer="codex"` rejects a non-`None` value (no USD signal) — use `max_evals` / `max_iterations` instead. |
 | `max_concurrency` | `8` | eval-server thread-pool size. |
 | `output_dir` | `None` | where the eval server writes per-eval JSON, `progress_log.jsonl`, `summary.json`. `None` → `outputs/optimize_anything/<task>/<engine>/<timestamp>/`. |
 | `run_dir` | `None` | engine workspace (gepa run dir / agent work dir; with `engine.write_agent_state=True` the gepa backend writes an agent-readable `iterations/` + `pareto/` tree here). Distinct from `output_dir`. `None` → subprocess engines use a tempdir; set it to persist artifacts. |
@@ -78,7 +78,7 @@ changing one argument. Each backend parses `engine_config` into its own typed da
 |---|---|---|---|
 | `gepa` | an LLM reflects on evaluator feedback and mutates the candidate; keeps a Pareto frontier | in-process | reflection-LM creds (default `openai/gpt-5.1`) or a custom LM |
 | `autoresearch` | one Claude Code subprocess iterates in a work dir (`program.md`, `candidate.txt`, `eval.sh` → HTTP eval server) | subprocess | `claude` on PATH + headless auth, `jq` |
-| `meta_harness` | a Claude subprocess reads frontier/history and writes `pending_eval.json` candidates; the engine benchmarks each | subprocess | `claude` on PATH + headless auth |
+| `meta_harness` | a Claude or Codex subprocess reads frontier/history and writes `pending_eval.json` candidates; the engine benchmarks each | subprocess | `claude` (default) or `codex` on PATH + headless auth (`engine_config.proposer`) |
 | `best_of_n` *(baseline)* | independent single-shot samples from one LLM; keep the best — no feedback, no history | in-process | LiteLLM creds for `model` (default `claude-sonnet-4-6`) |
 
 `scripts/preflight.py` checks a backend's prerequisites before a long run.
@@ -142,14 +142,23 @@ unreachable over HTTP.
 ### `meta_harness` — `engine_config` → `MetaHarnessConfig`
 | key | default | meaning |
 |---|---|---|
-| `model` | `"claude-sonnet-4-6"` | proposer model id. |
+| `proposer` | `"claude"` | coding-agent CLI: `"claude"` (Claude Code) or `"codex"` (OpenAI Codex). `"claude-code"` is an alias of `"claude"`. |
+| `model` | `"claude-sonnet-4-6"` | proposer model id. When `proposer="codex"` and this Claude default is left in place, it is rewritten to `"gpt-5.6-terra"`. |
 | `max_iterations` | `None` | hard cap on proposer sessions; `None` = until budget. |
 | `max_candidates_per_iter` | `3` | upper bound on candidates proposed per iteration. |
-| `effort` | `None` | `claude --effort` value. |
-| `max_thinking_tokens` | `None` | fixed thinking-token budget. |
+| `effort` | `None` | `claude --effort` value (ignored for Codex). |
+| `max_thinking_tokens` | `None` | fixed thinking-token budget (ignored for Codex). |
 
 Each iteration the proposer subprocess reads the frontier + history state files, writes
 `pending_eval.json` with 1+ candidates, and the engine benchmarks each through the eval server.
+
+```python
+# Claude Code (default)
+engine_config={"model": "claude-sonnet-4-6"}
+
+# OpenAI Codex CLI
+engine_config={"proposer": "codex", "model": "gpt-5.6-terra"}
+```
 
 ### `best_of_n` (baseline) — `engine_config` → `BestOfNConfig`
 Deliberately naive: each sample is one independent LLM call — no feedback, no history, no

--- a/.claude/skills/gepa-optimize-anything/references/gotchas.md
+++ b/.claude/skills/gepa-optimize-anything/references/gotchas.md
@@ -43,12 +43,16 @@ block, and old-API keys (`claude_code_agent`, top-level `reflection_lm_kwargs`, 
 `background` inside `engine_config`) now crash. See `api.md` for each backend's valid keys.
 
 ## 6. Agentic backends have launch-time prerequisites
-`autoresearch` / `meta_harness` `subprocess.Popen(["claude", ...])`. A missing `claude` CLI — or, on
-Linux, a missing `bwrap` (bubblewrap) while the default `sandbox=True` is in effect — aborts the run
-at launch with a boxed message and install instructions (`npm install -g @anthropic-ai/claude-code`;
-`sudo apt/dnf install bubblewrap`). An *unauthenticated* CLI or a missing `jq` (used by
-autoresearch's generated `eval.sh`) still surfaces only mid-run, and `sandbox=False` runs the agent
-unconfined (loud warning) — so run `scripts/preflight.py` first either way.
+`autoresearch` / default `meta_harness` shell out to `claude`; `meta_harness` with
+`engine_config={"proposer": "codex"}` shells out to `codex exec`. A missing CLI — or, on Linux, a
+missing `bwrap` (bubblewrap) while the default `sandbox=True` is in effect — aborts the run at
+launch with a boxed message and install instructions (`npm install -g @anthropic-ai/claude-code` or
+`npm install -g @openai/codex`; `sudo apt/dnf install bubblewrap`). An *unauthenticated* CLI or a
+missing `jq` (used by autoresearch's generated `eval.sh`) still surfaces only mid-run, and
+`sandbox=False` runs the agent unconfined (loud warning) — so run `scripts/preflight.py` first
+(`--proposer codex` when using Codex). Codex has no USD cost signal, so a non-`None`
+`max_token_cost` with `proposer="codex"` raises at construction — bound those runs with
+`max_evals` / `max_iterations` instead.
 
 ## 7. Give runs a real stop condition (`stop_at_score` / `max_token_cost`)
 `max_evals` caps eval calls, but two situations still burn money or time past the point of useful
@@ -61,8 +65,9 @@ work:
   emitting cache-hitting candidates without consuming eval budget and can spin until your process
   times out, still spending proposer-LLM tokens. With caching on, `stop_at_score` and/or
   `max_token_cost` (plus a wall-clock `timeout` on the launched process) are mandatory.
-Agentic backends also spend LLM tokens between evals — cap them with `max_token_cost`
-(enforced as `--max-budget-usd`).
+Agentic backends also spend LLM tokens between evals — cap Claude proposers with
+`max_token_cost` (enforced as `--max-budget-usd`); for Codex use `max_evals` /
+`max_iterations` instead.
 
 ## 8. Pick the right mode
 The mode is implicit in which sets you pass (`api.md`): no `dataset`/`valset` → single-task;

--- a/.claude/skills/gepa-optimize-anything/scripts/preflight.py
+++ b/.claude/skills/gepa-optimize-anything/scripts/preflight.py
@@ -52,9 +52,16 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--engine", default="gepa",
                     choices=["gepa", "best_of_n", "autoresearch", "meta_harness"])
+    ap.add_argument(
+        "--proposer",
+        default="claude",
+        choices=["claude", "codex", "claude-code"],
+        help="meta_harness proposer CLI (ignored for other engines); default claude",
+    )
     ap.add_argument("--test-lm", action="store_true",
                     help="make a 1-call round-trip to the reflection LM (costs a few tokens)")
     a = ap.parse_args()
+    proposer = "claude" if a.proposer in ("claude", "claude-code") else a.proposer
 
     print("== optimize_anything preflight ==")
 
@@ -77,20 +84,35 @@ def main() -> int:
         ok, fix = _creds_for(effective_lm)
         check(f"LLM creds present for '{effective_lm}'", ok, fix)
 
-    # 3) agentic engines need the claude CLI (and autoresearch's eval.sh uses jq)
-    if a.engine in ("autoresearch", "meta_harness"):
+    # 3) agentic engines need a coding-agent CLI (and autoresearch's eval.sh uses jq)
+    if a.engine == "autoresearch" or (a.engine == "meta_harness" and proposer == "claude"):
         cli = shutil.which("claude")
         check(f"`claude` CLI on PATH (required by {a.engine})", bool(cli),
               "install + authenticate the Claude Code CLI headless")
         if cli:
             print(f"      claude -> {cli}")
-        if a.engine == "autoresearch":
-            check("`jq` on PATH (used by the generated eval.sh)", bool(shutil.which("jq")),
-                  "install jq")
-        if sys.platform.startswith("linux"):
-            check("`bwrap` on PATH (default sandbox=True jails claude with bubblewrap)",
-                  bool(shutil.which("bwrap")),
-                  "sudo apt/dnf install bubblewrap, or pass sandbox=False (runs unconfined)")
+    if a.engine == "meta_harness" and proposer == "codex":
+        cli = shutil.which("codex")
+        check("`codex` CLI on PATH (required by meta_harness proposer=codex)", bool(cli),
+              "install + authenticate the Codex CLI (`npm i -g @openai/codex` / `brew install --cask codex`)")
+        if cli:
+            print(f"      codex -> {cli}")
+        has_auth = bool(os.environ.get("CODEX_API_KEY") or os.environ.get("OPENAI_API_KEY"))
+        # ChatGPT-login auth lives in ~/.codex/auth.json — presence is enough for a soft check.
+        auth_file = os.path.expanduser("~/.codex/auth.json")
+        has_auth = has_auth or os.path.isfile(auth_file)
+        check(
+            "Codex auth present (CODEX_API_KEY / OPENAI_API_KEY / ~/.codex/auth.json)",
+            has_auth,
+            "run `codex login` or export CODEX_API_KEY",
+        )
+    if a.engine == "autoresearch":
+        check("`jq` on PATH (used by the generated eval.sh)", bool(shutil.which("jq")),
+              "install jq")
+    if a.engine in ("autoresearch", "meta_harness") and sys.platform.startswith("linux"):
+        check("`bwrap` on PATH (default sandbox=True jails the agent with bubblewrap)",
+              bool(shutil.which("bwrap")),
+              "sudo apt/dnf install bubblewrap, or pass sandbox=False (runs unconfined)")
 
     # 4) optional live LM round-trip
     if a.test_lm and a.engine in ("gepa", "best_of_n"):

--- a/src/gepa/oa/config.py
+++ b/src/gepa/oa/config.py
@@ -39,9 +39,12 @@ class OptimizeAnythingConfig:
             unlimited. This is **not** an eval-budget field: the eval server
             never sees proposer spend (a subprocess's cost isn't even knowable
             until it exits). Each engine reads it at construction and enforces
-            it itself (gepa: ``max_reflection_cost``; autoresearch/meta_harness:
-            ``--max-budget-usd``). At least one of ``max_evals`` /
-            ``max_token_cost`` must be set so a run is bounded.
+            it itself (gepa: ``max_reflection_cost``; autoresearch /
+            ``meta_harness`` with Claude: ``--max-budget-usd``).
+            ``meta_harness`` with ``proposer="codex"`` cannot enforce this
+            (Codex reports no USD) and rejects a non-``None`` value — use
+            ``max_evals`` / ``max_iterations`` instead. At least one of
+            ``max_evals`` / ``max_token_cost`` must be set so a run is bounded.
         max_concurrency: Eval server thread-pool size.
         output_dir: Where the eval server persists per-eval JSON,
             ``progress_log.jsonl``, and ``summary.json``. When ``None``, the
@@ -53,11 +56,12 @@ class OptimizeAnythingConfig:
             use a tempdir; in-process engines skip artifact writes. Set
             explicitly to persist them.
         stop_at_score: Score threshold for early stop. Each engine interprets.
-        sandbox: OS-jail the subprocess engines' ``claude`` sessions (bwrap on
+        sandbox: OS-jail the subprocess engines' agent sessions (bwrap on
             Linux — requires the ``bubblewrap`` package — Claude Code's
-            Seatbelt sandbox on macOS). Default ``True``. Linux runs abort at
-            engine start when ``bwrap`` is missing; ``False`` prints a loud
-            warning and runs the agent unsandboxed with full host access.
+            Seatbelt sandbox or Codex ``workspace-write`` on macOS). Default
+            ``True``. Linux runs abort at engine start when ``bwrap`` is
+            missing; ``False`` prints a loud warning and runs the agent
+            unsandboxed with full host access.
         engine_config: Engine-specific options that don't generalize across
             engines. Each engine reads the keys it understands and warns about
             leftovers so typos surface. The keys an engine accepts are
@@ -80,13 +84,15 @@ class OptimizeAnythingConfig:
             - ``best_of_n`` — ``model``, ``temperature``, ``max_n``,
               ``lm_kwargs``, ``effort``, ``max_thinking_tokens`` (see
               ``BestOfNEngine`` / ``_BON_CONFIG_KEYS``).
-            - ``meta_harness`` — ``model``, ``max_iterations``,
+            - ``meta_harness`` — ``proposer`` (``"claude"`` default, or
+              ``"codex"``), ``model``, ``max_iterations``,
               ``max_candidates_per_iter``, ``effort``, ``max_thinking_tokens``
-              (see ``MetaHarnessEngine`` / ``_MH_CONFIG_KEYS``).
+              (see ``MetaHarnessEngine`` / ``MetaHarnessConfig``).
 
             ``effort`` (``claude --effort``) and ``max_thinking_tokens`` are
             Claude-CLI knobs, so they live in each agent engine's
-            ``engine_config``; the gepa engine takes reasoning knobs through
+            ``engine_config`` (ignored when ``meta_harness`` uses
+            ``proposer="codex"``); the gepa engine takes reasoning knobs through
             ``reflection.reflection_lm_kwargs`` instead.
     """
 

--- a/src/gepa/oa/engines/meta_harness.py
+++ b/src/gepa/oa/engines/meta_harness.py
@@ -1,6 +1,6 @@
-"""Meta-Harness engine: iterative candidate proposal via Claude Code.
+"""Meta-Harness engine: iterative candidate proposal via a coding-agent CLI.
 
-The proposer (a Claude subprocess) reads frontier + history and writes
+The proposer (Claude Code or Codex) reads frontier + history and writes
 ``pending_eval.json`` listing 1+ candidates; the engine benchmarks each one
 through the optimize_anything eval server, updates state files, and loops until the
 budget is exhausted or ``max_iterations`` is hit.
@@ -17,13 +17,20 @@ import sys
 import tempfile
 import time
 import uuid
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from gepa.oa.budget import BudgetExhausted, BudgetTracker
 from gepa.oa.engine import Result
-from gepa.oa.sandbox import DENY_WEB_TOOLS, bwrap_prefix, claude_permission_args, preflight_claude_engine
+from gepa.oa.sandbox import (
+    DENY_WEB_TOOLS,
+    bwrap_prefix,
+    claude_permission_args,
+    preflight_claude_engine,
+    preflight_codex_engine,
+)
 from gepa.oa.task import seed_as_text
 from gepa.oa.utils import example_to_json
 
@@ -31,6 +38,9 @@ if TYPE_CHECKING:
     from gepa.oa.config import OptimizeAnythingConfig
     from gepa.oa.eval_server import EvalServer
     from gepa.oa.task import Task
+
+_DEFAULT_CLAUDE_MODEL = "claude-sonnet-4-6"
+_DEFAULT_CODEX_MODEL = "gpt-5.6-terra"
 
 
 @dataclass
@@ -40,15 +50,21 @@ class MetaHarnessConfig:
     Populated from ``OptimizeAnythingConfig.engine_config``.
 
     Attributes:
-        model: Proposer model id. Versioned default — pin for reproducibility;
-            pass ``"sonnet"`` / ``"opus"`` to track Anthropic's current default.
+        proposer: Coding-agent CLI that proposes candidates — ``"claude"``
+            (default, Claude Code) or ``"codex"`` (OpenAI Codex CLI).
+            ``"claude-code"`` is accepted as an alias of ``"claude"``.
+        model: Proposer model id. Claude default is ``claude-sonnet-4-6``;
+            when ``proposer="codex"`` and the Claude default is left in place,
+            it is rewritten to ``gpt-5.6-terra``.
         max_iterations: Hard cap on proposer sessions. ``None`` = until budget.
         max_candidates_per_iter: Upper bound on candidates per iteration.
-        effort: ``claude --effort`` value (CLI flag).
+        effort: ``claude --effort`` value (CLI flag). Ignored for Codex.
         max_thinking_tokens: Fixed thinking-token budget (``MAX_THINKING_TOKENS``).
+            Ignored for Codex.
     """
 
-    model: str = "claude-sonnet-4-6"
+    proposer: str = "claude"
+    model: str = _DEFAULT_CLAUDE_MODEL
     max_iterations: int | None = None
     max_candidates_per_iter: int = 3
     effort: str | None = None
@@ -56,6 +72,20 @@ class MetaHarnessConfig:
 
     def __post_init__(self) -> None:
         self.max_candidates_per_iter = max(1, int(self.max_candidates_per_iter))
+        raw = (self.proposer or "claude").strip().lower()
+        if raw in ("claude", "claude-code"):
+            self.proposer = "claude"
+        elif raw == "codex":
+            self.proposer = "codex"
+        else:
+            raise ValueError(f"MetaHarnessConfig.proposer must be 'claude' or 'codex', got {self.proposer!r}")
+        if self.proposer == "codex" and self.model == _DEFAULT_CLAUDE_MODEL:
+            self.model = _DEFAULT_CODEX_MODEL
+        if self.proposer == "codex" and (self.effort is not None or self.max_thinking_tokens is not None):
+            warnings.warn(
+                "meta_harness proposer='codex' ignores engine_config effort / max_thinking_tokens (Claude CLI knobs)",
+                stacklevel=2,
+            )
 
 
 SKILL_MD = """\
@@ -201,6 +231,145 @@ Treat `evolution_summary.jsonl`, `frontier.json`, and any prior `agents/iter*.tx
 """
 
 
+# Codex reads project instructions from AGENTS.md (tool-agnostic wording).
+AGENTS_MD = """\
+# Meta-Harness (Candidate Evolution)
+
+Run ONE iteration of candidate evolution. Do all work in the main session — do NOT delegate to subagents. Constraints get lost when you delegate, leading to parameter-only changes and skipped prototyping.
+
+**You do NOT run benchmarks.** You analyze results, prototype changes, and write new candidate files. The outer loop (the meta_harness engine) handles benchmarking separately.
+
+## CRITICAL CONSTRAINTS
+
+- You MUST implement up to `max_candidates` new candidates every iteration (cap given in the task prompt; aim for 3 unless told otherwise).
+- Do NOT write "the frontier is optimal" or "stop iterating", or abort early.
+- ALWAYS complete all steps including prototyping.
+- Design candidates as a mix of exploitation and exploration.
+
+### Anti-parameter-tuning rules
+
+The most common failure mode is creating candidates that are just parameter variants of existing ones. Check `evolution_summary.jsonl` for what's been tried — parameter sweeps (constants, thresholds, length caps, retry counts) almost always regress or tie.
+
+**Good candidates change a fundamental mechanism:**
+
+- A new algorithmic approach (e.g. a different solver structure, a different decomposition)
+- A new prompt architecture (e.g. organize by failure clusters instead of listing rules sequentially)
+- A new control-flow strategy (e.g. multi-pass refinement vs. single-shot, conditional branching on input shape)
+- A new representation (e.g. tabular vs. narrative, normalized vs. raw)
+
+**Bad candidates just tune numbers.** If the candidate text differs from a previous one only by changing constants, it's a parameter variant. Rewrite with a genuinely novel mechanism.
+
+**Combining ideas is valid.** Take one mechanism from candidate A and another from candidate B, or draw on published approaches.
+
+If the last 3 iterations explored the same axis (prompt wording, retrieval count, etc.), pick a different axis.
+
+### Anti-overfitting rules
+
+- **No example-specific hints.** Do not hardcode knowledge about specific test inputs you've seen. Candidates must be general-purpose.
+- **Never echo example identifiers** in candidate code, prompts, or comments.
+- **General patterns are OK.** Rules like "favor short outputs when ambiguous" or "validate the parse before submitting" are fine — they apply broadly.
+
+## Budget
+
+Token-cost and eval-count budgets are enforced by the engine, not by you. Don't try to ration evals or refuse to propose because "budget might run out" — if the cap is reached, the engine simply stops spawning new proposer sessions. Your only job is to produce strong candidates this iteration.
+
+## WORKFLOW
+
+**Do ALL steps yourself in the main session.**
+
+### Step 0: Post-eval reports (write if missing)
+
+Check the reports directory (path in the task prompt's "Run directories" section). For each past iteration that has results in `evolution_summary.jsonl` but NO report, write one. Each report should be **<=30 lines** covering: what changed, which candidates improved/regressed and why, and a takeaway for future iterations.
+
+### Step 1: Analyze
+
+1. **Read all state files:**
+   - `task.md` — task objective + background + evaluation model
+   - `evolution_summary.jsonl` — what's been tried (one JSON per candidate)
+   - `frontier.json` — overall best (`best_name` / `best_score` /
+     `best_candidate_file`) **plus** `per_example`: a dict mapping each
+     example id to the candidate that scored highest on it
+     (`{best_name, score, file}`). The per-example frontier is the
+     strongest signal for *combination* candidates — when different
+     candidates win different examples, read both and design a new one
+     that fuses their mechanisms.
+   - `agents/baseline.txt` — the seed candidate
+   - top-scoring `agents/iter*.txt` files (use `frontier.json["per_example"]`
+     to identify per-example winners worth reading)
+   - `state/eval_traces/<candidate_name>/*.json` — per-eval records from the
+     eval server for every previously-scored candidate. **This is the most
+     important source for failure analysis.** Each JSON contains the full
+     `info` dict (compile errors, judge messages, per-example scores for
+     dataset tasks, logs, status). Read the traces of the best-and-worst
+     candidates to understand *why* they scored as they did before designing
+     new candidates.
+
+2. Formulate hypotheses — each must be falsifiable and target a different mechanism.
+
+### Step 2: Prototype — MANDATORY
+
+**You MUST prototype your mechanism before writing the final candidate.** Do NOT skip this step. Candidates that skip prototyping tend to have bugs or produce no improvement.
+
+For each candidate:
+
+1. Write a sketch in `scratch/` (inside the run's work dir) that exercises the core idea in isolation (run code candidates manually; for prompt candidates, at least re-read and self-critique).
+2. Try 2-3 variants and compare before picking the best one.
+3. Delete sketches when done.
+
+### Step 3: Implement
+
+For each candidate:
+
+1. Copy a top-performing existing candidate (or `agents/baseline.txt`) as a starting point, then make targeted modifications. Copy-then-edit ensures correct formatting and proven structure.
+2. Implement the new mechanism according to your hypothesis.
+3. **Self-critique (mandatory):** After writing, re-read the file and check: does this candidate introduce a genuinely NEW mechanism, or is it just a parameter variant? If only constants differ from the base, REWRITE with a truly novel mechanism.
+
+The benchmark auto-discovers files in `agents/` — you don't need to register candidates anywhere else.
+
+### Step 4: Write pending_eval.json
+
+Write to the path specified in the task prompt (NOT hardcoded — it may be in a run-specific subdirectory):
+
+```json
+{
+  "iteration": <N>,
+  "candidates": [
+    {
+      "name": "<snake_case_name>",
+      "file": "agents/iter<N>_<name>.txt",
+      "hypothesis": "<falsifiable claim>",
+      "axis": "exploitation|exploration",
+      "base": "<what it builds on>",
+      "components": ["tag1", "tag2", "..."]
+    }
+  ]
+}
+```
+
+Output: `CANDIDATES: <name1>, <name2>, <name3>`
+
+## Candidate format
+
+A candidate is the **entire text content of a single file** at `agents/iter<N>_<name>.txt`. Whatever you write there — code, a prompt, JSON, whatever the task expects — is what the eval server scores. Read `task.md` to learn what shape the task expects.
+
+- Create new candidate files by writing their full contents (do not leave stubs).
+- `agents/baseline.txt` is the seed; treat it as read-only.
+- Don't write outside `agents/` or the pending_eval.json path.
+
+## evolution_summary.jsonl Format
+
+One JSON object per line, one line per evaluated candidate:
+
+```json
+{"iteration": 1, "name": "example_candidate", "score": 45.0, "axis": "exploitation", "hypothesis": "...", "delta": +2.1, "outcome": "45.00 (+2.1)", "components": ["tag1", "tag2"]}
+```
+
+## Component Analysis
+
+Treat `evolution_summary.jsonl`, `frontier.json`, and any prior `agents/iter*.txt` files as the only shipped history sources.
+"""
+
+
 def _build_task_md(task: Task) -> str:
     optional = ""
     if task.objective:
@@ -224,15 +393,25 @@ def _build_task_md(task: Task) -> str:
     return f"# Task: {task.name}\n\n{optional}## Evaluation model\n\n{eval_section}\n"
 
 
-def _materialize_sandbox(work_dir: Path, task: Task, server: EvalServer, budget: BudgetTracker) -> None:
+def _materialize_sandbox(
+    work_dir: Path,
+    task: Task,
+    server: EvalServer,
+    budget: BudgetTracker,
+    *,
+    proposer: str = "claude",
+) -> None:
     del budget
     work_dir.mkdir(parents=True, exist_ok=True)
 
     (work_dir / "task.md").write_text(_build_task_md(task))
 
-    skill_dir = work_dir / ".claude" / "skills" / "gepa-optimize-anything-meta-harness"
-    skill_dir.mkdir(parents=True, exist_ok=True)
-    (skill_dir / "SKILL.md").write_text(SKILL_MD)
+    if proposer == "codex":
+        (work_dir / "AGENTS.md").write_text(AGENTS_MD)
+    else:
+        skill_dir = work_dir / ".claude" / "skills" / "gepa-optimize-anything-meta-harness"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(SKILL_MD)
 
     agents_dir = work_dir / "agents"
     agents_dir.mkdir(exist_ok=True)
@@ -277,21 +456,21 @@ def _materialize_sandbox(work_dir: Path, task: Task, server: EvalServer, budget:
                 (train_dir / f"{eid}.json").write_text(json.dumps(example_to_json(eid, ex), indent=2, default=str))
 
 
-def _run_proposer(
+def _proposer_prompt(
     *,
     work_dir: Path,
     iteration: int,
-    model: str,
-    effort: str | None,
     max_candidates: int,
-    max_budget_usd: float | None,
     pending_path: Path,
-    log_dir: Path,
-    max_thinking_tokens: int | None = None,
-    sandbox: bool = True,
-) -> tuple[int, float, str]:
+    proposer: str,
+) -> str:
     state = work_dir / "state"
-    prompt = (
+    follow = (
+        "Follow the instructions in `AGENTS.md` at the work dir root."
+        if proposer == "codex"
+        else "Follow the gepa-optimize-anything-meta-harness skill in `.claude/skills/`."
+    )
+    return (
         f"Run iteration {iteration} of the meta-harness evolution loop. "
         f"Produce up to {max_candidates} candidate(s).\n\n"
         f"## Run directories (absolute paths)\n"
@@ -302,10 +481,20 @@ def _run_proposer(
         f"- state/reports/: `{state / 'reports'}`\n"
         f"- agents/: `{work_dir / 'agents'}`\n"
         f"- Write pending_eval.json to: `{pending_path}`\n\n"
-        f"Follow the gepa-optimize-anything-meta-harness skill in `.claude/skills/`."
+        f"{follow}"
     )
 
-    session_id = str(uuid.uuid4())
+
+def _build_claude_proposer_cmd(
+    *,
+    work_dir: Path,
+    prompt: str,
+    model: str,
+    effort: str | None,
+    max_budget_usd: float | None,
+    session_id: str,
+    sandbox: bool,
+) -> list[str]:
     cmd: list[str] = bwrap_prefix(work_dir) if sandbox else []
     cmd += [
         "claude",
@@ -327,6 +516,118 @@ def _run_proposer(
         cmd.extend(["--effort", effort])
     if max_budget_usd is not None:
         cmd.extend(["--max-budget-usd", f"{max_budget_usd:.4f}"])
+    return cmd
+
+
+def _build_codex_proposer_cmd(
+    *,
+    work_dir: Path,
+    prompt: str,
+    model: str,
+    sandbox: bool,
+) -> list[str]:
+    """Build ``codex exec`` argv for one meta-harness proposer session.
+
+    Sandbox ownership (one layer only):
+    - Linux + sandboxed → bwrap jail (``agent="codex"`` home binds) +
+      ``--dangerously-bypass-approvals-and-sandbox`` inside (Codex's own
+      sandbox nests poorly under bwrap).
+    - macOS + sandboxed → no bwrap; ``--sandbox workspace-write``.
+    - unsandboxed → ``--sandbox danger-full-access``.
+    """
+    cmd: list[str] = bwrap_prefix(work_dir, agent="codex") if sandbox else []
+    cmd += [
+        "codex",
+        "exec",
+        "--json",
+        "--skip-git-repo-check",
+        "-C",
+        str(work_dir.resolve()),
+        "-m",
+        model,
+    ]
+    if sandbox and _is_macos():
+        cmd.extend(["--sandbox", "workspace-write"])
+    elif sandbox:
+        # Linux bwrap owns isolation.
+        cmd.append("--dangerously-bypass-approvals-and-sandbox")
+    else:
+        cmd.extend(["--sandbox", "danger-full-access"])
+    cmd.append(prompt)
+    return cmd
+
+
+def _is_macos() -> bool:
+    return sys.platform == "darwin"
+
+
+def _run_proposer(
+    *,
+    work_dir: Path,
+    iteration: int,
+    model: str,
+    effort: str | None,
+    max_candidates: int,
+    max_budget_usd: float | None,
+    pending_path: Path,
+    log_dir: Path,
+    max_thinking_tokens: int | None = None,
+    sandbox: bool = True,
+    proposer: str = "claude",
+) -> tuple[int, float, str]:
+    prompt = _proposer_prompt(
+        work_dir=work_dir,
+        iteration=iteration,
+        max_candidates=max_candidates,
+        pending_path=pending_path,
+        proposer=proposer,
+    )
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    if proposer == "codex":
+        return _run_codex_proposer(
+            work_dir=work_dir,
+            iteration=iteration,
+            model=model,
+            prompt=prompt,
+            log_dir=log_dir,
+            sandbox=sandbox,
+        )
+    return _run_claude_proposer(
+        work_dir=work_dir,
+        iteration=iteration,
+        model=model,
+        effort=effort,
+        max_budget_usd=max_budget_usd,
+        prompt=prompt,
+        log_dir=log_dir,
+        max_thinking_tokens=max_thinking_tokens,
+        sandbox=sandbox,
+    )
+
+
+def _run_claude_proposer(
+    *,
+    work_dir: Path,
+    iteration: int,
+    model: str,
+    effort: str | None,
+    max_budget_usd: float | None,
+    prompt: str,
+    log_dir: Path,
+    max_thinking_tokens: int | None,
+    sandbox: bool,
+) -> tuple[int, float, str]:
+    session_id = str(uuid.uuid4())
+    cmd = _build_claude_proposer_cmd(
+        work_dir=work_dir,
+        prompt=prompt,
+        model=model,
+        effort=effort,
+        max_budget_usd=max_budget_usd,
+        session_id=session_id,
+        sandbox=sandbox,
+    )
 
     env = {**os.environ, "GEPA_OMNI_WORK_DIR": str(work_dir)}
     env.pop("CLAUDECODE", None)
@@ -335,23 +636,21 @@ def _run_proposer(
         env["CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING"] = "1"
         env["MAX_THINKING_TOKENS"] = str(max_thinking_tokens)
 
-    log_dir.mkdir(parents=True, exist_ok=True)
     proc = subprocess.run(cmd, cwd=str(work_dir), env=env, capture_output=True, text=True)
     (log_dir / f"iter{iteration}_stdout.json").write_text(proc.stdout or "")
     (log_dir / f"iter{iteration}_stderr.txt").write_text(proc.stderr or "")
-    cost_usd, result_payload = _parse_proposer_result(proc.stdout or "")
+    cost_usd, result_payload = _parse_claude_proposer_result(proc.stdout or "")
 
     (log_dir / f"iter{iteration}_meta.json").write_text(
         json.dumps(
             {
                 "iteration": iteration,
+                "proposer": "claude",
                 "session_id": session_id,
                 "exit_code": proc.returncode,
                 "cost_usd": cost_usd,
                 "cmd": cmd,
                 "stderr_tail": (proc.stderr or "")[-2000:],
-                # Echo a few top-level result fields so a reviewer doesn't have
-                # to jump into stdout.json.
                 "result_summary": {
                     "duration_ms": result_payload.get("duration_ms"),
                     "num_turns": result_payload.get("num_turns"),
@@ -366,7 +665,54 @@ def _run_proposer(
     return proc.returncode, cost_usd, session_id
 
 
-def _parse_proposer_result(stdout: str) -> tuple[float, dict[str, Any]]:
+def _run_codex_proposer(
+    *,
+    work_dir: Path,
+    iteration: int,
+    model: str,
+    prompt: str,
+    log_dir: Path,
+    sandbox: bool,
+) -> tuple[int, float, str]:
+    cmd = _build_codex_proposer_cmd(work_dir=work_dir, prompt=prompt, model=model, sandbox=sandbox)
+    env = {**os.environ, "GEPA_OMNI_WORK_DIR": str(work_dir)}
+
+    proc = subprocess.run(cmd, cwd=str(work_dir), env=env, capture_output=True, text=True)
+    (log_dir / f"iter{iteration}_stdout.jsonl").write_text(proc.stdout or "")
+    (log_dir / f"iter{iteration}_stderr.txt").write_text(proc.stderr or "")
+
+    parsed = _parse_codex_proposer_result(proc.stdout or "")
+    session_id = parsed["thread_id"] or str(uuid.uuid4())
+    # Surface turn.failed / error events as a non-zero logical exit even when
+    # the CLI itself returned 0 (defensive; usually the CLI exits non-zero).
+    exit_code = proc.returncode
+    if exit_code == 0 and parsed["is_error"]:
+        exit_code = 1
+
+    (log_dir / f"iter{iteration}_meta.json").write_text(
+        json.dumps(
+            {
+                "iteration": iteration,
+                "proposer": "codex",
+                "session_id": session_id,
+                "exit_code": exit_code,
+                # Codex JSONL exposes token usage but not USD; report 0.
+                "cost_usd": 0.0,
+                "cmd": cmd,
+                "stderr_tail": (proc.stderr or "")[-2000:],
+                "result_summary": {
+                    "usage": parsed["usage"],
+                    "is_error": parsed["is_error"],
+                    "error": parsed["error"],
+                },
+            },
+            indent=2,
+        )
+    )
+    return exit_code, 0.0, session_id
+
+
+def _parse_claude_proposer_result(stdout: str) -> tuple[float, dict[str, Any]]:
     """Extract (cost_usd, result_payload) from ``claude --output-format json``.
 
     The CLI prints exactly one JSON object to stdout once the session ends:
@@ -401,6 +747,59 @@ def _parse_proposer_result(stdout: str) -> tuple[float, dict[str, Any]]:
     except (TypeError, ValueError):
         cost = 0.0
     return cost, payload
+
+
+# Back-compat alias for callers / tests that imported the old name.
+_parse_proposer_result = _parse_claude_proposer_result
+
+
+def _parse_codex_proposer_result(stdout: str) -> dict[str, Any]:
+    """Parse ``codex exec --json`` JSONL into session id and token usage.
+
+    Event types of interest (one JSON object per line)::
+
+        {"type":"thread.started","thread_id":"..."}
+        {"type":"turn.completed","usage":{"input_tokens":...,"output_tokens":...}}
+        {"type":"turn.failed",...}
+        {"type":"error",...}
+
+    Codex does not report USD in this stream; callers treat proposer cost as 0.
+    """
+    thread_id = ""
+    usage: dict[str, Any] | None = None
+    is_error = False
+    error: str | None = None
+
+    for raw_line in (stdout or "").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(event, dict):
+            continue
+        etype = event.get("type")
+        if etype == "thread.started":
+            tid = event.get("thread_id")
+            if isinstance(tid, str) and tid:
+                thread_id = tid
+        elif etype == "turn.completed":
+            raw_usage = event.get("usage")
+            if isinstance(raw_usage, dict):
+                usage = raw_usage
+        elif etype in ("turn.failed", "error"):
+            is_error = True
+            if error is None:
+                error = str(event.get("error") or event.get("message") or etype)
+
+    return {
+        "thread_id": thread_id,
+        "usage": usage,
+        "is_error": is_error,
+        "error": error,
+    }
 
 
 def _read_pending(pending_path: Path) -> list[dict[str, Any]]:
@@ -629,6 +1028,7 @@ class MetaHarnessEngine:
 
     def __init__(self, config: OptimizeAnythingConfig) -> None:
         engine_config = MetaHarnessConfig(**config.engine_config)
+        self.proposer = engine_config.proposer
         self.model = engine_config.model
         self.max_iterations = engine_config.max_iterations
         self.max_candidates_per_iter = engine_config.max_candidates_per_iter
@@ -637,14 +1037,24 @@ class MetaHarnessEngine:
         self.run_dir = config.run_dir
         self.stop_at_score = config.stop_at_score
         self.sandbox = config.sandbox
-        # Proposer-cost cap: USD this engine may spend across its claude
-        # subprocess sessions. Enforced via --max-budget-usd; the eval server
-        # never sees proposer spend.
+        # Proposer-cost cap: USD this engine may spend across its agent
+        # subprocess sessions. Claude enforces via --max-budget-usd; Codex
+        # has no USD signal, so reject max_token_cost for proposer="codex"
+        # (use max_evals / max_iterations instead). The eval server never
+        # sees proposer spend.
+        if self.proposer == "codex" and config.max_token_cost is not None:
+            raise ValueError(
+                "meta_harness proposer='codex' cannot enforce max_token_cost "
+                "(Codex reports no USD); set max_evals / max_iterations instead"
+            )
         self.max_token_cost = config.max_token_cost
         self._pending_tempdir: tempfile.TemporaryDirectory[str] | None = None
 
     def run(self, task: Task, server: EvalServer) -> Result:
-        preflight_claude_engine(self.name, sandbox=bool(self.sandbox))
+        if self.proposer == "codex":
+            preflight_codex_engine(self.name, sandbox=bool(self.sandbox))
+        else:
+            preflight_claude_engine(self.name, sandbox=bool(self.sandbox))
         budget = server.budget
 
         # When sandbox=True, force tempdir work_dir even if run_dir is set —
@@ -661,7 +1071,7 @@ class MetaHarnessEngine:
             self._pending_tempdir = tempfile.TemporaryDirectory(prefix="optimize_anything_mh_")
             work_dir = Path(self._pending_tempdir.name)
 
-        _materialize_sandbox(work_dir, task, server, budget)
+        _materialize_sandbox(work_dir, task, server, budget, proposer=self.proposer)
 
         state_dir = work_dir / "state"
         frontier_path = state_dir / "frontier.json"
@@ -711,6 +1121,7 @@ class MetaHarnessEngine:
                 log_dir=sessions_dir,
                 max_thinking_tokens=self.max_thinking_tokens,
                 sandbox=bool(self.sandbox),
+                proposer=self.proposer,
             )
             propose_time = time.time() - propose_start
             total_proposer_cost += cost
@@ -923,6 +1334,7 @@ class MetaHarnessEngine:
                 "meta_harness": {
                     "iterations_run": iteration,
                     "stop_reason": stop_reason,
+                    "proposer": self.proposer,
                     "proposer_cost": total_proposer_cost,
                     "session_ids": session_ids,
                     "work_dir": str(work_dir),

--- a/src/gepa/oa/sandbox.py
+++ b/src/gepa/oa/sandbox.py
@@ -1,8 +1,8 @@
-"""External bubblewrap jail for ``claude --print`` subprocesses.
+"""External bubblewrap jail for coding-agent subprocesses (Claude / Codex).
 
-Wraps the whole ``claude`` invocation in our own ``bwrap`` namespace instead
-of relying on Claude Code's built-in ``sandbox.enabled: true`` settings. The
-internal sandbox crashes on Ubuntu 24.04 with
+Wraps the whole agent invocation in our own ``bwrap`` namespace instead of
+relying on each CLI's built-in sandbox. Claude Code's internal sandbox
+crashes on Ubuntu 24.04 with
 ``bwrap: Can't mount tmpfs on /newroot/sbin: No such file or directory``
 because it tries to mount tmpfs on top of ``/sbin``, which is a symlink in
 the merged-``/usr`` layout. We control the bwrap argv, so we can detect
@@ -17,17 +17,18 @@ Layout we expose inside the jail:
 - ``/etc``: only the handful of files needed for DNS, certs, and user
   lookups (``resolv.conf``, ``hosts``, ``passwd``, ``group``, ``ssl``...).
 - ``/proc``, ``/dev``, ``/tmp``: standard mounts.
-- ``$HOME/.claude``, ``$HOME/.claude.json``, ``$HOME/.cache``: writable.
-- ``$HOME/.local``: read-only — ``claude`` itself lives under here.
+- Agent home dirs (``agent=`` selects which):
+  - ``claude``: ``$HOME/.claude``, ``$HOME/.claude.json``, ``$HOME/.cache``
+    writable; ``$HOME/.local`` read-only (where ``claude`` often lives).
+  - ``codex``: ``$HOME/.codex``, ``$HOME/.cache`` writable — no Claude paths.
 - ``work_dir``: the only writable path under ``/data``-style trees.
 
 Network namespace is shared with the host so the agent can reach
-``localhost:<eval-server-port>`` and ``api.anthropic.com``. ``WebFetch`` /
+``localhost:<eval-server-port>`` and the model API. Claude's ``WebFetch`` /
 ``WebSearch`` are denied at the tool layer via :data:`DENY_WEB_TOOLS`.
 
-macOS fallback: bwrap is Linux-only. On macOS we use Claude Code's
-built-in Seatbelt sandbox via :func:`claude_settings_args`, which the
-caller appends to the ``claude --print`` argv.
+macOS fallback: bwrap is Linux-only. On macOS Claude uses Seatbelt via
+:func:`claude_settings_args`; Codex uses ``--sandbox workspace-write``.
 """
 
 from __future__ import annotations
@@ -98,20 +99,70 @@ def _etc_bind_args() -> list[str]:
     return args
 
 
+def _bind_if_exists(args: list[str], path: Path, *, readonly: bool = False) -> None:
+    """Append a bwrap bind for ``path`` when it already exists on the host."""
+    if not (path.exists() or path.is_symlink()):
+        return
+    flag = "--ro-bind" if readonly else "--bind"
+    resolved = str(path.resolve()) if path.exists() else str(path)
+    args.extend([flag, resolved, resolved])
+
+
+def _agent_home_bind_args(home: Path, agent: str) -> list[str]:
+    """Return agent-specific ``$HOME`` binds for the bwrap jail.
+
+    Ensures writable dirs we own exist before binding so a Codex-only host
+    never needs Claude Code paths, and a Claude host never needs ``~/.codex``.
+    """
+    raw = (agent or "claude").strip().lower()
+    if raw in ("claude", "claude-code"):
+        agent_key = "claude"
+    elif raw == "codex":
+        agent_key = "codex"
+    else:
+        raise ValueError(f"bwrap_prefix agent must be 'claude' or 'codex', got {agent!r}")
+
+    args: list[str] = []
+    cache = home / ".cache"
+    cache.mkdir(parents=True, exist_ok=True)
+    _bind_if_exists(args, cache)
+
+    if agent_key == "claude":
+        claude_dir = home / ".claude"
+        claude_dir.mkdir(parents=True, exist_ok=True)
+        _bind_if_exists(args, claude_dir)
+        claude_json = home / ".claude.json"
+        # Preserve prior Claude behavior: bind the credentials file when present.
+        # Do not create an empty file — auth must come from a real CLI login.
+        _bind_if_exists(args, claude_json)
+        _bind_if_exists(args, home / ".local", readonly=True)
+    else:
+        codex_dir = home / ".codex"
+        codex_dir.mkdir(parents=True, exist_ok=True)
+        _bind_if_exists(args, codex_dir)
+
+    return args
+
+
 def bwrap_prefix(
     work_dir: Path | str,
     *,
     extra_writable: list[Path | str] | None = None,
+    agent: str = "claude",
 ) -> list[str]:
     """Return the ``bwrap`` argv prefix that jails everything that follows.
 
-    Returns ``[]`` on macOS — that platform uses :func:`claude_settings_args`
-    as a fallback because ``bwrap`` is Linux-only. Caller usage works on both
-    platforms::
+    Returns ``[]`` on macOS — that platform uses per-CLI sandboxes (Claude
+    Seatbelt via :func:`claude_settings_args`, Codex ``workspace-write``)
+    because ``bwrap`` is Linux-only. Caller usage works on both platforms::
 
         cmd = bwrap_prefix(work_dir)               # Linux: bwrap argv. macOS: [].
         cmd += ["claude", "--print", ...]
         cmd += claude_settings_args(work_dir)      # macOS: --settings JSON. Linux: [].
+
+    ``agent`` selects which ``$HOME`` auth/config dirs are bound (``"claude"``
+    default, or ``"codex"``). Absent optional paths are skipped so a Codex-only
+    host does not need Claude Code installed.
     """
     if _IS_MACOS:
         return []
@@ -129,18 +180,7 @@ def bwrap_prefix(
         "/tmp",
         *_system_bind_args(),
         *_etc_bind_args(),
-        "--bind",
-        str(home / ".claude"),
-        str(home / ".claude"),
-        "--bind",
-        str(home / ".claude.json"),
-        str(home / ".claude.json"),
-        "--ro-bind",
-        str(home / ".local"),
-        str(home / ".local"),
-        "--bind",
-        str(home / ".cache"),
-        str(home / ".cache"),
+        *_agent_home_bind_args(home, agent),
         "--bind",
         str(work),
         str(work),
@@ -300,6 +340,34 @@ def require_claude_cli(engine_name: str) -> None:
     )
 
 
+def require_codex_cli(engine_name: str) -> None:
+    """Abort with a boxed error when the ``codex`` CLI is not on PATH.
+
+    ``meta_harness`` with ``proposer="codex"`` shells out to ``codex exec``;
+    fail up front with install instructions instead of a mid-run
+    ``FileNotFoundError``.
+    """
+    if shutil.which("codex"):
+        return
+    print(
+        _boxed_message(
+            "CODEX CLI NOT FOUND",
+            [
+                f"The {engine_name!r} engine is configured with proposer='codex',",
+                "but no `codex` executable is on PATH.",
+                "",
+                "Install the OpenAI Codex CLI first:",
+                "  npm install -g @openai/codex",
+                "  (or: brew install --cask codex)",
+                "then run `codex login` (or set CODEX_API_KEY) and retry.",
+            ],
+        ),
+        file=sys.stderr,
+        flush=True,
+    )
+    raise RuntimeError(f"the {engine_name!r} engine requires the Codex CLI (`codex`), which was not found on PATH")
+
+
 def require_bwrap(engine_name: str) -> None:
     """Abort with a boxed error when ``sandbox=True`` can't be honored.
 
@@ -313,7 +381,7 @@ def require_bwrap(engine_name: str) -> None:
         _boxed_message(
             "SANDBOX UNAVAILABLE: bwrap NOT FOUND",
             [
-                "sandbox=True jails the Claude Code subprocess with bubblewrap on",
+                "sandbox=True jails the agent subprocess with bubblewrap on",
                 "Linux, but no `bwrap` executable is on PATH.",
                 "",
                 "Install it:",
@@ -333,20 +401,20 @@ def require_bwrap(engine_name: str) -> None:
     )
 
 
-def warn_sandbox_disabled(engine_name: str) -> None:
+def warn_sandbox_disabled(engine_name: str, *, agent: str = "Claude Code") -> None:
     """Print a boxed warning when the user opts out of sandboxing. Continues."""
     print(
         _boxed_message(
             "SANDBOX DISABLED",
             [
-                f"sandbox=False: the {engine_name!r} engine's Claude Code subprocess",
-                "runs with --permission-mode bypassPermissions and NO OS-level",
-                "confinement — unrestricted Bash plus read/write access to your",
-                "files as this user. Only web tools (WebFetch/WebSearch) are",
-                "disabled. While normally harmless, this is potentially DANGEROUS!",
+                f"sandbox=False: the {engine_name!r} engine's {agent} subprocess",
+                "runs with NO OS-level confinement — unrestricted Bash plus",
+                "read/write access to your files as this user. While normally",
+                "harmless, this is potentially DANGEROUS!",
                 "",
                 "Set sandbox=True (the default) to confine it to a throwaway",
-                "work dir (bwrap on Linux, Seatbelt on macOS).",
+                "work dir (bwrap on Linux; Claude Seatbelt / Codex",
+                "workspace-write on macOS).",
             ],
         ),
         file=sys.stderr,
@@ -366,4 +434,18 @@ def preflight_claude_engine(engine_name: str, *, sandbox: bool) -> None:
     if sandbox:
         require_bwrap(engine_name)
     else:
-        warn_sandbox_disabled(engine_name)
+        warn_sandbox_disabled(engine_name, agent="Claude Code")
+
+
+def preflight_codex_engine(engine_name: str, *, sandbox: bool) -> None:
+    """Run all launch-time checks for a Codex-subprocess engine.
+
+    Used by ``meta_harness`` when ``proposer="codex"``: verifies the ``codex``
+    CLI exists, then either verifies the bwrap jail can be built on Linux
+    (``sandbox=True``) or warns that the agent will run unconfined.
+    """
+    require_codex_cli(engine_name)
+    if sandbox:
+        require_bwrap(engine_name)
+    else:
+        warn_sandbox_disabled(engine_name, agent="Codex")

--- a/tests/test_optimize_anything_meta_harness_codex.py
+++ b/tests/test_optimize_anything_meta_harness_codex.py
@@ -1,0 +1,363 @@
+"""Unit tests for meta_harness Codex CLI proposer support (mocked subprocess)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gepa.oa.config import OptimizeAnythingConfig
+from gepa.oa.engines.meta_harness import (
+    MetaHarnessConfig,
+    MetaHarnessEngine,
+    _build_claude_proposer_cmd,
+    _build_codex_proposer_cmd,
+    _parse_codex_proposer_result,
+    _proposer_prompt,
+)
+
+
+def test_config_default_proposer_is_claude() -> None:
+    cfg = MetaHarnessConfig()
+    assert cfg.proposer == "claude"
+    assert cfg.model == "claude-sonnet-4-6"
+
+
+def test_config_codex_rewrites_claude_default_model() -> None:
+    cfg = MetaHarnessConfig(proposer="codex")
+    assert cfg.proposer == "codex"
+    assert cfg.model == "gpt-5.6-terra"
+
+
+def test_config_codex_keeps_explicit_model() -> None:
+    cfg = MetaHarnessConfig(proposer="codex", model="o4-mini")
+    assert cfg.model == "o4-mini"
+
+
+def test_config_claude_code_alias() -> None:
+    cfg = MetaHarnessConfig(proposer="claude-code")
+    assert cfg.proposer == "claude"
+
+
+def test_config_invalid_proposer() -> None:
+    with pytest.raises(ValueError, match="claude.*codex"):
+        MetaHarnessConfig(proposer="goose")
+
+
+def test_config_codex_warns_on_claude_knobs() -> None:
+    with pytest.warns(UserWarning, match="ignores"):
+        MetaHarnessConfig(proposer="codex", effort="high", max_thinking_tokens=8000)
+
+
+def test_engine_wires_proposer() -> None:
+    engine = MetaHarnessEngine(
+        OptimizeAnythingConfig(engine="meta_harness", engine_config={"proposer": "codex"}, sandbox=False)
+    )
+    assert engine.proposer == "codex"
+    assert engine.model == "gpt-5.6-terra"
+
+
+def test_build_codex_cmd_mac_sandbox(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("gepa.oa.engines.meta_harness._is_macos", lambda: True)
+    # Real bwrap_prefix returns [] on macOS; keep that contract.
+    monkeypatch.setattr("gepa.oa.engines.meta_harness.bwrap_prefix", lambda *a, **k: [])
+    cmd = _build_codex_proposer_cmd(work_dir=tmp_path, prompt="do the thing", model="gpt-5.6-terra", sandbox=True)
+    assert cmd[0] == "codex"
+    assert "bwrap" not in cmd
+    assert cmd[:4] == ["codex", "exec", "--json", "--skip-git-repo-check"]
+    assert "-C" in cmd and str(tmp_path.resolve()) in cmd
+    assert "-m" in cmd and "gpt-5.6-terra" in cmd
+    assert "--sandbox" in cmd and "workspace-write" in cmd
+    assert "--dangerously-bypass-approvals-and-sandbox" not in cmd
+    assert cmd[-1] == "do the thing"
+
+
+def test_build_codex_cmd_linux_sandbox(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("gepa.oa.engines.meta_harness._is_macos", lambda: False)
+    captured: dict[str, object] = {}
+
+    def fake_bwrap(work_dir, **kwargs):
+        captured["work_dir"] = work_dir
+        captured["kwargs"] = kwargs
+        return ["bwrap", "--bind", str(work_dir)]
+
+    monkeypatch.setattr("gepa.oa.engines.meta_harness.bwrap_prefix", fake_bwrap)
+    cmd = _build_codex_proposer_cmd(work_dir=tmp_path, prompt="propose", model="o4-mini", sandbox=True)
+    assert cmd[:2] == ["bwrap", "--bind"]
+    assert "codex" in cmd
+    assert "--dangerously-bypass-approvals-and-sandbox" in cmd
+    assert "workspace-write" not in cmd
+    assert captured["kwargs"] == {"agent": "codex"}
+
+
+def test_build_codex_cmd_unsandboxed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("gepa.oa.engines.meta_harness._is_macos", lambda: True)
+    cmd = _build_codex_proposer_cmd(work_dir=tmp_path, prompt="x", model="gpt-5.6-terra", sandbox=False)
+    assert cmd[0] == "codex"
+    assert "--sandbox" in cmd and "danger-full-access" in cmd
+
+
+def test_build_claude_cmd_unchanged_shape(tmp_path: Path) -> None:
+    cmd = _build_claude_proposer_cmd(
+        work_dir=tmp_path,
+        prompt="run iter",
+        model="claude-sonnet-4-6",
+        effort=None,
+        max_budget_usd=1.5,
+        session_id="sid-123",
+        sandbox=False,
+    )
+    assert "claude" in cmd
+    assert "--print" in cmd
+    assert "--output-format" in cmd and "json" in cmd
+    assert "--session-id" in cmd and "sid-123" in cmd
+    assert "--max-budget-usd" in cmd and "1.5000" in cmd
+    assert "codex" not in cmd
+
+
+def test_proposer_prompt_points_at_agents_md_for_codex(tmp_path: Path) -> None:
+    prompt = _proposer_prompt(
+        work_dir=tmp_path,
+        iteration=2,
+        max_candidates=3,
+        pending_path=tmp_path / "state" / "pending.json",
+        proposer="codex",
+    )
+    assert "AGENTS.md" in prompt
+    assert ".claude/skills" not in prompt
+
+
+def test_proposer_prompt_points_at_skill_for_claude(tmp_path: Path) -> None:
+    prompt = _proposer_prompt(
+        work_dir=tmp_path,
+        iteration=1,
+        max_candidates=3,
+        pending_path=tmp_path / "pending.json",
+        proposer="claude",
+    )
+    assert ".claude/skills" in prompt
+
+
+def test_parse_codex_jsonl_session_usage_cost() -> None:
+    stdout = "\n".join(
+        [
+            json.dumps({"type": "thread.started", "thread_id": "thread-abc"}),
+            json.dumps({"type": "turn.started"}),
+            json.dumps(
+                {
+                    "type": "turn.completed",
+                    "usage": {
+                        "input_tokens": 1_000_000,
+                        "cached_input_tokens": 0,
+                        "output_tokens": 500_000,
+                        "reasoning_output_tokens": 0,
+                    },
+                }
+            ),
+        ]
+    )
+    parsed = _parse_codex_proposer_result(stdout)
+    assert parsed["thread_id"] == "thread-abc"
+    assert parsed["usage"]["input_tokens"] == 1_000_000
+    assert parsed["is_error"] is False
+
+
+def test_parse_codex_jsonl_error_event() -> None:
+    stdout = "\n".join(
+        [
+            json.dumps({"type": "thread.started", "thread_id": "t1"}),
+            json.dumps({"type": "turn.failed", "error": "boom"}),
+        ]
+    )
+    parsed = _parse_codex_proposer_result(stdout)
+    assert parsed["is_error"] is True
+    assert parsed["error"] == "boom"
+
+
+def test_materialize_writes_agents_md_for_codex(tmp_path: Path) -> None:
+    from gepa.oa.budget import BudgetTracker
+    from gepa.oa.engines.meta_harness import _materialize_sandbox
+    from gepa.oa.task import Task
+
+    class _FakeServer:
+        def iter_split(self, split: str):
+            return iter(())
+
+    task = Task(name="t", seed_candidate="hello", train_set=None, val_set=None, test_set=None)
+    _materialize_sandbox(tmp_path, task, _FakeServer(), BudgetTracker(max_evals=10), proposer="codex")
+    assert (tmp_path / "AGENTS.md").exists()
+    assert not (tmp_path / ".claude" / "skills" / "gepa-optimize-anything-meta-harness" / "SKILL.md").exists()
+    assert (tmp_path / "agents" / "baseline.txt").read_text() == "hello"
+
+
+def test_materialize_writes_skill_for_claude(tmp_path: Path) -> None:
+    from gepa.oa.budget import BudgetTracker
+    from gepa.oa.engines.meta_harness import _materialize_sandbox
+    from gepa.oa.task import Task
+
+    class _FakeServer:
+        def iter_split(self, split: str):
+            return iter(())
+
+    task = Task(name="t", seed_candidate="hello", train_set=None, val_set=None, test_set=None)
+    _materialize_sandbox(tmp_path, task, _FakeServer(), BudgetTracker(max_evals=10), proposer="claude")
+    assert (tmp_path / ".claude" / "skills" / "gepa-optimize-anything-meta-harness" / "SKILL.md").exists()
+    assert not (tmp_path / "AGENTS.md").exists()
+
+
+def test_run_proposer_codex_invokes_subprocess(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from gepa.oa.engines import meta_harness as mh
+
+    monkeypatch.setattr(mh, "_is_macos", lambda: True)
+
+    captured: dict[str, object] = {}
+
+    class _Proc:
+        returncode = 0
+        stdout = json.dumps({"type": "thread.started", "thread_id": "tid-1"}) + "\n"
+        stdout += json.dumps({"type": "turn.completed", "usage": {"input_tokens": 100, "output_tokens": 50}})
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return _Proc()
+
+    monkeypatch.setattr(mh.subprocess, "run", fake_run)
+    log_dir = tmp_path / "sessions"
+    pending = tmp_path / "pending.json"
+    code, cost, sid = mh._run_proposer(
+        work_dir=tmp_path,
+        iteration=1,
+        model="gpt-5.6-terra",
+        effort=None,
+        max_candidates=2,
+        max_budget_usd=None,
+        pending_path=pending,
+        log_dir=log_dir,
+        sandbox=False,
+        proposer="codex",
+    )
+    assert code == 0
+    assert sid == "tid-1"
+    assert cost >= 0.0
+    cmd = captured["cmd"]
+    assert isinstance(cmd, list)
+    assert cmd[0] == "codex"
+    assert (log_dir / "iter1_stdout.jsonl").exists()
+    assert (log_dir / "iter1_meta.json").exists()
+
+
+def test_preflight_codex_requires_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    from gepa.oa import sandbox as sb
+
+    monkeypatch.setattr(sb.shutil, "which", lambda name: None if name == "codex" else "/bin/true")
+    with pytest.raises(RuntimeError, match="Codex CLI"):
+        sb.require_codex_cli("meta_harness")
+
+
+def test_engine_run_calls_codex_preflight(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from gepa.oa.budget import BudgetTracker
+    from gepa.oa.engines import meta_harness as mh
+    from gepa.oa.task import Task
+
+    called: list[tuple[str, bool]] = []
+
+    monkeypatch.setattr(
+        mh,
+        "preflight_codex_engine",
+        lambda name, *, sandbox: called.append((name, sandbox)),
+    )
+    monkeypatch.setattr(mh, "preflight_claude_engine", lambda *a, **k: (_ for _ in ()).throw(AssertionError("claude")))
+
+    # Short-circuit the loop: budget already exhausted.
+    class _Server:
+        budget = BudgetTracker(max_evals=0)
+        best_candidate = "seed"
+        best_score = 0.0
+
+        def __init__(self) -> None:
+            self.eval_log: list = []
+
+        def iter_split(self, split: str):
+            return iter(())
+
+    engine = MetaHarnessEngine(
+        OptimizeAnythingConfig(
+            engine="meta_harness",
+            engine_config={"proposer": "codex", "max_iterations": 1},
+            sandbox=False,
+            run_dir=str(tmp_path),
+            max_evals=0,
+        )
+    )
+    task = Task(name="t", seed_candidate="seed", train_set=None, val_set=None, test_set=None)
+    # BudgetTracker(max_evals=0) → exhausted immediately; run still materializes + preflights.
+    with patch.object(engine, "_best_score", return_value=None):
+        result = engine.run(task, _Server())  # type: ignore[arg-type]
+    assert called == [("meta_harness", False)]
+    assert result.metadata["meta_harness"]["proposer"] == "codex"
+
+
+def test_bwrap_prefix_codex_omits_claude_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Codex-only Linux host must not require ~/.claude* binds."""
+    from gepa.oa import sandbox as sb
+
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".codex").mkdir()
+    # Deliberately no ~/.claude or ~/.claude.json
+    monkeypatch.setattr(sb, "_IS_MACOS", False)
+    monkeypatch.setattr(sb.Path, "home", classmethod(lambda cls: home))
+
+    cmd = sb.bwrap_prefix(tmp_path / "work", agent="codex")
+    joined = " ".join(cmd)
+    assert str(home / ".codex") in joined
+    assert str(home / ".cache") in joined
+    assert ".claude" not in joined
+
+
+def test_bwrap_prefix_claude_includes_claude_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from gepa.oa import sandbox as sb
+
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude").mkdir()
+    (home / ".claude.json").write_text("{}")
+    (home / ".local").mkdir()
+    monkeypatch.setattr(sb, "_IS_MACOS", False)
+    monkeypatch.setattr(sb.Path, "home", classmethod(lambda cls: home))
+
+    cmd = sb.bwrap_prefix(tmp_path / "work", agent="claude")
+    joined = " ".join(cmd)
+    assert str(home / ".claude") in joined
+    assert str(home / ".claude.json") in joined
+    assert str(home / ".local") in joined
+    assert ".codex" not in joined
+
+
+def test_engine_rejects_max_token_cost_for_codex() -> None:
+    with pytest.raises(ValueError, match="max_token_cost"):
+        MetaHarnessEngine(
+            OptimizeAnythingConfig(
+                engine="meta_harness",
+                engine_config={"proposer": "codex"},
+                max_token_cost=1.0,
+                sandbox=False,
+            )
+        )
+
+
+def test_engine_allows_codex_without_max_token_cost() -> None:
+    engine = MetaHarnessEngine(
+        OptimizeAnythingConfig(
+            engine="meta_harness",
+            engine_config={"proposer": "codex"},
+            max_token_cost=None,
+            sandbox=False,
+        )
+    )
+    assert engine.proposer == "codex"
+    assert engine.max_token_cost is None


### PR DESCRIPTION
## Summary
- Add `engine_config={"proposer": "codex"}` to `meta_harness`, keeping Claude Code as the default proposer.
- Provide `AGENTS.md` for Codex (vs Claude skill), with agent-aware Linux `bwrap` home binds so Codex runs do not require Claude paths.
- Reject `max_token_cost` when `proposer="codex"`; bound those runs with `max_evals` / `max_iterations`. Update skill docs + preflight (`--proposer codex`).
- Resolves #417 (concern 2)