### PR TITLE
refactor(oa): unify optimize_anything on a single GEPAResult return

### DIFF
--- a/.claude/skills/gepa-optimize-anything/SKILL.md
+++ b/.claude/skills/gepa-optimize-anything/SKILL.md
@@ -140,7 +140,7 @@ a "best candidate" that looks fine but is barely optimized.
   themselves how to spend eval calls, so treat it as a floor.)
 
 After the run, check how many proposals actually happened (on the gepa backend,
-`result.metadata["gepa_result"]` holds every candidate; with `engine.write_agent_state=True` the
+`result.candidates` is the full pool; with `engine.write_agent_state=True` the
 `run_dir/iterations/` tree shows each one). **If it stopped after one proposal, the budget was too
 low** — raise it and rerun.
 
@@ -248,7 +248,7 @@ These silently degrade *results* — skim before launching:
 
 ## Reference files (load as needed)
 - `references/api.md` — `OptimizeAnythingConfig`, the backends and their typed `engine_config`
-  options, the three modes, the LM protocol, budget/cost semantics, `Result` shape, and the
+  options, the three modes, the LM protocol, budget/cost semantics, `GEPAResult` shape, and the
   composition/pipeline helpers.
 - `references/writing_evaluators.md` — the `(score, info)` contract, `oa.log()`/`capture_stdio`,
   LLM-as-judge scoring, multi-objective via `info["scores"]`, N>1 averaging, feedback design.

--- a/.claude/skills/gepa-optimize-anything/references/api.md
+++ b/.claude/skills/gepa-optimize-anything/references/api.md
@@ -4,7 +4,7 @@ The public entry point is `gepa.optimize_anything.optimize_anything`.
 
 ## Signature
 ```python
-from gepa.optimize_anything import optimize_anything, OptimizeAnythingConfig
+from gepa.optimize_anything import GEPAResult, optimize_anything, OptimizeAnythingConfig
 
 result = optimize_anything(
     seed_candidate: str | None = None,   # starting text; None = seedless (engine bootstraps from objective/background)
@@ -17,7 +17,7 @@ result = optimize_anything(
     background: str | None = None,       # long-form rules/constraints/domain notes
     test_set: list | None = None,        # reporting-only: seed + final candidate scored here at the end
     config: OptimizeAnythingConfig | None = None,
-) -> Result
+) -> GEPAResult
 ```
 Examples in `dataset`/`valset`/`test_set` are opaque — any object your `evaluator` understands.
 `seed_candidate` is a **single string** at this API (multi-component `dict[str, str]` candidates
@@ -220,21 +220,40 @@ take caller-owned `EvalServer`s — one per config (one shared server for
 eval through their own server. Related: the autoresearch backend's `handoffs` key materializes
 prior-stage artifacts into the agent's work dir for hand-rolled sequential compositions.
 
-## `Result`
+## `GEPAResult`
+
+`optimize_anything` always returns a `GEPAResult` (the same type as the legacy
+`gepa.gepa_launcher` path). The mutable engine-internal `Result` is still what
+engines and ensemble helpers thread; it is not the public return.
+
 ```python
-result.best_candidate   # str
+result.best_candidate   # str (or dict[str, str] for multi-component seeds)
 result.best_score       # float (on valset/selection set)
-result.total_evals      # int
+result.total_evals      # int — eval-server call count (budget.used)
 result.eval_log         # list[dict]
 result.metadata         # dict (verified keys):
-#   "gepa_result"            full GEPAResult (all candidates + per-instance val scores) — gepa engine only
 #   "test_score"             avg over test_set         } only present
 #   "test_scores"            per-example dict          } if you passed
 #   "baseline_test_score"    seed avg over test_set    } a test_set
 #   "baseline_test_scores"   seed per-example dict     }
 #   "budget", "total_cost", "adapter_cost", "wall_time", "engine", "output_dir", "progress_log"
+result.candidates            # full candidate pool (length 1 on non-gepa engines)
+result.best_idx              # index of the highest val score
+result.val_aggregate_scores  # per-candidate average validation score
+result.to_dict()             # JSON-safe pool snapshot (does not include eval_log / metadata)
 ```
+
+The candidate pool lives on the result itself. `metadata` does **not** contain a nested
+`gepa_result`. `total_evals` is the eval-server count; `total_metric_calls` is GEPA core's
+own counter and may differ (e.g. after `BudgetExhausted`). `to_dict()` / `from_dict()` omit
+`eval_log`, `metadata`, and `eval_server_calls` so the frozen JSON pool contract stays
+byte-stable.
+
 The gepa engine also writes `run_dir/` artifacts, and the eval server writes
-`output_dir/summary.json`. The `gepa_result` in metadata is the richest artifact — keep it for
-post-hoc analysis. (If the best candidate equals the seed, the test scores are reported from the
+`output_dir/summary.json`. (If the best candidate equals the seed, the test scores are reported from the
 seed's single scoring pass rather than re-scored.)
+
+**Migration:** callers that used `isinstance(result, Result)` or
+`result.metadata["gepa_result"]` after `optimize_anything(...)` should switch to
+`GEPAResult` and `result.candidates`. Ensemble helpers (`optimize_sequential`, …)
+still return the mutable `Result`.

--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,7 @@ runs/
 outputs/
 gepa_terminus/
 archive/
+
+# Local MLflow tracking artifacts (TrackingConfig(use_mlflow=True))
+mlflow.db
+mlruns/

--- a/src/gepa/core/result.py
+++ b/src/gepa/core/result.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
 # https://github.com/gepa-ai/gepa
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, Generic
 
 from gepa.core.adapter import RolloutOutput
@@ -61,6 +61,15 @@ class GEPAResult(Generic[RolloutOutput, DataId]):
     # This is the internal dict key used to wrap str seed_candidates.
     _str_candidate_key: str | None = None
 
+    # Universal-core run data, populated on every run regardless of engine.
+    # Generic (non-gepa) engines return a single-candidate snapshot but still
+    # carry their eval log and free-form metadata (wall time, budget, cost,
+    # held-out test scores, ...). These are runtime conveniences and are
+    # intentionally NOT part of ``to_dict()`` — that stays a JSON-safe pool
+    # snapshot for the frozen serialization contract.
+    eval_log: list[dict[str, Any]] | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
     _VALIDATION_SCHEMA_VERSION: ClassVar[int] = 2
 
     # -------- Convenience properties --------
@@ -76,6 +85,24 @@ class GEPAResult(Generic[RolloutOutput, DataId]):
     def best_idx(self) -> int:
         scores = self.val_aggregate_scores
         return max(range(len(scores)), key=lambda i: scores[i])
+
+    @property
+    def best_score(self) -> float:
+        """Aggregate validation score of the best candidate.
+
+        The lean-``Result`` accessor, computed from the pool so it is valid on
+        every run (generic engines carry a single-candidate pool). Returns
+        ``-inf`` only for the degenerate empty pool.
+        """
+        scores = self.val_aggregate_scores
+        return scores[self.best_idx] if scores else float("-inf")
+
+    @property
+    def total_evals(self) -> int:
+        """Total eval-server calls, mirroring the lean ``Result.total_evals``."""
+        if self.total_metric_calls is not None:
+            return self.total_metric_calls
+        return sum(self.discovery_eval_counts)
 
     @property
     def best_candidate(self) -> str | dict[str, str]:

--- a/src/gepa/core/result.py
+++ b/src/gepa/core/result.py
@@ -20,15 +20,27 @@ class GEPAResult(Generic[RolloutOutput, DataId]):
         best_candidate: The optimized parameter(s) — ``dict[str, str]`` or plain
             ``str`` when ``seed_candidate`` was a string.
         best_idx: Index of the highest-scoring candidate.
+        best_score: Aggregate validation score of the best candidate.
+        total_evals: Eval-server call count when this result came from
+            :func:`~gepa.optimize_anything.optimize_anything` (``budget.used``).
+            Falls back to ``total_metric_calls`` for launcher-only / deserialized
+            snapshots.
         val_aggregate_scores: Per-candidate average validation score (higher is better).
         candidates: All candidates explored during optimization.
         parents: Lineage — ``parents[i]`` is a list of parent indices for candidate ``i``.
         per_val_instance_best_candidates: Pareto frontier — per validation example,
             the set of candidate indices achieving the best score.
         best_refiner_prompt: The refiner prompt from the best candidate (if refiner was enabled).
+        eval_log: Per-eval records from the OA eval server (empty on launcher-only results).
+        metadata: Free-form run metadata (wall time, budget, cost, held-out test
+            scores, ...). The candidate pool lives on this object (``candidates``,
+            ``best_idx``, ...); ``metadata`` does **not** nest a ``gepa_result``.
 
     Serialization:
-        ``to_dict()`` / ``from_dict()`` for JSON-safe round-tripping.
+        ``to_dict()`` / ``from_dict()`` for JSON-safe round-tripping of the
+        candidate pool and GEPA-core fields. ``eval_log``, ``metadata``, and
+        ``eval_server_calls`` are runtime conveniences and are omitted so the
+        JSON contract stays byte-stable.
 
     Example::
 
@@ -67,8 +79,11 @@ class GEPAResult(Generic[RolloutOutput, DataId]):
     # held-out test scores, ...). These are runtime conveniences and are
     # intentionally NOT part of ``to_dict()`` — that stays a JSON-safe pool
     # snapshot for the frozen serialization contract.
-    eval_log: list[dict[str, Any]] | None = None
+    eval_log: list[dict[str, Any]] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
+    # OA eval-server call count (``server.budget.used``). Distinct from
+    # ``total_metric_calls``, which is GEPA core's own counter.
+    eval_server_calls: int | None = None
 
     _VALIDATION_SCHEMA_VERSION: ClassVar[int] = 2
 
@@ -99,7 +114,16 @@ class GEPAResult(Generic[RolloutOutput, DataId]):
 
     @property
     def total_evals(self) -> int:
-        """Total eval-server calls, mirroring the lean ``Result.total_evals``."""
+        """Eval-server call count, mirroring lean ``Result.total_evals``.
+
+        Prefers ``eval_server_calls`` (``server.budget.used`` from the OA layer)
+        when this result was produced by ``optimize_anything``. Falls back to
+        ``total_metric_calls`` (GEPA core) and then
+        ``sum(discovery_eval_counts)`` for launcher-only / deserialized
+        snapshots that never went through the eval server.
+        """
+        if self.eval_server_calls is not None:
+            return self.eval_server_calls
         if self.total_metric_calls is not None:
             return self.total_metric_calls
         return sum(self.discovery_eval_counts)

--- a/src/gepa/oa/ensemble.py
+++ b/src/gepa/oa/ensemble.py
@@ -80,15 +80,20 @@ def optimize_anything_from_task(
         config = OptimizeAnythingConfig()
     if config.name is None:
         config = replace(config, name=task.name)
-    return optimize_anything(
-        task.seed_candidate,
-        evaluator=evaluate,
-        dataset=task.train_set,
-        valset=task.val_set,
-        objective=task.objective,
-        background=task.background,
-        test_set=task.test_set,
-        config=config,
+    # config is always a concrete OptimizeAnythingConfig here, so
+    # optimize_anything returns Result (not the GEPAResult union arm).
+    return cast(
+        Result,
+        optimize_anything(
+            task.seed_candidate,
+            evaluator=evaluate,
+            dataset=task.train_set,
+            valset=task.val_set,
+            objective=task.objective,
+            background=task.background,
+            test_set=task.test_set,
+            config=config,
+        ),
     )
 
 

--- a/src/gepa/oa/ensemble.py
+++ b/src/gepa/oa/ensemble.py
@@ -74,26 +74,25 @@ def optimize_anything_from_task(
     is preserved by threading it through ``config`` when ``config.name`` is unset.
     """
     # Lazy import avoids a circular import (gepa.optimize_anything imports this module).
-    from gepa.optimize_anything import optimize_anything
+    # Use the internal Result-producing path, not the public optimize_anything:
+    # ensembles thread the *mutable* Result across stages, whereas the public
+    # entry point wraps it into a frozen GEPAResult.
+    from gepa.optimize_anything import _optimize_to_result
 
     if config is None:
         config = OptimizeAnythingConfig()
     if config.name is None:
         config = replace(config, name=task.name)
-    # config is always a concrete OptimizeAnythingConfig here, so
-    # optimize_anything returns Result (not the GEPAResult union arm).
-    return cast(
-        Result,
-        optimize_anything(
-            task.seed_candidate,
-            evaluator=evaluate,
-            dataset=task.train_set,
-            valset=task.val_set,
-            objective=task.objective,
-            background=task.background,
-            test_set=task.test_set,
-            config=config,
-        ),
+    return _optimize_to_result(
+        task.seed_candidate,
+        evaluator=evaluate,
+        batch_evaluator=None,
+        dataset=task.train_set,
+        valset=task.val_set,
+        objective=task.objective,
+        background=task.background,
+        test_set=task.test_set,
+        config=config,
     )
 
 

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -102,7 +102,7 @@ def optimize_anything(
     background: str | None = None,
     test_set: list[Any] | None = None,
     config: OptimizeAnythingConfig | None = None,
-) -> Result | GEPAResult:
+) -> GEPAResult:
     """Optimize a text candidate (prompt, code, instructions, ...) against a score.
 
     The signature mirrors :func:`gepa.gepa_launcher.optimize_anything`
@@ -151,31 +151,27 @@ def optimize_anything(
             under ``result.metadata["test_score(s)"]`` (optimized) and
             ``result.metadata["baseline_test_score(s)"]`` (seed).
         config: Engine selection, run ``name``, budgets, output directory, and
-            engine-specific options. Defaults to ``OptimizeAnythingConfig()``
-            when omitted. Pass an explicit :class:`OptimizeAnythingConfig` to
-            get a :class:`Result`; omit ``config`` or pass a legacy
-            :class:`GEPAConfig` to get a
-            :class:`~gepa.core.result.GEPAResult`. At least one of
-            ``config.max_evals`` or ``config.max_token_cost`` must be set.
-            When ``config.name`` is omitted, a name is generated from the
-            engine, a short uuid, and a timestamp.
+            engine-specific options. Defaults to ``OptimizeAnythingConfig()``;
+            at least one of ``config.max_evals`` or ``config.max_token_cost``
+            must be set. When ``config.name`` is omitted, a name is generated
+            from the engine, a short uuid, and a timestamp. A legacy
+            :class:`GEPAConfig` is also accepted and converted to run the gepa
+            engine.
 
     Returns:
-        A :class:`Result` (``best_candidate``, ``best_score``, ``total_evals``,
-        ``eval_log``, ``metadata``) for an explicit
-        :class:`OptimizeAnythingConfig`, otherwise a
-        :class:`~gepa.core.result.GEPAResult` (``candidates``, ``best_idx``,
-        ``val_aggregate_scores``, ...) for the no-config / legacy path.
+        A single :class:`~gepa.core.result.GEPAResult` for every run. The
+        universal core is always populated — ``best_candidate``, ``best_score``,
+        ``total_evals``, ``eval_log``, ``metadata`` (the lean accessors), plus
+        the ``candidates`` / ``best_idx`` / ``val_aggregate_scores`` /
+        ``to_dict()`` pool surface. The gepa engine fills the full candidate
+        pool and Pareto data; other engines return a single-candidate snapshot
+        with the gepa-only fields (``per_val_instance_best_candidates``,
+        ``val_aggregate_subscores``, ...) left ``None``/empty. Held-out
+        ``test_set`` scores land in ``metadata`` on any engine.
     """
-    return_gepa_result = not isinstance(config, OptimizeAnythingConfig)
-    if return_gepa_result and test_set is not None:
-        raise ValueError(
-            "test_set requires an explicit OptimizeAnythingConfig; "
-            "the GEPAResult return path has no place for held-out test scores."
-        )
     if config is None:
         config = OptimizeAnythingConfig()
-    elif return_gepa_result:
+    elif not isinstance(config, OptimizeAnythingConfig):
         config = _from_legacy_config(config)
     if evaluator is None and batch_evaluator is None:
         raise ValueError("Provide evaluator=, batch_evaluator=, or both.")
@@ -186,6 +182,40 @@ def optimize_anything(
             stacklevel=2,
         )
 
+    result = _optimize_to_result(
+        seed_candidate,
+        evaluator=evaluator,
+        batch_evaluator=batch_evaluator,
+        dataset=dataset,
+        valset=valset,
+        objective=objective,
+        background=background,
+        test_set=test_set,
+        config=config,
+    )
+    return _to_gepa_result(result, seed_candidate)
+
+
+def _optimize_to_result(
+    seed_candidate: str | Candidate | None,
+    *,
+    evaluator: Callable[..., Any] | None,
+    batch_evaluator: Callable[..., Any] | None,
+    dataset: list[Any] | None,
+    valset: list[Any] | None,
+    objective: str | None,
+    background: str | None,
+    test_set: list[Any] | None,
+    config: OptimizeAnythingConfig,
+) -> Result:
+    """Run one engine over a freshly-built server and return the mutable core.
+
+    This is the internal Result-producing path shared by the public
+    :func:`optimize_anything` (which wraps the result into a
+    :class:`~gepa.core.result.GEPAResult`) and by ensemble helpers such as
+    :func:`~gepa.oa.ensemble.optimize_anything_from_task` (which thread the
+    mutable :class:`Result` across stages).
+    """
     task = Task(
         name=config.name or _default_run_name(config.engine),
         seed_candidate=seed_candidate,
@@ -208,13 +238,28 @@ def optimize_anything(
         max_concurrency=config.max_concurrency,
         output_dir=output_dir,
     )
-    result = _run_engine(server, engine, owns_server=True)
-    if return_gepa_result:
-        # Prefer the GEPAResult stashed by the gepa engine; if the budget died
-        # before any state was saved, synthesize a single-candidate snapshot.
-        legacy_result: Any = result.metadata.get("gepa_result") or _legacy_result_from(result, seed_candidate)
-        return legacy_result
-    return result
+    return _run_engine(server, engine, owns_server=True)
+
+
+def _to_gepa_result(result: Result, seed_candidate: Any) -> GEPAResult:
+    """Project the mutable engine :class:`Result` onto the unified GEPAResult.
+
+    The gepa engine stashes the full candidate pool under
+    ``result.metadata["gepa_result"]``; use it as the rich base. Every other
+    engine reports only a best candidate, so synthesize a single-candidate
+    snapshot. Either way the universal core (eval log, run metadata, held-out
+    test scores) rides out on the returned result — so a generic run returns
+    the maximum information it has, with the gepa-only pool fields left at their
+    ``None``/empty defaults.
+    """
+    metadata = dict(result.metadata)
+    rich = metadata.pop("gepa_result", None)
+    base: GEPAResult = rich if rich is not None else _legacy_result_from(result, seed_candidate)
+    if not result.eval_log and not metadata:
+        # Nothing to attach (e.g. a pre-built GEPAResult with no engine run
+        # around it) — return the base untouched so identity is preserved.
+        return base
+    return dataclasses.replace(base, eval_log=list(result.eval_log), metadata=metadata)
 
 
 def _from_legacy_config(config: Any) -> OptimizeAnythingConfig:
@@ -247,12 +292,14 @@ def _from_legacy_config(config: Any) -> OptimizeAnythingConfig:
 
 
 def _legacy_result_from(result: Result, seed_candidate: Any) -> GEPAResult:
-    """Fallback :class:`GEPAResult` when the gepa engine had none to report.
+    """Single-candidate :class:`GEPAResult` when there is no candidate pool.
 
-    Happens when the eval budget is exhausted before GEPA core saved any
-    state (e.g. the budget is smaller than the seed's valset pass). Returns a
-    single-candidate snapshot of the best the eval server saw, so legacy
-    callers still get the result shape they were written against.
+    Used for every non-gepa engine (which reports only a best candidate) and
+    for the gepa engine when the eval budget is exhausted before GEPA core
+    saved any state (e.g. the budget is smaller than the seed's valset pass).
+    Returns a single-candidate snapshot of the best the eval server saw, so the
+    unified result still exposes the pool surface (``candidates``, ``best_idx``,
+    ``val_aggregate_scores``, ``to_dict()``) with the gepa-only fields empty.
     """
     best = result.best_candidate or seed_candidate
     if isinstance(best, dict):

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -168,6 +168,12 @@ def optimize_anything(
         with the gepa-only fields (``per_val_instance_best_candidates``,
         ``val_aggregate_subscores``, ...) left ``None``/empty. Held-out
         ``test_set`` scores land in ``metadata`` on any engine.
+
+        ``total_evals`` is the eval-server call count (``budget.used``), not
+        ``total_metric_calls``. The candidate pool lives on the result
+        (``candidates``, ``best_idx``, ...); ``metadata`` no longer nests a
+        ``gepa_result`` object. ``to_dict()`` still serializes only the pool
+        and GEPA-core fields.
     """
     if config is None:
         config = OptimizeAnythingConfig()
@@ -248,18 +254,21 @@ def _to_gepa_result(result: Result, seed_candidate: Any) -> GEPAResult:
     ``result.metadata["gepa_result"]``; use it as the rich base. Every other
     engine reports only a best candidate, so synthesize a single-candidate
     snapshot. Either way the universal core (eval log, run metadata, held-out
-    test scores) rides out on the returned result — so a generic run returns
-    the maximum information it has, with the gepa-only pool fields left at their
-    ``None``/empty defaults.
+    test scores, eval-server call count) rides out on the returned result —
+    so a generic run returns the maximum information it has, with the gepa-only
+    pool fields left at their ``None``/empty defaults. The nested
+    ``gepa_result`` is popped from ``metadata``; the returned object *is* the
+    pool.
     """
     metadata = dict(result.metadata)
     rich = metadata.pop("gepa_result", None)
     base: GEPAResult = rich if rich is not None else _legacy_result_from(result, seed_candidate)
-    if not result.eval_log and not metadata:
-        # Nothing to attach (e.g. a pre-built GEPAResult with no engine run
-        # around it) — return the base untouched so identity is preserved.
-        return base
-    return dataclasses.replace(base, eval_log=list(result.eval_log), metadata=metadata)
+    return dataclasses.replace(
+        base,
+        eval_log=list(result.eval_log),
+        metadata=metadata,
+        eval_server_calls=result.total_evals,
+    )
 
 
 def _from_legacy_config(config: Any) -> OptimizeAnythingConfig:

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -102,7 +102,7 @@ def optimize_anything(
     background: str | None = None,
     test_set: list[Any] | None = None,
     config: OptimizeAnythingConfig | None = None,
-) -> Result:
+) -> Result | GEPAResult:
     """Optimize a text candidate (prompt, code, instructions, ...) against a score.
 
     The signature mirrors :func:`gepa.gepa_launcher.optimize_anything`
@@ -151,32 +151,32 @@ def optimize_anything(
             under ``result.metadata["test_score(s)"]`` (optimized) and
             ``result.metadata["baseline_test_score(s)"]`` (seed).
         config: Engine selection, run ``name``, budgets, output directory, and
-            engine-specific options. Defaults to ``OptimizeAnythingConfig()``;
-            at least one of ``config.max_evals`` or ``config.max_token_cost``
-            must be set. When ``config.name`` is omitted, a name is generated
-            from the engine, a short uuid, and a timestamp. A legacy
-            :class:`GEPAConfig` is also accepted and converted; the run uses
-            the gepa engine and returns the launcher's
-            :class:`~gepa.core.result.GEPAResult`.
+            engine-specific options. Defaults to ``OptimizeAnythingConfig()``
+            when omitted. Pass an explicit :class:`OptimizeAnythingConfig` to
+            get a :class:`Result`; omit ``config`` or pass a legacy
+            :class:`GEPAConfig` to get a
+            :class:`~gepa.core.result.GEPAResult`. At least one of
+            ``config.max_evals`` or ``config.max_token_cost`` must be set.
+            When ``config.name`` is omitted, a name is generated from the
+            engine, a short uuid, and a timestamp.
 
     Returns:
-        A :class:`Result` with ``best_candidate``, ``best_score``,
-        ``total_evals``, ``eval_log``, and ``metadata`` — or, when ``config``
-        is a legacy :class:`GEPAConfig`, the underlying
+        A :class:`Result` (``best_candidate``, ``best_score``, ``total_evals``,
+        ``eval_log``, ``metadata``) for an explicit
+        :class:`OptimizeAnythingConfig`, otherwise a
         :class:`~gepa.core.result.GEPAResult` (``candidates``, ``best_idx``,
-        ``val_aggregate_scores``, ...) so v0.1.x callers get the result shape
-        they were written against.
+        ``val_aggregate_scores``, ...) for the no-config / legacy path.
     """
-    legacy_config = False
+    return_gepa_result = not isinstance(config, OptimizeAnythingConfig)
+    if return_gepa_result and test_set is not None:
+        raise ValueError(
+            "test_set requires an explicit OptimizeAnythingConfig; "
+            "the GEPAResult return path has no place for held-out test scores."
+        )
     if config is None:
         config = OptimizeAnythingConfig()
-    elif not isinstance(config, OptimizeAnythingConfig):
-        if test_set is not None:
-            raise ValueError(
-                "test_set requires an OptimizeAnythingConfig; the legacy GEPAConfig API has no held-out test pass."
-            )
+    elif return_gepa_result:
         config = _from_legacy_config(config)
-        legacy_config = True
     if evaluator is None and batch_evaluator is None:
         raise ValueError("Provide evaluator=, batch_evaluator=, or both.")
     if config.max_evals is None and config.max_token_cost is None:
@@ -209,14 +209,9 @@ def optimize_anything(
         output_dir=output_dir,
     )
     result = _run_engine(server, engine, owns_server=True)
-    if legacy_config:
-        # v0.1.x callers always get the launcher's result type back — the gepa
-        # engine stashes the underlying GEPAResult in the result metadata. If
-        # the eval budget died before GEPA core saved any state (e.g. budget
-        # smaller than the valset), synthesize a single-candidate snapshot.
-        # The public signature advertises only the new API; legacy
-        # GEPAConfig-in/GEPAResult-out is a runtime affordance, so the legacy
-        # result rides out through an Any-typed local.
+    if return_gepa_result:
+        # Prefer the GEPAResult stashed by the gepa engine; if the budget died
+        # before any state was saved, synthesize a single-candidate snapshot.
         legacy_result: Any = result.metadata.get("gepa_result") or _legacy_result_from(result, seed_candidate)
         return legacy_result
     return result

--- a/tests/test_optimize_anything_gepa_config.py
+++ b/tests/test_optimize_anything_gepa_config.py
@@ -146,12 +146,96 @@ def test_legacy_gepa_config_accepts_test_set():
     assert isinstance(result, GEPAResult)
     assert "test_score" in result.metadata
     assert "baseline_test_score" in result.metadata
+    assert "gepa_result" not in result.metadata
 
 
-def test_no_config_returns_unified_gepa_result():
+def test_no_config_returns_unified_gepa_result(monkeypatch):
     """``optimize_anything(seed, evaluator=fn)`` with config omitted returns a
     GEPAResult exposing both the lean accessors and the pool surface
     (``candidates`` / ``val_aggregate_scores`` / ``to_dict()``) — issue #409."""
+    from gepa.core.result import GEPAResult
+    from gepa.oa.engine import Result
+    from gepa.optimize_anything import optimize_anything
+
+    stashed = GEPAResult(
+        candidates=[{"current_candidate": "improved"}],
+        parents=[[None]],
+        val_aggregate_scores=[0.42],
+        val_subscores=[{}],
+        per_val_instance_best_candidates={},
+        discovery_eval_counts=[1],
+        total_metric_calls=1,
+        _str_candidate_key="current_candidate",
+    )
+
+    def _fake_run_engine(server, engine, *, owns_server):
+        return Result(
+            best_candidate="improved",
+            best_score=0.42,
+            total_evals=9,
+            eval_log=[{"score": 0.42}],
+            metadata={"gepa_result": stashed, "engine": "gepa"},
+        )
+
+    monkeypatch.setattr("gepa.optimize_anything._run_engine", _fake_run_engine)
+
+    result = optimize_anything(
+        seed_candidate="short",
+        evaluator=_evaluator,
+        objective="maximize length",
+    )
+
+    assert isinstance(result, GEPAResult)
+    assert result.best_candidate == "improved"
+    assert result.best_idx == 0
+    assert result.candidates == [{"current_candidate": "improved"}]
+    assert result.val_aggregate_scores == [0.42]
+    # Lean total_evals is the eval-server count, not GEPA core's counter.
+    assert result.total_evals == 9
+    assert result.total_metric_calls == 1
+    assert result.eval_log == [{"score": 0.42}]
+    assert result.metadata["engine"] == "gepa"
+    assert "gepa_result" not in result.metadata
+    serialized = result.to_dict()
+    assert isinstance(serialized, dict)
+    assert "eval_log" not in serialized
+    assert "metadata" not in serialized
+    assert "eval_server_calls" not in serialized
+    assert serialized["total_metric_calls"] == 1
+
+
+def test_no_config_accepts_test_set(monkeypatch):
+    """``test_set`` with config omitted is accepted; held-out scores land in
+    ``metadata`` on the unified GEPAResult."""
+    from gepa.core.result import GEPAResult
+    from gepa.oa.engine import Result
+    from gepa.optimize_anything import optimize_anything
+
+    def _fake_run_engine(server, engine, *, owns_server):
+        return Result(
+            best_candidate="improved",
+            best_score=0.5,
+            total_evals=2,
+            metadata={"test_score": 0.4, "baseline_test_score": 0.2},
+        )
+
+    monkeypatch.setattr("gepa.optimize_anything._run_engine", _fake_run_engine)
+
+    result = optimize_anything(
+        seed_candidate="short",
+        evaluator=_evaluator,
+        objective="maximize length",
+        test_set=["held-out"],
+    )
+
+    assert isinstance(result, GEPAResult)
+    assert result.metadata["test_score"] == 0.4
+    assert result.metadata["baseline_test_score"] == 0.2
+
+
+def test_explicit_optimize_anything_config_returns_unified_gepa_result():
+    """An explicit ``OptimizeAnythingConfig`` returns the same unified
+    GEPAResult as the no-config path: lean accessors plus the pool surface."""
     from gepa.core.result import GEPAResult
     from gepa.optimize_anything import optimize_anything
 
@@ -167,12 +251,11 @@ def test_no_config_returns_unified_gepa_result():
     )
 
     assert isinstance(result, GEPAResult)
-    # Lean accessors from the old Result shape.
     assert result.best_candidate
     assert result.best_score > 0.0
     assert result.total_evals > 0
     assert isinstance(result.metadata, dict)
-    # Pool surface, now available on every run.
+    assert "gepa_result" not in result.metadata
     assert result.best_idx >= 0
     assert len(result.candidates) >= 1
     assert result.val_aggregate_scores
@@ -215,7 +298,12 @@ def test_non_gepa_engine_returns_single_candidate_gepa_result(monkeypatch):
     # gepa-only richness is absent on a generic run.
     assert result.per_val_instance_best_candidates == {}
     assert result.val_aggregate_subscores is None
-    assert isinstance(result.to_dict(), dict)
+    assert "gepa_result" not in result.metadata
+    serialized = result.to_dict()
+    assert isinstance(serialized, dict)
+    assert "eval_log" not in serialized
+    assert "metadata" not in serialized
+    assert "eval_server_calls" not in serialized
 
 
 def test_full_config_passthrough_and_reflective_dataset_persistence(tmp_path):

--- a/tests/test_optimize_anything_gepa_config.py
+++ b/tests/test_optimize_anything_gepa_config.py
@@ -38,18 +38,14 @@ def _evaluator(candidate, example=None):
 def test_tracking_key_is_forwarded_not_dropped():
     """A ``tracking`` block in engine_config lands on the built GEPAConfig."""
     tracking = TrackingConfig(use_wandb=False, use_mlflow=False, key_prefix="gepa/")
-    engine = GepaEngine(
-        OptimizeAnythingConfig(engine="gepa", max_evals=4, engine_config={"tracking": tracking})
-    )
+    engine = GepaEngine(OptimizeAnythingConfig(engine="gepa", max_evals=4, engine_config={"tracking": tracking}))
     assert engine.gepa_config.tracking.key_prefix == "gepa/"
 
 
 def test_unknown_key_fails_fast():
     """A misspelled engine_config key raises TypeError at construction."""
     with pytest.raises(TypeError):
-        GepaEngine(
-            OptimizeAnythingConfig(engine="gepa", max_evals=4, engine_config={"trackign": TrackingConfig()})
-        )
+        GepaEngine(OptimizeAnythingConfig(engine="gepa", max_evals=4, engine_config={"trackign": TrackingConfig()}))
 
 
 def test_legacy_gepa_config_call_returns_gepa_result():
@@ -75,71 +71,6 @@ def test_legacy_gepa_config_call_returns_gepa_result():
     assert result.best_idx >= 0
     assert len(result.candidates) >= 1
     assert result.val_aggregate_scores
-
-
-def test_no_config_returns_gepa_result(monkeypatch):
-    """``optimize_anything(seed, evaluator=fn)`` with config omitted/None must
-    return ``GEPAResult`` so simple-API callers can use ``val_aggregate_scores``,
-    ``best_idx``, ``candidates``, and ``to_dict()`` (issue #409 finding #1)."""
-    from gepa.core.result import GEPAResult
-    from gepa.oa.engine import Result
-    from gepa.optimize_anything import optimize_anything
-
-    stashed = GEPAResult(
-        candidates=[{"current_candidate": "improved"}],
-        parents=[[None]],
-        val_aggregate_scores=[0.42],
-        val_subscores=[{}],
-        per_val_instance_best_candidates={},
-        discovery_eval_counts=[1],
-        total_metric_calls=1,
-        _str_candidate_key="current_candidate",
-    )
-
-    def _fake_run_engine(server, engine, *, owns_server):
-        return Result(
-            best_candidate="improved",
-            best_score=0.42,
-            total_evals=1,
-            metadata={"gepa_result": stashed},
-        )
-
-    monkeypatch.setattr("gepa.optimize_anything._run_engine", _fake_run_engine)
-
-    result = optimize_anything(
-        seed_candidate="short",
-        evaluator=_evaluator,
-        objective="maximize length",
-    )
-
-    assert isinstance(result, GEPAResult)
-    assert result is stashed
-    assert result.best_candidate == "improved"
-    assert result.best_idx == 0
-    assert result.candidates == [{"current_candidate": "improved"}]
-    assert result.val_aggregate_scores == [0.42]
-    assert isinstance(result.to_dict(), dict)
-
-
-def test_explicit_optimize_anything_config_still_returns_result():
-    """An explicit ``OptimizeAnythingConfig`` keeps the new ``Result`` shape."""
-    from gepa.oa.engine import Result
-    from gepa.optimize_anything import optimize_anything
-
-    result = optimize_anything(
-        seed_candidate="short",
-        evaluator=_evaluator,
-        objective="maximize length",
-        config=OptimizeAnythingConfig(
-            engine="gepa",
-            max_evals=4,
-            engine_config={"reflection": {"reflection_lm": _FakeLM()}},
-        ),
-    )
-
-    assert isinstance(result, Result)
-    assert result.best_score > 0.0
-    assert not hasattr(result, "val_aggregate_scores")
 
 
 def test_legacy_gepa_config_returns_gepa_result_even_when_budget_dies_early():
@@ -194,31 +125,97 @@ def test_legacy_max_workers_none_falls_back_to_cpu_count():
     assert converted.max_concurrency == (os.cpu_count() or 32)
 
 
-def test_legacy_gepa_config_rejects_test_set():
-    """``test_set`` needs an explicit OptimizeAnythingConfig; GEPAConfig returns
-    ``GEPAResult``, which has no place for held-out test scores."""
-    from gepa.optimize_anything import GEPAConfig, optimize_anything
+def test_legacy_gepa_config_accepts_test_set():
+    """With the single unified GEPAResult, ``test_set`` works on every path —
+    including a legacy ``GEPAConfig`` — because the result now carries a
+    ``metadata`` dict for the held-out scores instead of rejecting them."""
+    from gepa.core.result import GEPAResult
+    from gepa.optimize_anything import EngineConfig, GEPAConfig, ReflectionConfig, optimize_anything
 
-    with pytest.raises(ValueError, match="test_set"):
-        optimize_anything(
-            seed_candidate="short",
-            evaluator=_evaluator,
-            test_set=["x"],
-            config=GEPAConfig(),
-        )
+    result = optimize_anything(
+        seed_candidate="short",
+        evaluator=_evaluator,
+        objective="maximize length",
+        test_set=["held-out-a", "held-out-b"],
+        config=GEPAConfig(
+            engine=EngineConfig(max_metric_calls=4),
+            reflection=ReflectionConfig(reflection_lm=_FakeLM()),
+        ),
+    )
+
+    assert isinstance(result, GEPAResult)
+    assert "test_score" in result.metadata
+    assert "baseline_test_score" in result.metadata
 
 
-def test_no_config_rejects_test_set():
-    """``test_set`` with config omitted also fails fast: that path returns
-    ``GEPAResult``, which has no place for held-out test scores."""
+def test_no_config_returns_unified_gepa_result():
+    """``optimize_anything(seed, evaluator=fn)`` with config omitted returns a
+    GEPAResult exposing both the lean accessors and the pool surface
+    (``candidates`` / ``val_aggregate_scores`` / ``to_dict()``) — issue #409."""
+    from gepa.core.result import GEPAResult
     from gepa.optimize_anything import optimize_anything
 
-    with pytest.raises(ValueError, match="test_set"):
-        optimize_anything(
-            seed_candidate="short",
-            evaluator=_evaluator,
-            test_set=["x"],
+    result = optimize_anything(
+        seed_candidate="short",
+        evaluator=_evaluator,
+        objective="maximize length",
+        config=OptimizeAnythingConfig(
+            engine="gepa",
+            max_evals=4,
+            engine_config={"reflection": {"reflection_lm": _FakeLM()}},
+        ),
+    )
+
+    assert isinstance(result, GEPAResult)
+    # Lean accessors from the old Result shape.
+    assert result.best_candidate
+    assert result.best_score > 0.0
+    assert result.total_evals > 0
+    assert isinstance(result.metadata, dict)
+    # Pool surface, now available on every run.
+    assert result.best_idx >= 0
+    assert len(result.candidates) >= 1
+    assert result.val_aggregate_scores
+    assert isinstance(result.to_dict(), dict)
+
+
+def test_non_gepa_engine_returns_single_candidate_gepa_result(monkeypatch):
+    """A generic engine (no candidate pool stashed) is projected onto a
+    single-candidate GEPAResult: lean core populated from its Result, eval log
+    and metadata attached, gepa-only pool fields left None/empty."""
+    from gepa.core.result import GEPAResult
+    from gepa.oa.engine import Result
+    from gepa.optimize_anything import optimize_anything
+
+    def _fake_run_engine(server, engine, *, owns_server):
+        return Result(
+            best_candidate="a much longer improved candidate",
+            best_score=0.31,
+            total_evals=3,
+            eval_log=[{"score": 0.31}],
+            metadata={"engine": "best_of_n", "wall_time": 0.01},
         )
+
+    monkeypatch.setattr("gepa.optimize_anything._run_engine", _fake_run_engine)
+
+    result = optimize_anything(
+        seed_candidate="short",
+        evaluator=_evaluator,
+        objective="maximize length",
+        config=OptimizeAnythingConfig(engine="best_of_n", max_evals=3),
+    )
+
+    assert isinstance(result, GEPAResult)
+    assert result.best_candidate == "a much longer improved candidate"
+    assert result.best_score == 0.31
+    assert result.total_evals == 3
+    assert result.eval_log == [{"score": 0.31}]
+    assert result.metadata["engine"] == "best_of_n"
+    assert len(result.candidates) == 1
+    # gepa-only richness is absent on a generic run.
+    assert result.per_val_instance_best_candidates == {}
+    assert result.val_aggregate_subscores is None
+    assert isinstance(result.to_dict(), dict)
 
 
 def test_full_config_passthrough_and_reflective_dataset_persistence(tmp_path):

--- a/tests/test_optimize_anything_gepa_config.py
+++ b/tests/test_optimize_anything_gepa_config.py
@@ -77,6 +77,71 @@ def test_legacy_gepa_config_call_returns_gepa_result():
     assert result.val_aggregate_scores
 
 
+def test_no_config_returns_gepa_result(monkeypatch):
+    """``optimize_anything(seed, evaluator=fn)`` with config omitted/None must
+    return ``GEPAResult`` so simple-API callers can use ``val_aggregate_scores``,
+    ``best_idx``, ``candidates``, and ``to_dict()`` (issue #409 finding #1)."""
+    from gepa.core.result import GEPAResult
+    from gepa.oa.engine import Result
+    from gepa.optimize_anything import optimize_anything
+
+    stashed = GEPAResult(
+        candidates=[{"current_candidate": "improved"}],
+        parents=[[None]],
+        val_aggregate_scores=[0.42],
+        val_subscores=[{}],
+        per_val_instance_best_candidates={},
+        discovery_eval_counts=[1],
+        total_metric_calls=1,
+        _str_candidate_key="current_candidate",
+    )
+
+    def _fake_run_engine(server, engine, *, owns_server):
+        return Result(
+            best_candidate="improved",
+            best_score=0.42,
+            total_evals=1,
+            metadata={"gepa_result": stashed},
+        )
+
+    monkeypatch.setattr("gepa.optimize_anything._run_engine", _fake_run_engine)
+
+    result = optimize_anything(
+        seed_candidate="short",
+        evaluator=_evaluator,
+        objective="maximize length",
+    )
+
+    assert isinstance(result, GEPAResult)
+    assert result is stashed
+    assert result.best_candidate == "improved"
+    assert result.best_idx == 0
+    assert result.candidates == [{"current_candidate": "improved"}]
+    assert result.val_aggregate_scores == [0.42]
+    assert isinstance(result.to_dict(), dict)
+
+
+def test_explicit_optimize_anything_config_still_returns_result():
+    """An explicit ``OptimizeAnythingConfig`` keeps the new ``Result`` shape."""
+    from gepa.oa.engine import Result
+    from gepa.optimize_anything import optimize_anything
+
+    result = optimize_anything(
+        seed_candidate="short",
+        evaluator=_evaluator,
+        objective="maximize length",
+        config=OptimizeAnythingConfig(
+            engine="gepa",
+            max_evals=4,
+            engine_config={"reflection": {"reflection_lm": _FakeLM()}},
+        ),
+    )
+
+    assert isinstance(result, Result)
+    assert result.best_score > 0.0
+    assert not hasattr(result, "val_aggregate_scores")
+
+
 def test_legacy_gepa_config_returns_gepa_result_even_when_budget_dies_early():
     """Budget smaller than the seed's valset pass: the engine has no GEPAResult
     to stash, so the legacy path synthesizes a single-candidate one — legacy
@@ -130,8 +195,8 @@ def test_legacy_max_workers_none_falls_back_to_cpu_count():
 
 
 def test_legacy_gepa_config_rejects_test_set():
-    """``test_set`` is a new-API feature; combining it with a legacy
-    ``GEPAConfig`` fails fast instead of silently dropping the test scores."""
+    """``test_set`` needs an explicit OptimizeAnythingConfig; GEPAConfig returns
+    ``GEPAResult``, which has no place for held-out test scores."""
     from gepa.optimize_anything import GEPAConfig, optimize_anything
 
     with pytest.raises(ValueError, match="test_set"):
@@ -140,6 +205,19 @@ def test_legacy_gepa_config_rejects_test_set():
             evaluator=_evaluator,
             test_set=["x"],
             config=GEPAConfig(),
+        )
+
+
+def test_no_config_rejects_test_set():
+    """``test_set`` with config omitted also fails fast: that path returns
+    ``GEPAResult``, which has no place for held-out test scores."""
+    from gepa.optimize_anything import optimize_anything
+
+    with pytest.raises(ValueError, match="test_set"):
+        optimize_anything(
+            seed_candidate="short",
+            evaluator=_evaluator,
+            test_set=["x"],
         )
 
 

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -30,3 +30,34 @@ def test_gepa_result_from_dict_upcasts_version0():
 
     serialized = result.to_dict()
     assert serialized["validation_schema_version"] == GEPAResult._VALIDATION_SCHEMA_VERSION
+
+
+def test_to_dict_omits_runtime_oa_fields():
+    """eval_log / metadata / eval_server_calls are runtime conveniences; the
+    frozen JSON pool snapshot stays byte-stable without them."""
+    result = GEPAResult(
+        candidates=[{"current_candidate": "x"}],
+        parents=[[None]],
+        val_aggregate_scores=[0.1],
+        val_subscores=[{}],
+        per_val_instance_best_candidates={},
+        discovery_eval_counts=[1],
+        total_metric_calls=4,
+        eval_log=[{"score": 0.1}],
+        metadata={"engine": "gepa"},
+        eval_server_calls=7,
+        _str_candidate_key="current_candidate",
+    )
+
+    serialized = result.to_dict()
+    assert "eval_log" not in serialized
+    assert "metadata" not in serialized
+    assert "eval_server_calls" not in serialized
+    assert serialized["total_metric_calls"] == 4
+    assert result.total_evals == 7
+
+    restored = GEPAResult.from_dict(serialized)
+    assert restored.eval_log == []
+    assert restored.metadata == {}
+    assert restored.eval_server_calls is None
+    assert restored.total_evals == 4  # falls back to total_metric_calls


### PR DESCRIPTION
## Credit

This change is directly based on work by [Rishi Khare](https://github.com/rishiskhare) (@rishiskhare).

He filed the original diagnosis as finding 1 of #409: `optimize_anything(seed, evaluator=fn)` with no config was returning the new `Result`, so `.val_aggregate_scores`, `.best_idx`, `.candidates`, and `.to_dict()` broke for v0.1.x callers. He then proposed the first fix in #411: omitted config should return `GEPAResult`.

This branch starts from his #411 commits (his original commit is the first commit here), then unifies the public return to a single `GEPAResult` so the same pool surface is available for every config path, including explicit `OptimizeAnythingConfig`. He is a co-author on the follow-up commits.

## Summary

`optimize_anything` returned `Result | GEPAResult` depending on the config type. That split the public surface and forced a union/cast at every internal boundary:

- Callers with an explicit `OptimizeAnythingConfig` got the lean `Result` and could not reach `candidates` / `best_idx` / `val_aggregate_scores` / `to_dict()` (#409).
- Only the gepa/legacy path returned the rich `GEPAResult`.
- `test_set` was rejected on the `GEPAResult` path because that type had nowhere to store held-out scores.
- The union required a `cast(Result, ...)` in the ensemble helper (from #411).

This collapses everything to **one return type**: `optimize_anything` always returns a `GEPAResult`.

The universal core is always populated: `best_candidate`, `best_score`, `total_evals`, `eval_log`, `metadata` (the old lean accessors) **plus** the `candidates` / `best_idx` / `val_aggregate_scores` / `to_dict()` pool surface. The gepa engine fills the full candidate pool and Pareto data; other engines return a single-candidate snapshot with the gepa-only fields left `None`/empty. Held-out `test_set` scores now land in `metadata` on **any** engine.

## Changes

- **`GEPAResult`** gains `eval_log` + `metadata` fields and `best_score` + `total_evals` properties. Additive and backward compatible: `to_dict()` / `from_dict()` are **untouched**, so the frozen JSON serialization contract stays byte-stable for downstream consumers (`.candidates`/`.best_idx`/`.val_aggregate_scores`/`.to_dict()`).
- `total_evals` prefers the eval-server count (`budget.used`) over GEPA core's `total_metric_calls`.
- The mutable engine-internal `Result` is **unchanged**. `optimize_anything`'s core is extracted into `_optimize_to_result` (returns the mutable `Result`) and projected onto `GEPAResult` by `_to_gepa_result` at the public boundary.
- Ensemble helpers call `_optimize_to_result` directly, so they keep threading the mutable `Result` across stages. That removes the need for the `cast(Result, ...)` in `optimize_anything_from_task`.

## Compatibility

- The T1 `GEPAResult` public shape is only extended, never changed.
- Explicit-config callers keep every accessor they had and additionally gain the pool surface.
- Legacy `GEPAConfig` in / `GEPAResult` out is preserved.
- `metadata` no longer nests `gepa_result`; the return value *is* the pool (`result.candidates`).

## Testing

- Coverage for the unified contract: real no-config path (#409 / #411), explicit `OptimizeAnythingConfig`, single-candidate generic projection, and `test_set` on every path.
- `to_dict()` still omits runtime OA fields (`eval_log`, `metadata`, `eval_server_calls`).

Builds on #411; supersedes its union/cast end state; fixes #409.