### PR TITLE
feat: add Codex agent backends to AutoResearch and Meta-Harness

### DIFF
--- a/src/gepa/oa/__init__.py
+++ b/src/gepa/oa/__init__.py
@@ -5,6 +5,7 @@ the shared engine protocol, eval server, budget tracker, and registries used by
 that public API.
 """
 
+from gepa.oa.agent_runner import AgentRunner, AgentRunResult, CodexAgentRunner, PiAgentRunner
 from gepa.oa.budget import BudgetExhausted, BudgetTracker
 from gepa.oa.config import OptimizeAnythingConfig
 from gepa.oa.engine import Engine, Result
@@ -23,9 +24,13 @@ from gepa.oa.task import Task
 __all__ = [
     "BudgetExhausted",
     "BudgetTracker",
+    "AgentRunResult",
+    "AgentRunner",
+    "CodexAgentRunner",
     "Engine",
     "EvalServer",
     "OptimizeAnythingConfig",
+    "PiAgentRunner",
     "Result",
     "Task",
     "get_engine_cls",

--- a/src/gepa/oa/agent_runner.py
+++ b/src/gepa/oa/agent_runner.py
@@ -1,0 +1,895 @@
+"""Agent subprocess runners shared by the long-running OA engines.
+
+The public engines deliberately keep their evaluator and result contracts
+independent from the agent CLI.  This module is the small boundary between
+those concerns: a runner returns normalized output while the engine owns
+candidate materialization, evaluation, and budget policy.
+
+``PiAgentRunner`` supports both modes used by Omni:
+
+* one-shot JSONL sessions for Meta-Harness iterations and GEPA proposers;
+* one persistent RPC process for AutoResearch/Ralph continuations.
+
+``CodexAgentRunner`` uses the Codex CLI's workspace-write sandbox. Meta-Harness
+uses one ephemeral invocation per iteration; AutoResearch resumes one persisted
+Codex thread for Ralph continuations.
+
+Pi's tool allowlist is intentionally only a command-construction convenience.
+Callers that request ``sandbox=True`` must provide an OS sandbox prefix.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import queue
+import shutil
+import signal
+import subprocess
+import threading
+import time
+import uuid
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+ProgressCheck = Callable[[], str | None]
+SandboxPrefix = Callable[[Path], list[str]]
+
+
+@dataclass
+class AgentRunResult:
+    """Normalized result from an agent invocation."""
+
+    command: tuple[str, ...]
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+    session_id: str | None = None
+    usage: dict[str, Any] = field(default_factory=dict)
+    cost_usd: float | None = None  # ``None`` means token usage was not priced.
+    cost_known: bool = True
+    timed_out: bool = False
+    completed: bool = False
+    final_text: str = ""
+
+
+class AgentRunner(Protocol):
+    """Minimal runner contract consumed by agent-backed engines."""
+
+    def run(
+        self,
+        prompt: str,
+        *,
+        work_dir: Path,
+        timeout_seconds: float | None = None,
+        progress_check: ProgressCheck | None = None,
+        max_budget_usd: float | None = None,
+    ) -> AgentRunResult: ...
+
+    def close(self) -> None: ...
+
+
+def _iter_json_lines(stdout: str) -> Iterable[dict[str, Any]]:
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if isinstance(payload, dict):
+            yield payload
+
+
+def _text_value(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "".join(_text_value(item) for item in value)
+    if isinstance(value, dict):
+        for key in ("text", "content", "result", "message"):
+            if key in value:
+                text = _text_value(value[key])
+                if text:
+                    return text
+    return ""
+
+
+def _event_text(event: dict[str, Any]) -> str:
+    event_type = str(event.get("type", ""))
+    if event_type in {"message_end", "assistant_message", "result", "agent_end"}:
+        for key in ("message", "content", "text", "result", "data"):
+            text = _text_value(event.get(key))
+            if text:
+                return text
+    return ""
+
+
+def _numeric(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _iter_mappings(value: Any, *, inside_cost: bool = False) -> Iterable[tuple[dict[str, Any], bool]]:
+    if not isinstance(value, dict):
+        return
+    yield value, inside_cost
+    for key, child in value.items():
+        if isinstance(child, dict):
+            yield from _iter_mappings(child, inside_cost=inside_cost or key == "cost")
+        elif isinstance(child, list):
+            for item in child:
+                yield from _iter_mappings(item, inside_cost=inside_cost or key == "cost")
+
+
+def _merge_usage(events: Iterable[dict[str, Any]]) -> tuple[dict[str, Any], float]:
+    """Collect nested Pi usage/cost fields without assuming one event schema."""
+    usage: dict[str, Any] = {}
+    cost = 0.0
+    token_aliases = {
+        "input_tokens": ("input_tokens", "prompt_tokens", "inputTokens", "input"),
+        "output_tokens": ("output_tokens", "completion_tokens", "outputTokens", "output"),
+        "cache_read_tokens": ("cache_read_tokens", "cacheReadTokens", "cache_read"),
+        "cache_write_tokens": ("cache_write_tokens", "cacheWriteTokens", "cache_write"),
+    }
+    for event in events:
+        for source, inside_cost in _iter_mappings(event):
+            for canonical, aliases in token_aliases.items():
+                value = next(
+                    (_numeric(source.get(key)) for key in aliases if _numeric(source.get(key)) is not None), None
+                )
+                if value is not None:
+                    usage[canonical] = value if canonical not in usage else usage[canonical] + value
+            for key in ("cost_usd", "total_cost_usd", "totalCostUsd", "cost"):
+                value = _numeric(source.get(key))
+                if value is not None:
+                    cost = max(cost, value)
+            if inside_cost:
+                value = _numeric(source.get("total"))
+                if value is not None:
+                    cost = max(cost, value)
+    return usage, cost
+
+
+def normalize_pi_output(stdout: str) -> tuple[dict[str, Any], float, str, bool]:
+    """Return ``(usage, cost, final_text, completed)`` for Pi JSONL output."""
+    events = list(_iter_json_lines(stdout))
+    usage, cost = _merge_usage(events)
+    final_text = ""
+    for event in events:
+        text = _event_text(event)
+        if text:
+            final_text = text
+    completed = any(str(event.get("type", "")) == "agent_end" for event in events)
+    return usage, cost, final_text, completed
+
+
+_CODEX_TOKEN_ALIASES = {
+    "input_tokens": ("input_tokens", "prompt_tokens", "inputTokens"),
+    "output_tokens": ("output_tokens", "completion_tokens", "outputTokens"),
+    "cache_read_tokens": ("cache_read_tokens", "cached_input_tokens", "cacheReadTokens"),
+    "reasoning_output_tokens": ("reasoning_output_tokens", "reasoningOutputTokens"),
+}
+
+
+def _codex_usage(events: Iterable[dict[str, Any]]) -> dict[str, int]:
+    """Return the last cumulative usage mapping emitted by Codex."""
+    latest: dict[str, int] = {}
+    for event in events:
+        for source, _inside_cost in _iter_mappings(event):
+            candidate: dict[str, int] = {}
+            for canonical, aliases in _CODEX_TOKEN_ALIASES.items():
+                value = next(
+                    (_numeric(source.get(alias)) for alias in aliases if _numeric(source.get(alias)) is not None),
+                    None,
+                )
+                if value is not None:
+                    candidate[canonical] = int(value)
+            if candidate:
+                latest = candidate
+    return latest
+
+
+def _codex_session_id(events: Iterable[dict[str, Any]]) -> str | None:
+    session_id: str | None = None
+    for event in events:
+        value = event.get("thread_id") or event.get("session_id")
+        if value is None and isinstance(event.get("thread"), dict):
+            value = event["thread"].get("id")
+        if value:
+            session_id = str(value)
+    return session_id
+
+
+def _codex_final_text(events: Iterable[dict[str, Any]]) -> str:
+    final_text = ""
+    for event in events:
+        event_type = str(event.get("type", ""))
+        if event_type not in {"item.completed", "turn.completed", "assistant_message", "result", "agent_end"}:
+            continue
+        for key in ("text", "message", "content", "result", "item", "last_message"):
+            text = _text_value(event.get(key))
+            if text:
+                final_text = text
+    return final_text
+
+
+def normalize_codex_output(
+    stdout: str,
+    *,
+    input_cost_per_million: float | None = None,
+    output_cost_per_million: float | None = None,
+) -> tuple[dict[str, Any], float | None, str, str | None, bool, bool]:
+    """Normalize Codex JSONL output.
+
+    Returns ``(usage, cost, final_text, session_id, completed, cost_known)``.
+    Codex does not emit provider USD pricing, so ``cost_known`` is true only
+    when both rates and both input/output token totals are available.
+    """
+    events = list(_iter_json_lines(stdout))
+    usage = _codex_usage(events)
+    session_id = _codex_session_id(events)
+    final_text = _codex_final_text(events)
+    completed = any(
+        str(event.get("type", "")) in {"turn.completed", "agent_end"} for event in events
+    )
+    cost_known = (
+        input_cost_per_million is not None
+        and output_cost_per_million is not None
+        and "input_tokens" in usage
+        and "output_tokens" in usage
+    )
+    cost: float | None = None
+    if cost_known:
+        assert input_cost_per_million is not None
+        assert output_cost_per_million is not None
+        cost = (
+            usage["input_tokens"] * input_cost_per_million
+            + usage["output_tokens"] * output_cost_per_million
+        ) / 1_000_000.0
+    return usage, cost, final_text, session_id, completed, cost_known
+
+
+def validate_codex_pricing(
+    max_token_cost: float | None,
+    input_cost_per_million: float | None,
+    output_cost_per_million: float | None,
+) -> None:
+    """Validate Codex pricing before a backend process is launched."""
+    if max_token_cost is not None and (
+        isinstance(max_token_cost, bool)
+        or not isinstance(max_token_cost, (int, float))
+        or not math.isfinite(max_token_cost)
+        or max_token_cost < 0
+    ):
+        raise ValueError("max_token_cost must be a finite non-negative number or None")
+    for name, value in (
+        ("input_cost_per_million", input_cost_per_million),
+        ("output_cost_per_million", output_cost_per_million),
+    ):
+        if value is not None and (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(value)
+            or value < 0
+        ):
+            raise ValueError(f"{name} must be a finite non-negative number or None")
+    if (input_cost_per_million is None) != (output_cost_per_million is None):
+        raise ValueError(
+            "Codex pricing must provide both input_cost_per_million and "
+            "output_cost_per_million, or neither"
+        )
+    if max_token_cost is not None and (input_cost_per_million is None or output_cost_per_million is None):
+        raise ValueError(
+            "Codex with max_token_cost requires both input_cost_per_million "
+            "and output_cost_per_million"
+        )
+
+
+@dataclass
+class _PersistentProcess:
+    process: subprocess.Popen[str]
+    events: queue.Queue[tuple[str, str | None]]
+    stdout: list[str]
+    stderr: list[str]
+    reader_threads: list[threading.Thread]
+
+
+class PiAgentRunner:
+    """Run Pi in JSON or persistent RPC mode.
+
+    Args:
+        command: Pi executable or an argv prefix.
+        model: Pi provider/model string. ``None`` leaves model selection to Pi.
+        persistent: Keep one RPC process alive across :meth:`run` calls.
+        tools: Comma-separated Pi tool allowlist.
+        sandbox: Require and use ``sandbox_prefix`` for every process.
+        sandbox_prefix: Function returning an OS-level sandbox argv prefix.
+    """
+
+    def __init__(
+        self,
+        command: str | list[str] = "pi",
+        *,
+        model: str | None = None,
+        persistent: bool = False,
+        tools: str = "read,grep,find,ls,bash,edit,write",
+        sandbox: bool = False,
+        sandbox_prefix: SandboxPrefix | None = None,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        self.command = [command] if isinstance(command, str) else list(command)
+        self.model = model
+        self.persistent = persistent
+        self.tools = tools
+        self.sandbox = sandbox
+        self.sandbox_prefix = sandbox_prefix
+        self.env = env
+        self._persistent: _PersistentProcess | None = None
+        self._session_id: str | None = None
+
+    def build_command(self, work_dir: Path, *, rpc: bool, prompt: str | None = None) -> list[str]:
+        if self.sandbox:
+            if self.sandbox_prefix is None:
+                raise RuntimeError("Pi sandboxing was requested without an OS sandbox prefix")
+            command = self.sandbox_prefix(work_dir)
+        else:
+            command = []
+        command += [*self.command, "--mode", "rpc" if rpc else "json"]
+        command += [
+            "--no-session",
+            "--no-context-files",
+            "--no-extensions",
+            "--no-skills",
+            "--no-prompt-templates",
+            "--no-themes",
+            "--no-approve",
+            "--tools",
+            self.tools,
+        ]
+        if self.model:
+            command += ["--model", self.model]
+        if prompt is not None:
+            command += ["--print", prompt]
+        return command
+
+    def run(
+        self,
+        prompt: str,
+        *,
+        work_dir: Path,
+        timeout_seconds: float | None = None,
+        progress_check: ProgressCheck | None = None,
+        max_budget_usd: float | None = None,
+    ) -> AgentRunResult:
+        work_dir = Path(work_dir)
+        if self.persistent:
+            return self._run_rpc(
+                prompt,
+                work_dir=work_dir,
+                timeout_seconds=timeout_seconds,
+                progress_check=progress_check,
+                max_budget_usd=max_budget_usd,
+            )
+        return self._run_json(
+            prompt,
+            work_dir=work_dir,
+            timeout_seconds=timeout_seconds,
+            progress_check=progress_check,
+            max_budget_usd=max_budget_usd,
+        )
+
+    def _run_json(
+        self,
+        prompt: str,
+        *,
+        work_dir: Path,
+        timeout_seconds: float | None,
+        progress_check: ProgressCheck | None,
+        max_budget_usd: float | None,
+    ) -> AgentRunResult:
+        command = self.build_command(work_dir, rpc=False, prompt=prompt)
+        running = self._start_persistent(command, work_dir)
+        proc = running.process
+        if proc.stdin is not None:
+            proc.stdin.close()
+        started = time.monotonic()
+        timed_out = False
+        reason: str | None = None
+        while proc.poll() is None:
+            self._drain_queued(running)
+            reason = progress_check() if progress_check is not None else None
+            if reason:
+                timed_out = True
+                self._terminate(proc)
+                break
+            if max_budget_usd is not None:
+                _usage, cost, _text, _completed = normalize_pi_output("".join(running.stdout))
+                if cost > max_budget_usd:
+                    timed_out = True
+                    reason = f"PI_TOKEN_BUDGET: terminated Pi above the ${max_budget_usd:.6f} cap."
+                    self._terminate(proc)
+                    break
+            if timeout_seconds is not None and time.monotonic() - started >= timeout_seconds:
+                timed_out = True
+                reason = f"PI_TIMEOUT: terminated Pi after {timeout_seconds:.1f}s."
+                self._terminate(proc)
+                break
+            time.sleep(0.05)
+        self._drain_queued(running)
+        if proc.poll() is None:
+            proc.wait()
+        for thread in running.reader_threads:
+            thread.join(timeout=1)
+        self._drain_queued(running)
+        stdout = "".join(running.stdout)
+        stderr = "".join(running.stderr)
+        if reason:
+            stderr = (stderr or "") + f"\n{reason}\n"
+        usage, cost, final_text, completed = normalize_pi_output(stdout or "")
+        return AgentRunResult(
+            command=tuple(command),
+            returncode=proc.returncode if proc.returncode is not None else -signal.SIGTERM,
+            stdout=stdout or "",
+            stderr=stderr or "",
+            session_id=self._session_id or str(uuid.uuid4()),
+            usage=usage,
+            cost_usd=cost,
+            timed_out=timed_out,
+            completed=completed and not timed_out,
+            final_text=final_text,
+        )
+
+    def _run_rpc(
+        self,
+        prompt: str,
+        *,
+        work_dir: Path,
+        timeout_seconds: float | None,
+        progress_check: ProgressCheck | None,
+        max_budget_usd: float | None,
+    ) -> AgentRunResult:
+        if self._persistent is None:
+            command = self.build_command(work_dir, rpc=True)
+            self._persistent = self._start_persistent(command, work_dir)
+            self._session_id = str(uuid.uuid4())
+        running = self._persistent
+        assert running is not None
+        process = running.process
+        command = self.build_command(work_dir, rpc=True)
+        stdout_start = len(running.stdout)
+        stderr_start = len(running.stderr)
+        try:
+            assert process.stdin is not None
+            process.stdin.write(json.dumps({"type": "prompt", "message": prompt}) + "\n")
+            process.stdin.flush()
+        except (BrokenPipeError, OSError) as exc:
+            self.close()
+            return AgentRunResult(
+                command=tuple(command),
+                returncode=process.returncode if process.returncode is not None else 1,
+                stderr=f"Pi RPC session could not receive prompt: {exc}",
+                session_id=self._session_id,
+            )
+
+        started = time.monotonic()
+        completed = False
+        timed_out = False
+        reason: str | None = None
+        while not completed:
+            reason = progress_check() if progress_check is not None else None
+            if reason:
+                timed_out = True
+                break
+            if timeout_seconds is not None and time.monotonic() - started >= timeout_seconds:
+                timed_out = True
+                reason = f"PI_TIMEOUT: terminated Pi RPC after {timeout_seconds:.1f}s."
+                break
+            try:
+                stream, line = running.events.get(timeout=0.05)
+            except queue.Empty:
+                if process.poll() is not None:
+                    break
+                continue
+            if stream == "stdout":
+                if line is not None:
+                    running.stdout.append(line)
+                    try:
+                        event = json.loads(line)
+                    except (json.JSONDecodeError, TypeError):
+                        event = None
+                    if isinstance(event, dict) and event.get("type") == "agent_end":
+                        completed = True
+                    if max_budget_usd is not None:
+                        _usage, cost, _text, _complete = normalize_pi_output(line)
+                        if cost > max_budget_usd:
+                            timed_out = True
+                            reason = f"PI_TOKEN_BUDGET: terminated Pi above the ${max_budget_usd:.6f} cap."
+                            break
+            elif line is not None:
+                running.stderr.append(line)
+        if timed_out:
+            self._terminate(process)
+            self._persistent = None
+        # Keep the RPC process alive after agent_end.  Drain only already queued
+        # output so the next prompt starts with a clean event boundary.
+        while True:
+            try:
+                stream, line = running.events.get_nowait()
+            except queue.Empty:
+                break
+            if stream == "stdout" and line is not None:
+                running.stdout.append(line)
+            elif line is not None:
+                running.stderr.append(line)
+        stdout = "".join(running.stdout[stdout_start:])
+        stderr = "".join(running.stderr[stderr_start:])
+        if reason:
+            stderr += f"\n{reason}\n"
+        usage, cost, final_text, parsed_completed = normalize_pi_output(stdout)
+        return AgentRunResult(
+            command=tuple(command),
+            returncode=0 if completed and not timed_out else (process.returncode or -signal.SIGTERM),
+            stdout=stdout,
+            stderr=stderr,
+            session_id=self._session_id,
+            usage=usage,
+            cost_usd=cost,
+            timed_out=timed_out,
+            completed=completed and parsed_completed and not timed_out,
+            final_text=final_text,
+        )
+
+    @staticmethod
+    def _start(command: list[str], work_dir: Path, *, stdin: Any) -> subprocess.Popen[str]:
+        kwargs: dict[str, Any] = {
+            "cwd": str(work_dir),
+            "stdin": stdin,
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.PIPE,
+            "text": True,
+            "bufsize": 1,
+        }
+        if os.name == "posix":
+            kwargs["start_new_session"] = True
+        return subprocess.Popen(command, **kwargs)
+
+    def _start_persistent(self, command: list[str], work_dir: Path) -> _PersistentProcess:
+        kwargs: dict[str, Any] = {
+            "cwd": str(work_dir),
+            "stdin": subprocess.PIPE,
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.PIPE,
+            "text": True,
+            "bufsize": 1,
+        }
+        if self.env is not None:
+            kwargs["env"] = self.env
+        if os.name == "posix":
+            kwargs["start_new_session"] = True
+        try:
+            process = subprocess.Popen(command, **kwargs)
+        except OSError as exc:
+            raise RuntimeError(f"failed to start Pi: {exc}") from exc
+        events: queue.Queue[tuple[str, str | None]] = queue.Queue()
+        stdout: list[str] = []
+        stderr: list[str] = []
+
+        def read_stream(stream: Any, name: str) -> None:
+            try:
+                for line in iter(stream.readline, ""):
+                    events.put((name, line))
+            finally:
+                events.put((name, None))
+
+        threads = [
+            threading.Thread(target=read_stream, args=(process.stdout, "stdout"), daemon=True),
+            threading.Thread(target=read_stream, args=(process.stderr, "stderr"), daemon=True),
+        ]
+        for thread in threads:
+            thread.start()
+        return _PersistentProcess(process, events, stdout, stderr, threads)
+
+    @staticmethod
+    def _drain_queued(running: _PersistentProcess) -> None:
+        while True:
+            try:
+                stream, line = running.events.get_nowait()
+            except queue.Empty:
+                return
+            if stream == "stdout" and line is not None:
+                running.stdout.append(line)
+            elif line is not None:
+                running.stderr.append(line)
+
+    @staticmethod
+    def _terminate(proc: subprocess.Popen[str]) -> None:
+        if os.name == "posix" and getattr(proc, "pid", None) is not None:
+            try:
+                os.killpg(proc.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                return
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                try:
+                    os.killpg(proc.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                proc.wait()
+            return
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+
+    def close(self) -> None:
+        running = self._persistent
+        self._persistent = None
+        if running is not None:
+            if running.process.stdin is not None:
+                try:
+                    running.process.stdin.close()
+                except OSError:
+                    pass
+            if running.process.poll() is None:
+                self._terminate(running.process)
+
+
+class CodexAgentRunner:
+    """Run Codex CLI agent turns in the workspace-write sandbox.
+
+    ``persistent=True`` means that each call is a new ``codex exec resume``
+    process attached to one persisted Codex thread. It does not keep a CLI
+    process alive between calls. ``persistent=False`` uses an ephemeral thread
+    for each call.
+    """
+
+    def __init__(
+        self,
+        command: str | list[str] = "codex",
+        *,
+        model: str | None = None,
+        persistent: bool = False,
+        sandbox: bool = True,
+        env: dict[str, str] | None = None,
+        input_cost_per_million: float | None = None,
+        output_cost_per_million: float | None = None,
+    ) -> None:
+        if not sandbox:
+            raise ValueError("CodexAgentRunner requires sandbox=True (workspace-write)")
+        validate_codex_pricing(None, input_cost_per_million, output_cost_per_million)
+        self.command = [command] if isinstance(command, str) else list(command)
+        if not self.command:
+            raise ValueError("CodexAgentRunner requires a non-empty command")
+        self.model = model
+        self.persistent = persistent
+        self.env = env
+        self.input_cost_per_million = input_cost_per_million
+        self.output_cost_per_million = output_cost_per_million
+        self._session_id: str | None = None
+
+    def build_command(self, work_dir: Path, output_path: Path, prompt: str) -> list[str]:
+        command = [*self.command, "exec"]
+        resuming = self.persistent and self._session_id is not None
+        if resuming:
+            command.append("resume")
+        else:
+            if not self.persistent:
+                command.append("--ephemeral")
+        command.extend(
+            [
+                "--config",
+                'approval_policy="never"',
+                "--config",
+                "sandbox_workspace_write.network_access=true",
+                "--ignore-user-config",
+                "--ignore-rules",
+                "--skip-git-repo-check",
+                "--json",
+                "--output-last-message",
+                str(output_path),
+            ]
+        )
+        if not resuming:
+            command.extend(["--cd", str(work_dir), "--sandbox", "workspace-write"])
+        if self.model:
+            command.extend(["--model", self.model])
+        if resuming:
+            command.append(self._session_id or "")
+        command.append(prompt)
+        return command
+
+    def run(
+        self,
+        prompt: str,
+        *,
+        work_dir: Path,
+        timeout_seconds: float | None = None,
+        progress_check: ProgressCheck | None = None,
+        max_budget_usd: float | None = None,
+    ) -> AgentRunResult:
+        validate_codex_pricing(
+            max_budget_usd,
+            self.input_cost_per_million,
+            self.output_cost_per_million,
+        )
+        work_dir = Path(work_dir)
+        log_dir = work_dir / ".codex-runner"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        output_path = log_dir / f"last-message-{uuid.uuid4().hex}.txt"
+        command = self.build_command(work_dir, output_path, prompt)
+        running = self._start_capture(command, work_dir)
+        proc = running.process
+        started = time.monotonic()
+        timed_out = False
+        reason: str | None = None
+
+        while proc.poll() is None:
+            self._drain_queued(running)
+            reason = progress_check() if progress_check is not None else None
+            stdout = "".join(running.stdout)
+            _usage, cost, _text, _session, _completed, cost_known = normalize_codex_output(
+                stdout,
+                input_cost_per_million=self.input_cost_per_million,
+                output_cost_per_million=self.output_cost_per_million,
+            )
+            if reason:
+                timed_out = True
+                self._terminate(proc)
+                break
+            if max_budget_usd is not None and cost_known and cost is not None and cost > max_budget_usd:
+                timed_out = True
+                reason = f"CODEX_TOKEN_BUDGET: terminated Codex above the ${max_budget_usd:.6f} cap."
+                self._terminate(proc)
+                break
+            if timeout_seconds is not None and time.monotonic() - started >= timeout_seconds:
+                timed_out = True
+                reason = f"CODEX_TIMEOUT: terminated Codex after {timeout_seconds:.1f}s."
+                self._terminate(proc)
+                break
+            time.sleep(0.05)
+
+        self._drain_queued(running)
+        if proc.poll() is None:
+            proc.wait()
+        for thread in running.reader_threads:
+            thread.join(timeout=1)
+        self._drain_queued(running)
+        stdout = "".join(running.stdout)
+        stderr = "".join(running.stderr)
+        if reason:
+            stderr += f"\n{reason}\n"
+        usage, cost, final_text, session_id, completed, cost_known = normalize_codex_output(
+            stdout,
+            input_cost_per_million=self.input_cost_per_million,
+            output_cost_per_million=self.output_cost_per_million,
+        )
+        if output_path.exists():
+            saved_text = output_path.read_text(encoding="utf-8")
+            if saved_text.strip():
+                final_text = saved_text.strip()
+        if session_id is not None:
+            self._session_id = session_id
+        effective_session_id = session_id or self._session_id
+        returncode = proc.returncode if proc.returncode is not None else -signal.SIGTERM
+        budget_exceeded = False
+        if max_budget_usd is not None and cost_known and cost is not None and cost > max_budget_usd and not timed_out:
+            budget_exceeded = True
+            stderr += f"\nCODEX_TOKEN_BUDGET: Codex exited above the ${max_budget_usd:.6f} cap.\n"
+            returncode = 1
+        if max_budget_usd is not None and not cost_known and not timed_out:
+            stderr += "\nCODEX_USAGE_MISSING: cannot enforce the USD cap without Codex token usage.\n"
+            returncode = 1
+        if returncode == 0 and not completed and not timed_out:
+            stderr += "\nCODEX_MALFORMED_OUTPUT: Codex exited without turn.completed.\n"
+            returncode = 1
+        if returncode != 0 and not timed_out and not budget_exceeded and "CODEX_" not in stderr:
+            stderr += f"\nCODEX_PROCESS_ERROR: Codex exited with status {returncode}.\n"
+        if returncode == 0 and effective_session_id is None:
+            stderr += "\nCODEX_MISSING_SESSION_ID: Codex did not emit a resumable thread id.\n"
+            returncode = 1
+            completed = False
+        (log_dir / f"{output_path.stem}.jsonl").write_text(stdout, encoding="utf-8")
+        (log_dir / f"{output_path.stem}.stderr").write_text(stderr, encoding="utf-8")
+        (log_dir / f"{output_path.stem}.command.json").write_text(
+            json.dumps(command, indent=2) + "\n", encoding="utf-8"
+        )
+        return AgentRunResult(
+            command=tuple(command),
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
+            session_id=effective_session_id,
+            usage=usage,
+            cost_usd=cost,
+            cost_known=cost_known,
+            timed_out=timed_out,
+            completed=completed and not timed_out and returncode == 0,
+            final_text=final_text,
+        )
+
+    def _start_capture(self, command: list[str], work_dir: Path) -> _PersistentProcess:
+        kwargs: dict[str, Any] = {
+            "cwd": str(work_dir),
+            "stdin": subprocess.DEVNULL,
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.PIPE,
+            "text": True,
+            "bufsize": 1,
+        }
+        if self.env is not None:
+            process_env = dict(self.env)
+        else:
+            process_env = dict(os.environ)
+        if process_env.get("TERM") in {None, "", "dumb"}:
+            # Codex's non-interactive exec path still initializes a terminal
+            # UI when TERM=dumb. Give the subprocess a normal terminal type;
+            # this does not alter its workspace-write sandbox posture.
+            process_env["TERM"] = "xterm-256color"
+        kwargs["env"] = process_env
+        if os.name == "posix":
+            kwargs["start_new_session"] = True
+        executable = shutil.which(self.command[0]) or self.command[0]
+        command = [executable, *command[1:]] if command else ["codex"]
+        try:
+            process = subprocess.Popen(command, **kwargs)
+        except OSError as exc:
+            raise RuntimeError(f"failed to start Codex: {exc}") from exc
+        events: queue.Queue[tuple[str, str | None]] = queue.Queue()
+        stdout: list[str] = []
+        stderr: list[str] = []
+
+        def read_stream(stream: Any, name: str) -> None:
+            try:
+                for line in iter(stream.readline, ""):
+                    events.put((name, line))
+            finally:
+                events.put((name, None))
+
+        threads = [
+            threading.Thread(target=read_stream, args=(process.stdout, "stdout"), daemon=True),
+            threading.Thread(target=read_stream, args=(process.stderr, "stderr"), daemon=True),
+        ]
+        for thread in threads:
+            thread.start()
+        return _PersistentProcess(process, events, stdout, stderr, threads)
+
+    @staticmethod
+    def _drain_queued(running: _PersistentProcess) -> None:
+        while True:
+            try:
+                stream, line = running.events.get_nowait()
+            except queue.Empty:
+                return
+            if stream == "stdout" and line is not None:
+                running.stdout.append(line)
+            elif line is not None:
+                running.stderr.append(line)
+
+    @staticmethod
+    def _terminate(proc: subprocess.Popen[str]) -> None:
+        PiAgentRunner._terminate(proc)
+
+    def close(self) -> None:
+        """Close runner state without deleting persisted Codex sessions."""
+        return
+
+
+__all__ = [
+    "AgentRunResult",
+    "AgentRunner",
+    "CodexAgentRunner",
+    "PiAgentRunner",
+    "normalize_codex_output",
+    "normalize_pi_output",
+    "validate_codex_pricing",
+]

--- a/src/gepa/oa/config.py
+++ b/src/gepa/oa/config.py
@@ -53,11 +53,10 @@ class OptimizeAnythingConfig:
             use a tempdir; in-process engines skip artifact writes. Set
             explicitly to persist them.
         stop_at_score: Score threshold for early stop. Each engine interprets.
-        sandbox: OS-jail the subprocess engines' ``claude`` sessions (bwrap on
-            Linux — requires the ``bubblewrap`` package — Claude Code's
-            Seatbelt sandbox on macOS). Default ``True``. Linux runs abort at
-            engine start when ``bwrap`` is missing; ``False`` prints a loud
-            warning and runs the agent unsandboxed with full host access.
+        sandbox: OS-jail agent subprocess engines (bwrap on Linux; Claude's
+            Seatbelt or Pi's ``sandbox-exec`` profile on macOS). Default
+            ``True``. Pi never falls back to an unsandboxed process when a
+            requested jail is unavailable.
         engine_config: Engine-specific options that don't generalize across
             engines. Each engine reads the keys it understands and warns about
             leftovers so typos surface. The keys an engine accepts are
@@ -72,17 +71,22 @@ class OptimizeAnythingConfig:
               reflection LM, wandb/mlflow tracking, reasoning knobs (via
               ``reflection.reflection_lm_kwargs``, e.g. ``reasoning_effort`` /
               ``thinking``), and (via ``reflection.custom_candidate_proposer``)
-              a Claude Code proposer here — see
+              a Codex or Pi custom proposer here — see
               :class:`~gepa.oa.engines.gepa.GepaEngine`.
-            - ``autoresearch`` — ``model``, ``ralph``, ``max_no_eval_seconds``,
-              ``handoffs``, ``effort``, ``max_thinking_tokens`` (see
+            - ``autoresearch`` — ``agent_backend``, ``pi_command``,
+              ``codex_command``, ``codex_input_cost_per_million``,
+              ``codex_output_cost_per_million``, ``model``, ``ralph``,
+              ``max_no_eval_seconds``, ``handoffs``, ``effort``,
+              ``max_thinking_tokens`` (see
               ``AutoResearchEngine`` / ``_AR_CONFIG_KEYS``).
             - ``best_of_n`` — ``model``, ``temperature``, ``max_n``,
               ``lm_kwargs``, ``effort``, ``max_thinking_tokens`` (see
               ``BestOfNEngine`` / ``_BON_CONFIG_KEYS``).
-            - ``meta_harness`` — ``model``, ``max_iterations``,
-              ``max_candidates_per_iter``, ``effort``, ``max_thinking_tokens``
-              (see ``MetaHarnessEngine`` / ``_MH_CONFIG_KEYS``).
+            - ``meta_harness`` — ``agent_backend``, ``pi_command``,
+              ``codex_command``, ``codex_input_cost_per_million``,
+              ``codex_output_cost_per_million``, ``model``, ``max_iterations``,
+              ``max_candidates_per_iter``, ``timeout_seconds``, ``effort``,
+              ``max_thinking_tokens`` (see ``MetaHarnessEngine``).
 
             ``effort`` (``claude --effort``) and ``max_thinking_tokens`` are
             Claude-CLI knobs, so they live in each agent engine's

--- a/src/gepa/oa/engines/autoresearch.py
+++ b/src/gepa/oa/engines/autoresearch.py
@@ -1,7 +1,7 @@
-"""AutoResearch engine: black-box optimization via a Claude Code subprocess.
+"""AutoResearch engine: black-box optimization via an agent subprocess.
 
 The api creates an :class:`EvalServer` and starts its HTTP endpoint. This
-engine launches one ``claude --print`` session inside a work_dir laid out
+engine launches one configured agent session inside a work_dir laid out
 with ``program.md``, ``candidate.txt``, ``best_candidate.txt``, and an
 ``eval.sh`` script that POSTs to the eval server. Budget enforcement happens
 server-side (HTTP 429 on exhaustion); LLM cost is bounded via
@@ -29,10 +29,23 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from gepa.oa.agent_runner import (
+    CodexAgentRunner,
+    PiAgentRunner,
+    normalize_codex_output,
+    validate_codex_pricing,
+)
 from gepa.oa.budget import BudgetTracker
 from gepa.oa.engine import Result
 from gepa.oa.engines.claude_utils import copy_session_transcript
-from gepa.oa.sandbox import DENY_WEB_TOOLS, bwrap_prefix, claude_permission_args, preflight_claude_engine
+from gepa.oa.sandbox import (
+    DENY_WEB_TOOLS,
+    bwrap_prefix,
+    claude_permission_args,
+    pi_sandbox_prefix,
+    preflight_agent_engine,
+    preflight_claude_engine,
+)
 from gepa.oa.task import seed_as_text
 from gepa.oa.utils import example_to_json
 
@@ -49,11 +62,18 @@ class AutoResearchConfig:
     Populated from ``OptimizeAnythingConfig.engine_config``.
 
     Attributes:
-        model: Claude model id. Versioned default — pin for reproducibility;
-            pass ``"sonnet"`` / ``"opus"`` to track Anthropic's current default.
-        ralph: Continue one Claude Code session via repeated
-            ``claude --resume`` while budget remains. Stops early on a zero-cost
-            iteration (no progress) or a claude error.
+        model: Agent model id. The Claude default remains for backwards
+            compatibility; Pi profiles should always pass an explicit
+            provider/model string. Codex may use the authenticated CLI default.
+        agent_backend: ``"claude"`` (legacy), ``"pi"``, or ``"codex"``. There
+            is no implicit fallback when an agent backend is requested.
+        pi_command: Pi executable or absolute path.
+        codex_command: Codex executable or absolute path.
+        codex_input_cost_per_million: Optional input-token USD rate.
+        codex_output_cost_per_million: Optional output-token USD rate.
+        ralph: Continue one agent session while budget remains. Claude uses
+            ``--resume``; Pi uses one persistent RPC process; Codex resumes one
+            persisted thread.
         max_no_eval_seconds: Terminate the subprocess after this many seconds
             without an eval call. ``None`` disables the guard.
         handoffs: Prior-stage artifacts for sequential compositions — each item
@@ -63,7 +83,12 @@ class AutoResearchConfig:
         max_thinking_tokens: Fixed thinking-token budget (``MAX_THINKING_TOKENS``).
     """
 
-    model: str = "claude-sonnet-4-6"
+    model: str | None = "claude-sonnet-4-6"
+    agent_backend: str = "claude"
+    pi_command: str = "pi"
+    codex_command: str = "codex"
+    codex_input_cost_per_million: float | None = None
+    codex_output_cost_per_million: float | None = None
     ralph: bool = True
     max_no_eval_seconds: float | None = None
     handoffs: list[dict[str, Any]] | None = None
@@ -74,11 +99,18 @@ class AutoResearchConfig:
         # yaml/CLI may pass ralph as a string ("false") and max_no_eval_seconds
         # as a string/int; coerce to the declared types.
         self.ralph = _config_bool(self.ralph)
+        self.agent_backend = str(self.agent_backend).strip().lower()
+        if self.agent_backend not in {"claude", "pi", "codex"}:
+            raise ValueError("autoresearch agent_backend must be 'claude', 'pi', or 'codex'")
+        if self.agent_backend == "pi" and self.model == "claude-sonnet-4-6":
+            raise ValueError("autoresearch with agent_backend='pi' requires an explicit provider/model")
+        if self.agent_backend == "codex" and self.model == "claude-sonnet-4-6":
+            self.model = None
         if self.max_no_eval_seconds is not None:
             self.max_no_eval_seconds = float(self.max_no_eval_seconds)
 
 
-# Nudge fed to claude --resume on each Ralph iteration.
+# Nudge fed to the configured agent on each Ralph iteration.
 RALPH_CONTINUE_PROMPT = (
     "Continue iterating on the candidate. Re-read program.md if needed. "
     "Run ./eval.sh as appropriate. "
@@ -464,7 +496,7 @@ def _safe_name(value: str) -> str:
 
 
 class AutoResearchEngine:
-    """Black-box research optimizer backed by Claude Code.
+    """Black-box research optimizer backed by Claude Code, Pi, or Codex.
 
     Engine-specific options come from ``OptimizeAnythingConfig.engine_config``,
     parsed into :class:`AutoResearchConfig`.
@@ -475,6 +507,11 @@ class AutoResearchEngine:
     def __init__(self, config: OptimizeAnythingConfig) -> None:
         engine_config = AutoResearchConfig(**config.engine_config)
         self.model = engine_config.model
+        self.agent_backend = engine_config.agent_backend
+        self.pi_command = engine_config.pi_command
+        self.codex_command = engine_config.codex_command
+        self.codex_input_cost_per_million = engine_config.codex_input_cost_per_million
+        self.codex_output_cost_per_million = engine_config.codex_output_cost_per_million
         self.ralph = engine_config.ralph
         self.max_no_eval_seconds = engine_config.max_no_eval_seconds
         self.handoffs = engine_config.handoffs
@@ -483,13 +520,40 @@ class AutoResearchEngine:
         self.run_dir = config.run_dir
         self.stop_at_score = config.stop_at_score
         self.sandbox = config.sandbox
-        # Proposer-cost cap: USD the claude subprocess(es) may spend. Enforced
-        # via --max-budget-usd; the eval server never sees proposer spend.
+        # Proposer-cost cap: USD the configured agent subprocess(es) may spend.
+        # Claude receives --max-budget-usd; Pi is monitored through events.
         self.max_token_cost = config.max_token_cost
+        if self.agent_backend == "codex":
+            validate_codex_pricing(
+                self.max_token_cost,
+                self.codex_input_cost_per_million,
+                self.codex_output_cost_per_million,
+            )
         self._pending_tempdir: tempfile.TemporaryDirectory[str] | None = None
+        self._pi_runner: PiAgentRunner | None = None
+        self._pi_session_id: str | None = None
+        self._codex_runner: CodexAgentRunner | None = None
+        self._codex_session_id: str | None = None
+        self._codex_cost_known = True
+        self._codex_usage: dict[str, Any] = {}
 
     def run(self, task: Task, server: EvalServer) -> Result:
-        preflight_claude_engine(self.name, sandbox=bool(self.sandbox))
+        if self.agent_backend == "pi":
+            preflight_agent_engine(
+                self.name,
+                backend="pi",
+                command=self.pi_command,
+                sandbox=bool(self.sandbox),
+            )
+        elif self.agent_backend == "codex":
+            preflight_agent_engine(
+                self.name,
+                backend="codex",
+                command=self.codex_command,
+                sandbox=bool(self.sandbox),
+            )
+        else:
+            preflight_claude_engine(self.name, sandbox=bool(self.sandbox))
         budget = server.budget
 
         # When sandbox=True, force tempdir work_dir even if run_dir is set.
@@ -540,9 +604,9 @@ class AutoResearchEngine:
 
         adapter_cost = 0.0
         ralph_iterations = 1
-        invocations: list[dict[str, float | int | None]] = []
+        invocations: list[dict[str, Any]] = []
 
-        proc = self._run_claude(
+        proc = self._run_agent(
             work_dir=work_dir,
             session_id=session_id,
             prompt=prompt,
@@ -557,15 +621,27 @@ class AutoResearchEngine:
             and "NO_EVAL_PROGRESS" not in proc.stderr
             and not _saw_budget_exhausted(proc)
         ):
+            artifact_dir = self._persist_failure_artifacts(server, work_dir)
+            self._close_agent_runners()
+            diagnostics = f" diagnostics={artifact_dir}" if artifact_dir is not None else ""
             raise RuntimeError(
-                "Claude Code subprocess failed "
+                f"{self.agent_backend} agent subprocess failed "
                 f"(exit {proc.returncode}). "
                 f"stdout_tail={_tail_text(proc.stdout)!r} "
-                f"stderr_tail={_tail_text(proc.stderr)!r}"
+                f"stderr_tail={_tail_text(proc.stderr)!r}{diagnostics}"
             )
-        iter_cost = _extract_claude_cost(proc.stdout)
-        adapter_cost += iter_cost
-        invocations.append({"cost": iter_cost, "score": server.best_score, "returncode": proc.returncode})
+        iter_cost = self._extract_agent_cost(proc.stdout)
+        adapter_cost += iter_cost or 0.0
+        invocation = {"cost": iter_cost, "score": server.best_score, "returncode": proc.returncode}
+        if self.agent_backend == "codex":
+            invocation.update(
+                {
+                    "usage": dict(self._codex_usage),
+                    "cost_known": self._codex_cost_known,
+                    "cost_estimate_usd": iter_cost if self._codex_cost_known else None,
+                }
+            )
+        invocations.append(invocation)
 
         if self.ralph:
             while ralph_iterations < _RALPH_SAFETY_ITERATION_CAP:
@@ -581,7 +657,7 @@ class AutoResearchEngine:
                     break
                 if proc.returncode != 0:
                     break
-                proc = self._run_claude(
+                proc = self._run_agent(
                     work_dir=work_dir,
                     session_id=session_id,
                     prompt=RALPH_CONTINUE_PROMPT,
@@ -590,9 +666,18 @@ class AutoResearchEngine:
                     resume=True,
                     env=env,
                 )
-                iter_cost = _extract_claude_cost(proc.stdout)
-                adapter_cost += iter_cost
-                invocations.append({"cost": iter_cost, "score": server.best_score, "returncode": proc.returncode})
+                iter_cost = self._extract_agent_cost(proc.stdout)
+                adapter_cost += iter_cost or 0.0
+                invocation = {"cost": iter_cost, "score": server.best_score, "returncode": proc.returncode}
+                if self.agent_backend == "codex":
+                    invocation.update(
+                        {
+                            "usage": dict(self._codex_usage),
+                            "cost_known": self._codex_cost_known,
+                            "cost_estimate_usd": iter_cost if self._codex_cost_known else None,
+                        }
+                    )
+                invocations.append(invocation)
                 if _saw_budget_exhausted(proc):
                     break
                 if proc.returncode != 0:
@@ -600,8 +685,12 @@ class AutoResearchEngine:
                 ralph_iterations += 1
                 # Iteration produced no measurable cost — agent likely
                 # has no more progress to make. Stop spending.
-                if iter_cost < 0.001:
+                if iter_cost is not None and iter_cost < 0.001:
                     break
+
+        runner_session_id = self._codex_session_id if self.agent_backend == "codex" else self._pi_session_id
+        self._close_agent_runners()
+        adapter_cost_known = self.agent_backend != "codex" or self._codex_cost_known
 
         best_candidate = best_file.read_text() if best_file.exists() else seed_as_text(task.seed_candidate)
         best_score = server.best_score
@@ -618,13 +707,219 @@ class AutoResearchEngine:
             total_evals=server.budget.used,
             eval_log=server.eval_log,
             metadata={
-                "adapter_cost": adapter_cost,
+                "adapter_cost": adapter_cost if adapter_cost_known else None,
                 "session_id": session_id,
+                "agent_backend": self.agent_backend,
+                "runner_session_id": runner_session_id,
+                "adapter_cost_known": adapter_cost_known,
+                "adapter_cost_estimate_usd": (
+                    adapter_cost
+                    if adapter_cost_known
+                    else None
+                ),
                 "work_dir": str(work_dir),
                 "ralph_iterations": ralph_iterations,
                 "invocations": invocations,
             },
         )
+
+    def _run_agent(
+        self,
+        *,
+        work_dir: Path,
+        session_id: str,
+        prompt: str,
+        budget: BudgetTracker,
+        adapter_cost: float,
+        resume: bool,
+        env: dict[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        if self.agent_backend == "claude":
+            return self._run_claude(
+                work_dir=work_dir,
+                session_id=session_id,
+                prompt=prompt,
+                budget=budget,
+                adapter_cost=adapter_cost,
+                resume=resume,
+                env=env,
+            )
+        if self.agent_backend == "pi":
+            return self._run_pi(
+                work_dir=work_dir,
+                session_id=session_id,
+                prompt=prompt,
+                budget=budget,
+                adapter_cost=adapter_cost,
+                env=env,
+            )
+        return self._run_codex(
+            work_dir=work_dir,
+            prompt=prompt,
+            budget=budget,
+            adapter_cost=adapter_cost,
+            env=env,
+        )
+
+    def _run_pi(
+        self,
+        *,
+        work_dir: Path,
+        session_id: str,
+        prompt: str,
+        budget: BudgetTracker,
+        adapter_cost: float,
+        env: dict[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        del session_id
+        if self._pi_runner is None:
+            self._pi_runner = PiAgentRunner(
+                command=self.pi_command,
+                model=self.model,
+                persistent=True,
+                sandbox=bool(self.sandbox),
+                sandbox_prefix=pi_sandbox_prefix,
+                env={**env, "GEPA_OMNI_WORK_DIR": str(work_dir)},
+            )
+        last_eval_used = budget.used
+        last_eval_time = time.monotonic()
+        exhausted_since: float | None = None
+
+        def progress_check() -> str | None:
+            nonlocal last_eval_used, last_eval_time, exhausted_since
+            if budget.used != last_eval_used:
+                last_eval_used = budget.used
+                last_eval_time = time.monotonic()
+            if self.max_no_eval_seconds is not None and time.monotonic() - last_eval_time >= self.max_no_eval_seconds:
+                return f"NO_EVAL_PROGRESS: terminated Pi after {self.max_no_eval_seconds:.1f}s without eval progress."
+            if budget.exhausted:
+                if exhausted_since is None:
+                    exhausted_since = time.monotonic()
+                elif time.monotonic() - exhausted_since >= _BUDGET_EXHAUSTION_GRACE_SECONDS:
+                    return "BUDGET_EXHAUSTED: terminated Pi after eval budget was exhausted."
+            return None
+
+        try:
+            result = self._pi_runner.run(
+                prompt,
+                work_dir=work_dir,
+                progress_check=progress_check,
+                max_budget_usd=(None if self.max_token_cost is None else max(0.0, self.max_token_cost - adapter_cost)),
+            )
+        except BaseException:
+            self._close_pi_runner()
+            raise
+        self._pi_session_id = result.session_id
+        stdout = result.stdout
+        stderr = result.stderr
+        if result.returncode == 0 and not result.completed and not result.timed_out:
+            stderr += "\nPI_MALFORMED_OUTPUT: Pi exited without an agent_end event.\n"
+            returncode = 1
+        else:
+            returncode = result.returncode
+        return subprocess.CompletedProcess(result.command, returncode, stdout, stderr)
+
+    def _run_codex(
+        self,
+        *,
+        work_dir: Path,
+        prompt: str,
+        budget: BudgetTracker,
+        adapter_cost: float,
+        env: dict[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        if self._codex_runner is None:
+            self._codex_runner = CodexAgentRunner(
+                command=self.codex_command,
+                model=self.model,
+                persistent=True,
+                sandbox=bool(self.sandbox),
+                env={**env, "GEPA_OMNI_WORK_DIR": str(work_dir)},
+                input_cost_per_million=self.codex_input_cost_per_million,
+                output_cost_per_million=self.codex_output_cost_per_million,
+            )
+        last_eval_used = budget.used
+        last_eval_time = time.monotonic()
+        exhausted_since: float | None = None
+
+        def progress_check() -> str | None:
+            nonlocal last_eval_used, last_eval_time, exhausted_since
+            if budget.used != last_eval_used:
+                last_eval_used = budget.used
+                last_eval_time = time.monotonic()
+            if self.max_no_eval_seconds is not None and time.monotonic() - last_eval_time >= self.max_no_eval_seconds:
+                return f"NO_EVAL_PROGRESS: terminated Codex after {self.max_no_eval_seconds:.1f}s without eval progress."
+            if budget.exhausted:
+                if exhausted_since is None:
+                    exhausted_since = time.monotonic()
+                elif time.monotonic() - exhausted_since >= _BUDGET_EXHAUSTION_GRACE_SECONDS:
+                    return "BUDGET_EXHAUSTED: terminated Codex after eval budget was exhausted."
+            return None
+
+        try:
+            result = self._codex_runner.run(
+                prompt,
+                work_dir=work_dir,
+                progress_check=progress_check,
+                max_budget_usd=(None if self.max_token_cost is None else max(0.0, self.max_token_cost - adapter_cost)),
+            )
+        except BaseException:
+            self._close_agent_runners()
+            raise
+        self._codex_session_id = result.session_id
+        self._codex_usage = dict(result.usage)
+        self._codex_cost_known = self._codex_cost_known and result.cost_known
+        stdout = result.stdout
+        stderr = result.stderr
+        if result.returncode == 0 and not result.completed and not result.timed_out:
+            stderr += "\nCODEX_MALFORMED_OUTPUT: Codex exited without a completed turn.\n"
+            returncode = 1
+        else:
+            returncode = result.returncode
+        return subprocess.CompletedProcess(result.command, returncode, stdout, stderr)
+
+    def _extract_agent_cost(self, stdout: str) -> float | None:
+        if self.agent_backend == "pi":
+            from gepa.oa.agent_runner import normalize_pi_output
+
+            _usage, cost, _text, _completed = normalize_pi_output(stdout)
+            return float(cost or 0.0)
+        if self.agent_backend == "codex":
+            _usage, cost, _text, _session, _completed, _known = normalize_codex_output(
+                stdout,
+                input_cost_per_million=self.codex_input_cost_per_million,
+                output_cost_per_million=self.codex_output_cost_per_million,
+            )
+            return cost
+        return _extract_claude_cost(stdout)
+
+    def _persist_failure_artifacts(self, server: EvalServer, work_dir: Path) -> Path | None:
+        destination = getattr(server, "output_dir", None)
+        if destination is None and self.run_dir:
+            destination = Path(self.run_dir)
+        if destination is None:
+            return None
+        destination = Path(destination)
+        try:
+            destination.mkdir(parents=True, exist_ok=True)
+            if _is_under(work_dir, destination):
+                return destination
+            persisted = destination / "work"
+            shutil.copytree(work_dir, persisted, dirs_exist_ok=True)
+            return persisted
+        except (OSError, shutil.Error):
+            return None
+
+    def _close_pi_runner(self) -> None:
+        if self._pi_runner is not None:
+            self._pi_runner.close()
+            self._pi_runner = None
+
+    def _close_agent_runners(self) -> None:
+        self._close_pi_runner()
+        if self._codex_runner is not None:
+            self._codex_runner.close()
+            self._codex_runner = None
 
     def _run_claude(
         self,
@@ -655,9 +950,9 @@ class AutoResearchEngine:
             "--print",
             "--output-format",
             "json",
-            "--model",
-            self.model,
         ]
+        if self.model:
+            cmd.extend(["--model", self.model])
         if resume:
             cmd.extend(["--resume", session_id])
         else:
@@ -759,7 +1054,11 @@ def _tail_text(text: str | None, *, max_chars: int = 2000) -> str:
 
 def _saw_budget_exhausted(proc: subprocess.CompletedProcess[str]) -> bool:
     """Return whether Claude observed the eval server's exhausted-budget marker."""
-    return _BUDGET_EXHAUSTED_MARKER in (proc.stdout or "") or _BUDGET_EXHAUSTED_MARKER in (proc.stderr or "")
+    output = (proc.stdout or "") + "\n" + (proc.stderr or "")
+    return any(
+        marker in output
+        for marker in (_BUDGET_EXHAUSTED_MARKER, "CODEX_TOKEN_BUDGET", "CODEX_USAGE_MISSING")
+    )
 
 
 def _config_bool(value: object) -> bool:

--- a/src/gepa/oa/engines/meta_harness.py
+++ b/src/gepa/oa/engines/meta_harness.py
@@ -1,6 +1,6 @@
-"""Meta-Harness engine: iterative candidate proposal via Claude Code.
+"""Meta-Harness engine: iterative candidate proposal via an agent.
 
-The proposer (a Claude subprocess) reads frontier + history and writes
+The configured proposer subprocess reads frontier + history and writes
 ``pending_eval.json`` listing 1+ candidates; the engine benchmarks each one
 through the optimize_anything eval server, updates state files, and loops until the
 budget is exhausted or ``max_iterations`` is hit.
@@ -21,9 +21,21 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
+from gepa.oa.agent_runner import (
+    CodexAgentRunner,
+    PiAgentRunner,
+    validate_codex_pricing,
+)
 from gepa.oa.budget import BudgetExhausted, BudgetTracker
 from gepa.oa.engine import Result
-from gepa.oa.sandbox import DENY_WEB_TOOLS, bwrap_prefix, claude_permission_args, preflight_claude_engine
+from gepa.oa.sandbox import (
+    DENY_WEB_TOOLS,
+    bwrap_prefix,
+    claude_permission_args,
+    pi_sandbox_prefix,
+    preflight_agent_engine,
+    preflight_claude_engine,
+)
 from gepa.oa.task import seed_as_text
 from gepa.oa.utils import example_to_json
 
@@ -40,22 +52,45 @@ class MetaHarnessConfig:
     Populated from ``OptimizeAnythingConfig.engine_config``.
 
     Attributes:
-        model: Proposer model id. Versioned default — pin for reproducibility;
-            pass ``"sonnet"`` / ``"opus"`` to track Anthropic's current default.
+        model: Proposer model id. The Claude default remains for backwards
+            compatibility; Pi profiles should pass an explicit provider/model.
+            Codex may use the authenticated CLI default.
+        agent_backend: ``"claude"`` (legacy), ``"pi"``, or ``"codex"``. There
+            is no implicit fallback when an agent backend is requested.
+        pi_command: Pi executable or absolute path.
+        codex_command: Codex executable or absolute path.
+        codex_input_cost_per_million: Optional input-token USD rate.
+        codex_output_cost_per_million: Optional output-token USD rate.
         max_iterations: Hard cap on proposer sessions. ``None`` = until budget.
         max_candidates_per_iter: Upper bound on candidates per iteration.
         effort: ``claude --effort`` value (CLI flag).
         max_thinking_tokens: Fixed thinking-token budget (``MAX_THINKING_TOKENS``).
+        timeout_seconds: Maximum wall time for one agent proposer session.
     """
 
-    model: str = "claude-sonnet-4-6"
+    model: str | None = "claude-sonnet-4-6"
+    agent_backend: str = "claude"
+    pi_command: str = "pi"
+    codex_command: str = "codex"
+    codex_input_cost_per_million: float | None = None
+    codex_output_cost_per_million: float | None = None
     max_iterations: int | None = None
     max_candidates_per_iter: int = 3
     effort: str | None = None
     max_thinking_tokens: int | None = None
+    timeout_seconds: float | None = None
 
     def __post_init__(self) -> None:
         self.max_candidates_per_iter = max(1, int(self.max_candidates_per_iter))
+        self.agent_backend = str(self.agent_backend).strip().lower()
+        if self.agent_backend not in {"claude", "pi", "codex"}:
+            raise ValueError("meta_harness agent_backend must be 'claude', 'pi', or 'codex'")
+        if self.agent_backend == "pi" and self.model == "claude-sonnet-4-6":
+            raise ValueError("meta_harness with agent_backend='pi' requires an explicit provider/model")
+        if self.agent_backend == "codex" and self.model == "claude-sonnet-4-6":
+            self.model = None
+        if self.timeout_seconds is not None:
+            self.timeout_seconds = float(self.timeout_seconds)
 
 
 SKILL_MD = """\
@@ -281,7 +316,7 @@ def _run_proposer(
     *,
     work_dir: Path,
     iteration: int,
-    model: str,
+    model: str | None,
     effort: str | None,
     max_candidates: int,
     max_budget_usd: float | None,
@@ -313,12 +348,12 @@ def _run_proposer(
         prompt,
         "--output-format",
         "json",
-        "--model",
-        model,
         "--session-id",
         session_id,
         DENY_WEB_TOOLS,
     ]
+    if model:
+        cmd.extend(["--model", model])
     # Single source of the permission posture (see claude_permission_args):
     # bypassPermissions in the bwrap jail / unsandboxed, or the macOS Seatbelt
     # settings whose --permission-mode default enforces the file-tool whitelist.
@@ -364,6 +399,164 @@ def _run_proposer(
         )
     )
     return proc.returncode, cost_usd, session_id
+
+
+def _run_pi_proposer(
+    *,
+    work_dir: Path,
+    iteration: int,
+    model: str | None,
+    max_candidates: int,
+    max_budget_usd: float | None,
+    pending_path: Path,
+    log_dir: Path,
+    timeout_seconds: float | None = None,
+    sandbox: bool = True,
+    pi_command: str = "pi",
+) -> tuple[int, float, str]:
+    """Run one fresh Pi session while retaining the Meta-Harness workspace."""
+    del pending_path  # The path is included in the prompt; Pi writes it itself.
+    state = work_dir / "state"
+    prompt = (
+        f"Run iteration {iteration} of the meta-harness evolution loop. "
+        f"Produce up to {max_candidates} candidate(s).\n\n"
+        f"## Run directories (absolute paths)\n"
+        f"- task.md: `{work_dir / 'task.md'}`\n"
+        f"- state/frontier.json: `{state / 'frontier.json'}`\n"
+        f"- state/evolution_summary.jsonl: `{state / 'evolution_summary.jsonl'}`\n"
+        f"- state/eval_traces/<candidate_name>/: `{state / 'eval_traces'}`\n"
+        f"- state/reports/: `{state / 'reports'}`\n"
+        f"- agents/: `{work_dir / 'agents'}`\n"
+        f"- Write pending_eval.json to: `{state / f'pending_eval_iter{iteration}.json'}`\n\n"
+        "Follow the explicit Meta-Harness instructions below. The outer loop "
+        "benchmarks candidates; do not run the evaluator yourself.\n\n"
+        f"{SKILL_MD}"
+    )
+
+    runner = PiAgentRunner(
+        command=pi_command,
+        model=model,
+        persistent=False,
+        tools="read,grep,find,ls,bash,edit,write",
+        sandbox=sandbox,
+        sandbox_prefix=pi_sandbox_prefix,
+        env={**os.environ, "GEPA_OMNI_WORK_DIR": str(work_dir)},
+    )
+    try:
+        result = runner.run(
+            prompt,
+            work_dir=work_dir,
+            timeout_seconds=timeout_seconds,
+            max_budget_usd=max_budget_usd,
+        )
+    finally:
+        runner.close()
+
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / f"iter{iteration}_stdout.jsonl").write_text(result.stdout or "")
+    (log_dir / f"iter{iteration}_stderr.txt").write_text(result.stderr or "")
+    exit_code = result.returncode
+    if exit_code == 0 and not result.completed:
+        exit_code = 1
+    (log_dir / f"iter{iteration}_meta.json").write_text(
+        json.dumps(
+            {
+                "iteration": iteration,
+                "agent_backend": "pi",
+                "session_id": result.session_id,
+                "exit_code": exit_code,
+                "cost_usd": result.cost_usd,
+                "usage": result.usage,
+                "timed_out": result.timed_out,
+                "completed": result.completed,
+                "cmd": list(result.command),
+                "stderr_tail": (result.stderr or "")[-2000:],
+            },
+            indent=2,
+        )
+    )
+    return exit_code, float(result.cost_usd or 0.0), result.session_id or str(uuid.uuid4())
+
+
+def _run_codex_proposer(
+    *,
+    work_dir: Path,
+    iteration: int,
+    model: str | None,
+    max_candidates: int,
+    max_budget_usd: float | None,
+    pending_path: Path,
+    log_dir: Path,
+    timeout_seconds: float | None = None,
+    sandbox: bool = True,
+    codex_command: str = "codex",
+    input_cost_per_million: float | None = None,
+    output_cost_per_million: float | None = None,
+) -> tuple[int, float | None, str | None, bool]:
+    """Run one fresh ephemeral Codex session for a Meta-Harness iteration."""
+    del pending_path  # The path is included in the prompt; Codex writes it itself.
+    state = work_dir / "state"
+    prompt = (
+        f"Run iteration {iteration} of the meta-harness evolution loop. "
+        f"Produce up to {max_candidates} candidate(s).\n\n"
+        f"## Run directories (absolute paths)\n"
+        f"- task.md: `{work_dir / 'task.md'}`\n"
+        f"- state/frontier.json: `{state / 'frontier.json'}`\n"
+        f"- state/evolution_summary.jsonl: `{state / 'evolution_summary.jsonl'}`\n"
+        f"- state/eval_traces/<candidate_name>/: `{state / 'eval_traces'}`\n"
+        f"- state/reports/: `{state / 'reports'}`\n"
+        f"- agents/: `{work_dir / 'agents'}`\n"
+        f"- Write pending_eval.json to: `{state / f'pending_eval_iter{iteration}.json'}`\n\n"
+        "Follow the explicit Meta-Harness instructions below. The outer loop "
+        "benchmarks candidates; do not run the evaluator yourself.\n\n"
+        f"{SKILL_MD}"
+    )
+
+    runner = CodexAgentRunner(
+        command=codex_command,
+        model=model,
+        persistent=False,
+        sandbox=sandbox,
+        env={**os.environ, "GEPA_OMNI_WORK_DIR": str(work_dir)},
+        input_cost_per_million=input_cost_per_million,
+        output_cost_per_million=output_cost_per_million,
+    )
+    try:
+        result = runner.run(
+            prompt,
+            work_dir=work_dir,
+            timeout_seconds=timeout_seconds,
+            max_budget_usd=max_budget_usd,
+        )
+    finally:
+        runner.close()
+
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / f"iter{iteration}_stdout.jsonl").write_text(result.stdout or "")
+    (log_dir / f"iter{iteration}_stderr.txt").write_text(result.stderr or "")
+    exit_code = result.returncode
+    if exit_code == 0 and not result.completed:
+        exit_code = 1
+    (log_dir / f"iter{iteration}_meta.json").write_text(
+        json.dumps(
+            {
+                "iteration": iteration,
+                "agent_backend": "codex",
+                "session_id": result.session_id,
+                "exit_code": exit_code,
+                "cost_usd": result.cost_usd,
+                "cost_estimate_usd": result.cost_usd if result.cost_known else None,
+                "cost_known": result.cost_known,
+                "usage": result.usage,
+                "timed_out": result.timed_out,
+                "completed": result.completed,
+                "cmd": list(result.command),
+                "stderr_tail": (result.stderr or "")[-2000:],
+            },
+            indent=2,
+        )
+    )
+    return exit_code, result.cost_usd, result.session_id, result.cost_known
 
 
 def _parse_proposer_result(stdout: str) -> tuple[float, dict[str, Any]]:
@@ -609,6 +802,10 @@ def _elapsed(seconds: float) -> str:
     return f"{m}m{s:02d}s" if m else f"{s}s"
 
 
+def _format_cost(cost: float | None) -> str:
+    return f"${cost:.3f}" if cost is not None else "unknown"
+
+
 def _colorize_score(score: float) -> str:
     s = f"{score:.4f}"
     if score > 0:
@@ -630,21 +827,48 @@ class MetaHarnessEngine:
     def __init__(self, config: OptimizeAnythingConfig) -> None:
         engine_config = MetaHarnessConfig(**config.engine_config)
         self.model = engine_config.model
+        self.agent_backend = engine_config.agent_backend
+        self.pi_command = engine_config.pi_command
+        self.codex_command = engine_config.codex_command
+        self.codex_input_cost_per_million = engine_config.codex_input_cost_per_million
+        self.codex_output_cost_per_million = engine_config.codex_output_cost_per_million
         self.max_iterations = engine_config.max_iterations
         self.max_candidates_per_iter = engine_config.max_candidates_per_iter
         self.effort = engine_config.effort
         self.max_thinking_tokens = engine_config.max_thinking_tokens
+        self.timeout_seconds = engine_config.timeout_seconds
         self.run_dir = config.run_dir
         self.stop_at_score = config.stop_at_score
         self.sandbox = config.sandbox
-        # Proposer-cost cap: USD this engine may spend across its claude
-        # subprocess sessions. Enforced via --max-budget-usd; the eval server
-        # never sees proposer spend.
+        # Proposer-cost cap: USD this engine may spend across agent sessions.
+        # Claude receives --max-budget-usd; Pi is monitored through normalized
+        # event costs and the outer loop stops before another session starts.
         self.max_token_cost = config.max_token_cost
+        if self.agent_backend == "codex":
+            validate_codex_pricing(
+                self.max_token_cost,
+                self.codex_input_cost_per_million,
+                self.codex_output_cost_per_million,
+            )
         self._pending_tempdir: tempfile.TemporaryDirectory[str] | None = None
 
     def run(self, task: Task, server: EvalServer) -> Result:
-        preflight_claude_engine(self.name, sandbox=bool(self.sandbox))
+        if self.agent_backend == "pi":
+            preflight_agent_engine(
+                self.name,
+                backend="pi",
+                command=self.pi_command,
+                sandbox=bool(self.sandbox),
+            )
+        elif self.agent_backend == "codex":
+            preflight_agent_engine(
+                self.name,
+                backend="codex",
+                command=self.codex_command,
+                sandbox=bool(self.sandbox),
+            )
+        else:
+            preflight_claude_engine(self.name, sandbox=bool(self.sandbox))
         budget = server.budget
 
         # When sandbox=True, force tempdir work_dir even if run_dir is set —
@@ -669,8 +893,10 @@ class MetaHarnessEngine:
         sessions_dir = work_dir / "sessions"
         sessions_dir.mkdir(parents=True, exist_ok=True)
 
-        session_ids: list[str] = []
-        total_proposer_cost = 0.0
+        session_ids: list[str | None] = []
+        total_proposer_cost: float | None = 0.0
+        numeric_proposer_cost = 0.0
+        total_proposer_cost_known = True
         cap = self.max_iterations if self.max_iterations is not None else 50
 
         run_start = time.time()
@@ -684,7 +910,7 @@ class MetaHarnessEngine:
 
             per_session_cap: float | None = None
             if self.max_token_cost is not None:
-                remaining = self.max_token_cost - total_proposer_cost
+                remaining = self.max_token_cost - numeric_proposer_cost
                 if remaining <= 0:
                     stop_reason = "token_budget_exhausted"
                     break
@@ -692,7 +918,7 @@ class MetaHarnessEngine:
 
             _log(
                 f"\n{_bold(f'[meta-harness] iteration {iteration}/{cap}')} "
-                f"{_dim(f'(evals used={budget.used}, cost=${total_proposer_cost:.3f})')}"
+                f"{_dim(f'(evals used={budget.used}, cost={_format_cost(total_proposer_cost)})')}"
             )
 
             pending_path = state_dir / f"pending_eval_iter{iteration}.json"
@@ -700,25 +926,62 @@ class MetaHarnessEngine:
                 pending_path.unlink()
 
             propose_start = time.time()
-            exit_code, cost, session_id = _run_proposer(
-                work_dir=work_dir,
-                iteration=iteration,
-                model=self.model,
-                effort=self.effort,
-                max_candidates=self.max_candidates_per_iter,
-                max_budget_usd=per_session_cap,
-                pending_path=pending_path,
-                log_dir=sessions_dir,
-                max_thinking_tokens=self.max_thinking_tokens,
-                sandbox=bool(self.sandbox),
-            )
+            proposer_cost_known = True
+            if self.agent_backend == "pi":
+                exit_code, cost, session_id = _run_pi_proposer(
+                    work_dir=work_dir,
+                    iteration=iteration,
+                    model=self.model,
+                    max_candidates=self.max_candidates_per_iter,
+                    max_budget_usd=per_session_cap,
+                    pending_path=pending_path,
+                    log_dir=sessions_dir,
+                    timeout_seconds=self.timeout_seconds,
+                    sandbox=bool(self.sandbox),
+                    pi_command=self.pi_command,
+                )
+            elif self.agent_backend == "codex":
+                exit_code, cost, session_id, proposer_cost_known = _run_codex_proposer(
+                    work_dir=work_dir,
+                    iteration=iteration,
+                    model=self.model,
+                    max_candidates=self.max_candidates_per_iter,
+                    max_budget_usd=per_session_cap,
+                    pending_path=pending_path,
+                    log_dir=sessions_dir,
+                    timeout_seconds=self.timeout_seconds,
+                    sandbox=bool(self.sandbox),
+                    codex_command=self.codex_command,
+                    input_cost_per_million=self.codex_input_cost_per_million,
+                    output_cost_per_million=self.codex_output_cost_per_million,
+                )
+            else:
+                exit_code, cost, session_id = _run_proposer(
+                    work_dir=work_dir,
+                    iteration=iteration,
+                    model=self.model,
+                    effort=self.effort,
+                    max_candidates=self.max_candidates_per_iter,
+                    max_budget_usd=per_session_cap,
+                    pending_path=pending_path,
+                    log_dir=sessions_dir,
+                    max_thinking_tokens=self.max_thinking_tokens,
+                    sandbox=bool(self.sandbox),
+                )
             propose_time = time.time() - propose_start
-            total_proposer_cost += cost
+            if cost is not None:
+                numeric_proposer_cost += cost
+            if cost is None or not proposer_cost_known:
+                total_proposer_cost_known = False
+                total_proposer_cost = None
+            elif total_proposer_cost_known:
+                total_proposer_cost = numeric_proposer_cost
             session_ids.append(session_id)
+            session_label = session_id[:8] if session_id else "<missing>"
 
             _log(
-                f"  {_cyan('proposer')} exit={exit_code} cost=${cost:.3f} "
-                f"time={_elapsed(propose_time)} session={session_id[:8]}"
+                f"  {_cyan('proposer')} exit={exit_code} cost={_format_cost(cost)} "
+                f"time={_elapsed(propose_time)} session={session_label}"
             )
 
             if exit_code != 0:
@@ -899,7 +1162,7 @@ class MetaHarnessEngine:
             f"\n{_bold('[meta-harness] done')} "
             f"reason={stop_reason} iters={iteration} "
             f"best={self._best_score(frontier_path)} "
-            f"evals={budget.used} proposer_cost=${total_proposer_cost:.3f}"
+            f"evals={budget.used} proposer_cost={_format_cost(total_proposer_cost)}"
         )
 
         best_candidate = cast(str, server.best_candidate)
@@ -920,10 +1183,24 @@ class MetaHarnessEngine:
             eval_log=server.eval_log,
             metadata={
                 "adapter_cost": total_proposer_cost,
+                "adapter_cost_known": (
+                    self.agent_backend != "codex" or total_proposer_cost_known
+                ),
+                "adapter_cost_estimate_usd": (
+                    total_proposer_cost
+                    if self.agent_backend != "codex" or total_proposer_cost_known
+                    else None
+                ),
+                "agent_backend": self.agent_backend,
                 "meta_harness": {
                     "iterations_run": iteration,
                     "stop_reason": stop_reason,
                     "proposer_cost": total_proposer_cost,
+                    "proposer_cost_estimate_usd": (
+                        total_proposer_cost
+                        if self.agent_backend != "codex" or total_proposer_cost_known
+                        else None
+                    ),
                     "session_ids": session_ids,
                     "work_dir": str(work_dir),
                     "frontier": self._read_frontier(frontier_path),
@@ -949,11 +1226,12 @@ class MetaHarnessEngine:
             return
         dest.mkdir(parents=True, exist_ok=True)
         work_dir = Path(result.metadata.get("work_dir", ""))
-        session_ids: list[str] = result.metadata.get("session_ids", []) or []
+        session_ids: list[str | None] = result.metadata.get("session_ids", []) or []
         transcripts_dir = dest / "sessions"
         transcripts_dir.mkdir(parents=True, exist_ok=True)
         for sid in session_ids:
-            _copy_session_transcript(work_dir, sid, transcripts_dir)
+            if sid:
+                _copy_session_transcript(work_dir, sid, transcripts_dir)
         if work_dir.exists() and not _is_under(work_dir, dest):
             shutil.copytree(work_dir, dest / "work", dirs_exist_ok=True)
         if self._pending_tempdir is not None:

--- a/src/gepa/oa/ensemble.py
+++ b/src/gepa/oa/ensemble.py
@@ -303,7 +303,13 @@ def optimize_adaptive_sequential(
     # max_evals cap and with only its own adapter_cost; restate both for the
     # whole run now that the scheduler has restored the shared budget.
     result.metadata["budget"] = server.budget.status()
-    result.metadata["total_cost"] = server.total_cost + float(result.metadata.get("adapter_cost", 0.0))
+    raw_adapter_cost = result.metadata.get("adapter_cost")
+    adapter_cost_known = result.metadata.get("adapter_cost_known", raw_adapter_cost is not None)
+    result.metadata["total_cost"] = (
+        server.total_cost + float(raw_adapter_cost)
+        if adapter_cost_known and raw_adapter_cost is not None
+        else None
+    )
 
     baseline_test = _score_test(server, task, task.seed_candidate)
     if result.best_candidate == task.seed_candidate:
@@ -572,7 +578,8 @@ def optimize_adaptive_sequential_with_server(
     no_improvement_slices = 0
     switches = 0
     idle_slices_in_round = 0
-    adapter_cost = 0.0
+    adapter_cost: float | None = 0.0
+    adapter_cost_known = True
 
     try:
         while not server.budget.exhausted:
@@ -606,8 +613,15 @@ def optimize_adaptive_sequential_with_server(
             eval_delta = after_evals - before_evals
             current_stage_evals += eval_delta
             stage_results.append(result)
-            result_cost = float(result.metadata.get("adapter_cost", 0.0))
-            adapter_cost += result_cost
+            raw_result_cost = result.metadata.get("adapter_cost")
+            result_cost_known = result.metadata.get("adapter_cost_known", raw_result_cost is not None)
+            if result_cost_known and raw_result_cost is not None and adapter_cost_known:
+                result_cost = float(raw_result_cost)
+                adapter_cost = (adapter_cost or 0.0) + result_cost
+            else:
+                result_cost = None
+                adapter_cost = None
+                adapter_cost_known = False
 
             improved = result.best_score > before_best + improvement_epsilon
             if best_so_far is None or result.best_score > best_so_far.best_score + improvement_epsilon:
@@ -682,6 +696,8 @@ def optimize_adaptive_sequential_with_server(
     final.metadata["adaptive_schedule"] = schedule
     final.metadata["adaptive_switches"] = switches
     final.metadata["adapter_cost"] = adapter_cost
+    final.metadata["adapter_cost_known"] = adapter_cost_known
+    final.metadata["adapter_cost_estimate_usd"] = adapter_cost if adapter_cost_known else None
     final.metadata["best_stage_score"] = best_so_far.best_score if best_so_far is not None else final.best_score
     final.metadata["best_stage_candidate"] = (
         best_so_far.best_candidate if best_so_far is not None else final.best_candidate

--- a/src/gepa/oa/eval_server.py
+++ b/src/gepa/oa/eval_server.py
@@ -426,7 +426,7 @@ class EvalServer:
         return self.log_progress(avg_score, candidate=candidate)
 
     def log_progress(
-        self, val_score: float, candidate: str | None = None, reflection_cost: float = 0.0
+        self, val_score: float, candidate: str | None = None, reflection_cost: float | None = 0.0
     ) -> dict[str, Any]:
         """Record a progress checkpoint."""
         candidate_id: int | None = None

--- a/src/gepa/oa/sandbox.py
+++ b/src/gepa/oa/sandbox.py
@@ -1,4 +1,4 @@
-"""External bubblewrap jail for ``claude --print`` subprocesses.
+"""External jails for agent subprocesses.
 
 Wraps the whole ``claude`` invocation in our own ``bwrap`` namespace instead
 of relying on Claude Code's built-in ``sandbox.enabled: true`` settings. The
@@ -25,9 +25,9 @@ Network namespace is shared with the host so the agent can reach
 ``localhost:<eval-server-port>`` and ``api.anthropic.com``. ``WebFetch`` /
 ``WebSearch`` are denied at the tool layer via :data:`DENY_WEB_TOOLS`.
 
-macOS fallback: bwrap is Linux-only. On macOS we use Claude Code's
-built-in Seatbelt sandbox via :func:`claude_settings_args`, which the
-caller appends to the ``claude --print`` argv.
+macOS fallback: bwrap is Linux-only. Claude keeps its existing settings-based
+Seatbelt path; Pi uses the native ``sandbox-exec`` profile returned by
+:func:`pi_sandbox_prefix` because Pi has no built-in filesystem sandbox.
 """
 
 from __future__ import annotations
@@ -102,6 +102,8 @@ def bwrap_prefix(
     work_dir: Path | str,
     *,
     extra_writable: list[Path | str] | None = None,
+    include_claude_config: bool = True,
+    include_pi_config: bool = False,
 ) -> list[str]:
     """Return the ``bwrap`` argv prefix that jails everything that follows.
 
@@ -129,12 +131,6 @@ def bwrap_prefix(
         "/tmp",
         *_system_bind_args(),
         *_etc_bind_args(),
-        "--bind",
-        str(home / ".claude"),
-        str(home / ".claude"),
-        "--bind",
-        str(home / ".claude.json"),
-        str(home / ".claude.json"),
         "--ro-bind",
         str(home / ".local"),
         str(home / ".local"),
@@ -153,10 +149,91 @@ def bwrap_prefix(
         "--chdir",
         str(work),
     ]
+    if include_claude_config:
+        # Claude's own session/auth files remain writable for the legacy
+        # Claude engine. Pi must not inherit these paths accidentally.
+        claude_args = [
+            "--bind",
+            str(home / ".claude"),
+            str(home / ".claude"),
+            "--bind",
+            str(home / ".claude.json"),
+            str(home / ".claude.json"),
+        ]
+        insert_at = args.index("--ro-bind")
+        args[insert_at:insert_at] = claude_args
+    if include_pi_config:
+        pi_dir = home / ".pi"
+        if pi_dir.exists() or pi_dir.is_symlink():
+            insert_at = args.index("--ro-bind")
+            args[insert_at:insert_at] = ["--ro-bind", str(pi_dir), str(pi_dir)]
     for p in extra_writable or ():
         resolved = str(Path(p).resolve())
         args.extend(["--bind", resolved, resolved])
     return args
+
+
+def _seatbelt_subpath(path: Path | str) -> str:
+    return str(Path(path).resolve()).replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _build_macos_pi_profile(
+    work_dir: Path | str,
+    *,
+    extra_writable: list[Path | str] | None = None,
+) -> str:
+    """Build a restrictive Seatbelt profile for Pi.
+
+    Pi needs to execute its own runtime and tools, read provider credentials,
+    and reach both the evaluator and model provider. It may write only the
+    temporary workspace and staging directories. The profile intentionally
+    does not grant access to the checkout or arbitrary user files.
+    """
+    work_paths = [_seatbelt_subpath(work_dir), *(_seatbelt_subpath(p) for p in extra_writable or ())]
+    write_paths = [*work_paths, "/tmp", "/private/tmp"]
+    read_paths = [
+        "/bin",
+        "/sbin",
+        "/usr",
+        "/System",
+        "/Library",
+        "/private/var",
+        str(Path.home() / ".pi"),
+        str(Path.home() / ".cache"),
+        str(Path.home() / ".config"),
+        str(Path.home() / ".vite-plus"),
+    ]
+    lines = ["(version 1)", "(deny default)", "(allow process*)", "(allow sysctl-read)", "(allow network*)"]
+    lines.extend(f'(allow file-read* (subpath "{path}"))' for path in read_paths + work_paths)
+    lines.extend(f'(allow file-write* (subpath "{path}"))' for path in write_paths)
+    return "\n".join(lines)
+
+
+def pi_sandbox_prefix(
+    work_dir: Path | str,
+    *,
+    extra_writable: list[Path | str] | None = None,
+) -> list[str]:
+    """Return the mandatory OS sandbox prefix for a Pi subprocess.
+
+    The returned prefix is never empty when this function succeeds. Callers
+    should invoke :func:`preflight_pi_engine` before launching Pi so a missing
+    runtime becomes an actionable configuration error rather than an
+    accidental unsandboxed run.
+    """
+    if _IS_MACOS:
+        sandbox_exec = shutil.which("sandbox-exec") or "/usr/bin/sandbox-exec"
+        if not os.path.exists(sandbox_exec):
+            raise RuntimeError("Pi sandbox requested but macOS sandbox-exec is unavailable")
+        return ["sandbox-exec", "-p", _build_macos_pi_profile(work_dir, extra_writable=extra_writable)]
+    if not shutil.which("bwrap"):
+        raise RuntimeError("Pi sandbox requested but bwrap (bubblewrap) is unavailable on Linux")
+    return bwrap_prefix(
+        work_dir,
+        extra_writable=extra_writable,
+        include_claude_config=False,
+        include_pi_config=True,
+    )
 
 
 def _abs_glob(path: str) -> str:
@@ -298,6 +375,129 @@ def require_claude_cli(engine_name: str) -> None:
     raise RuntimeError(
         f"the {engine_name!r} engine requires the Claude Code CLI (`claude`), which was not found on PATH"
     )
+
+
+def require_pi_cli(engine_name: str, command: str = "pi") -> None:
+    """Abort with an actionable error when the Pi executable is unavailable."""
+    executable = command.split()[0] if command.strip() else command
+    if executable and shutil.which(executable):
+        return
+    print(
+        _boxed_message(
+            "PI CLI NOT FOUND",
+            [
+                f"The {engine_name!r} engine is configured with the Pi backend,",
+                f"but `{command or 'pi'}` is not available on PATH.",
+                "",
+                "Install Pi and authenticate a provider before retrying.",
+                "Set engine_config={'pi_command': '/absolute/path/to/pi'} when",
+                "the executable is not on PATH.",
+            ],
+        ),
+        file=sys.stderr,
+        flush=True,
+    )
+    raise RuntimeError(f"the {engine_name!r} engine requires the Pi CLI ({command!r}), which was not found on PATH")
+
+
+def require_codex_cli(engine_name: str, command: str = "codex") -> None:
+    """Abort with an actionable error when the Codex executable is unavailable."""
+    executable = command.split()[0] if command.strip() else command
+    if executable and shutil.which(executable):
+        return
+    print(
+        _boxed_message(
+            "CODEX CLI NOT FOUND",
+            [
+                f"The {engine_name!r} engine is configured with the Codex backend,",
+                f"but `{command or 'codex'}` is not available on PATH.",
+                "",
+                "Install and authenticate the Codex CLI before retrying.",
+                "Set engine_config={'codex_command': '/absolute/path/to/codex'} when",
+                "the executable is not on PATH.",
+            ],
+        ),
+        file=sys.stderr,
+        flush=True,
+    )
+    raise RuntimeError(f"the {engine_name!r} engine requires the Codex CLI ({command!r}), which was not found on PATH")
+
+
+def preflight_codex_engine(engine_name: str, *, command: str = "codex", sandbox: bool) -> None:
+    """Validate Codex and require its workspace-write sandbox posture."""
+    require_codex_cli(engine_name, command)
+    if not sandbox:
+        raise RuntimeError(
+            f"sandbox=False is unsupported for the {engine_name!r} Codex backend; "
+            "Codex requires --sandbox workspace-write"
+        )
+
+
+def require_pi_sandbox(engine_name: str) -> None:
+    """Abort when Pi's requested OS-level confinement is unavailable."""
+    if _IS_MACOS:
+        if shutil.which("sandbox-exec") or os.path.exists("/usr/bin/sandbox-exec"):
+            return
+        runtime = "sandbox-exec (macOS Seatbelt)"
+    else:
+        if shutil.which("bwrap"):
+            return
+        runtime = "bwrap (bubblewrap)"
+    print(
+        _boxed_message(
+            "PI SANDBOX UNAVAILABLE",
+            [
+                f"sandbox=True for the {engine_name!r} engine requires {runtime}.",
+                "Pi's --tools allowlist is not an OS security boundary, so the",
+                "engine will not silently fall back to an unsandboxed subprocess.",
+                "Install the runtime or explicitly choose a non-sandboxed profile",
+                "only after reviewing the host-access implications.",
+            ],
+        ),
+        file=sys.stderr,
+        flush=True,
+    )
+    raise RuntimeError(f"sandbox=True on the {engine_name!r} engine but {runtime} was not found")
+
+
+def preflight_pi_engine(engine_name: str, *, command: str = "pi", sandbox: bool) -> None:
+    """Validate the Pi CLI and, when requested, its mandatory OS jail."""
+    require_pi_cli(engine_name, command)
+    if sandbox:
+        require_pi_sandbox(engine_name)
+    else:
+        print(
+            _boxed_message(
+                "PI SANDBOX DISABLED",
+                [
+                    f"sandbox=False: the {engine_name!r} Pi subprocess runs with",
+                    "full host process and file permissions; Pi's tool allowlist",
+                    "does not replace OS confinement.",
+                ],
+            ),
+            file=sys.stderr,
+            flush=True,
+        )
+
+
+def preflight_agent_engine(
+    engine_name: str,
+    *,
+    backend: str,
+    command: str = "pi",
+    sandbox: bool,
+) -> None:
+    """Dispatch preflight checks without silently falling back between agents."""
+    if backend == "pi":
+        preflight_pi_engine(engine_name, command=command, sandbox=sandbox)
+        return
+    if backend == "claude":
+        preflight_claude_engine(engine_name, sandbox=sandbox)
+        return
+    if backend == "codex":
+        preflight_codex_engine(engine_name, command=command, sandbox=sandbox)
+        return
+    raise RuntimeError(f"unsupported agent backend {backend!r}; choose 'codex', 'pi', or 'claude'")
 
 
 def require_bwrap(engine_name: str) -> None:

--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -58,6 +58,7 @@ from gepa.gepa_launcher import (
     make_litellm_lm,
     set_log_context,
 )
+from gepa.oa.agent_runner import AgentRunner, AgentRunResult, CodexAgentRunner, PiAgentRunner
 from gepa.oa.budget import BudgetExhausted, BudgetTracker
 from gepa.oa.config import OptimizeAnythingConfig
 from gepa.oa.engine import Engine, Result
@@ -295,8 +296,12 @@ def _run_engine(server: EvalServer, engine: Engine, *, owns_server: bool) -> Res
     result.eval_log = server.eval_log
     result.metadata.setdefault("wall_time", time.time() - start)
     result.metadata["budget"] = server.budget.status()
-    adapter_cost = float(result.metadata.get("adapter_cost", 0.0))
-    result.metadata["total_cost"] = server.total_cost + adapter_cost
+    raw_adapter_cost = result.metadata.get("adapter_cost", 0.0)
+    adapter_cost_known = result.metadata.get("adapter_cost_known", raw_adapter_cost is not None)
+    if adapter_cost_known and raw_adapter_cost is not None:
+        result.metadata["total_cost"] = server.total_cost + float(raw_adapter_cost)
+    else:
+        result.metadata["total_cost"] = None
     result.metadata["progress_log"] = server.progress_log
     result.metadata["engine"] = engine.name
     if server.output_dir is not None:
@@ -392,6 +397,9 @@ def _resolve_output_dir(output_dir: str | Path | None, *, task: Task, engine_nam
 
 __all__ = [
     "AutoResearchEngine",
+    "AgentRunResult",
+    "AgentRunner",
+    "CodexAgentRunner",
     "BestOfNEngine",
     "BudgetExhausted",
     "BudgetTracker",
@@ -413,6 +421,7 @@ __all__ = [
     "MetaHarnessEngine",
     "OptimizationState",
     "OptimizeAnythingConfig",
+    "PiAgentRunner",
     "RefinerConfig",
     "ReflectionConfig",
     "Result",

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from gepa.oa.agent_runner import (
+    CodexAgentRunner,
+    PiAgentRunner,
+    normalize_codex_output,
+    normalize_pi_output,
+)
+
+
+def _python_command(source: str) -> list[str]:
+    return [sys.executable, "-u", "-c", source]
+
+
+def test_normalize_pi_jsonl_usage_cost_and_completion() -> None:
+    raw = "\n".join(
+        [
+            json.dumps({"type": "message_end", "message": {"content": '{"new_texts": {}}'}}),
+            json.dumps({"type": "agent_end", "usage": {"input_tokens": 10, "output_tokens": 4}, "cost_usd": 0.25}),
+        ]
+    )
+    usage, cost, text, completed = normalize_pi_output(raw)
+    assert usage == {"input_tokens": 10.0, "output_tokens": 4.0}
+    assert cost == 0.25
+    assert '"new_texts"' in text
+    assert completed
+
+
+def test_normalize_pi_reads_usage_nested_in_message() -> None:
+    raw = json.dumps(
+        {
+            "type": "message_end",
+            "message": {
+                "usage": {
+                    "input": 7,
+                    "output": 5,
+                    "cost": {"total": 0.33},
+                }
+            },
+        }
+    )
+    usage, cost, _text, _completed = normalize_pi_output(raw)
+    assert usage == {"input_tokens": 7.0, "output_tokens": 5.0}
+    assert cost == 0.33
+
+
+def test_pi_json_runner_uses_read_only_flags_and_normalizes_output(tmp_path: Path) -> None:
+    source = (
+        "import json; "
+        "print(json.dumps({'type':'message_end','message':{'content':'{\\\"answer\\\":\\\"ok\\\"}'}})); "
+        "print(json.dumps({'type':'agent_end','usage':{'input_tokens':2,'output_tokens':3},'cost_usd':0.1}))"
+    )
+    runner = PiAgentRunner(command=_python_command(source), model="provider/model")
+    result = runner.run("prompt", work_dir=tmp_path)
+    assert result.returncode == 0
+    assert result.completed
+    assert result.usage["input_tokens"] == 2.0
+    assert result.cost_usd == 0.1
+    assert "--mode" in result.command
+    assert "json" in result.command
+    for flag in ("--no-session", "--no-context-files", "--no-extensions", "--no-skills", "--no-approve"):
+        assert flag in result.command
+    assert result.command[result.command.index("--tools") + 1] == "read,grep,find,ls,bash,edit,write"
+
+
+def test_pi_rpc_runner_reuses_one_process_for_ralph_continuations(tmp_path: Path) -> None:
+    source = (
+        "import json,sys\n"
+        "for line in sys.stdin:\n"
+        "    if line.strip():\n"
+        "        data=json.loads(line)\n"
+        "        print(json.dumps({'type':'message_end','message':{'content':data['message']}}))\n"
+        "        print(json.dumps({'type':'agent_end','usage':{'input_tokens':1,'output_tokens':1},'cost_usd':0.01}))\n"
+        "        sys.stdout.flush()\n"
+    )
+    runner = PiAgentRunner(command=_python_command(source), persistent=True, model="provider/model")
+    first = runner.run("first", work_dir=tmp_path)
+    second = runner.run("second", work_dir=tmp_path)
+    assert first.completed and second.completed
+    assert first.session_id == second.session_id
+    assert first.final_text == "first"
+    assert second.final_text == "second"
+    assert first.cost_usd == second.cost_usd == 0.01
+    runner.close()
+
+
+def test_pi_runner_terminates_timed_out_process_group(tmp_path: Path) -> None:
+    source = "import time; time.sleep(30)"
+    runner = PiAgentRunner(command=_python_command(source))
+    result = runner.run("prompt", work_dir=tmp_path, timeout_seconds=0.05)
+    assert result.timed_out
+    assert "PI_TIMEOUT" in result.stderr
+    assert result.returncode != 0
+
+
+def _codex_jsonl_source() -> str:
+    return (
+        "import json,sys\n"
+        "args=sys.argv[1:]\n"
+        "resuming='resume' in args\n"
+        "print(json.dumps({'type':'thread.started','thread_id':'thread-123'}))\n"
+        "print(json.dumps({'type':'item.completed','item':{'type':'agent_message','text':'codex answer'}}))\n"
+        "print(json.dumps({'type':'turn.completed','usage':{'input_tokens':100 if not resuming else 20,'output_tokens':50}}))\n"
+    )
+
+
+def test_normalize_codex_jsonl_usage_cost_and_completion() -> None:
+    raw = "\n".join(
+        [
+            json.dumps({"type": "thread.started", "thread_id": "thread-123"}),
+            json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "answer"}}),
+            json.dumps(
+                {
+                    "type": "turn.completed",
+                    "usage": {"input_tokens": 100, "cached_input_tokens": 12, "output_tokens": 50},
+                }
+            ),
+        ]
+    )
+    usage, cost, text, session_id, completed, cost_known = normalize_codex_output(
+        raw,
+        input_cost_per_million=2.0,
+        output_cost_per_million=4.0,
+    )
+    assert usage == {"input_tokens": 100, "cache_read_tokens": 12, "output_tokens": 50}
+    assert cost == 0.0004
+    assert text == "answer"
+    assert session_id == "thread-123"
+    assert completed
+    assert cost_known
+
+
+def test_normalize_codex_usage_only_marks_cost_unknown() -> None:
+    raw = json.dumps(
+        {
+            "type": "turn.completed",
+            "thread_id": "thread-123",
+            "usage": {"input_tokens": 100, "output_tokens": 50},
+        }
+    )
+    usage, cost, _text, _session_id, completed, cost_known = normalize_codex_output(raw)
+    assert usage == {"input_tokens": 100, "output_tokens": 50}
+    assert cost is None
+    assert completed
+    assert not cost_known
+
+
+def test_codex_runner_uses_workspace_write_and_resumes_thread(tmp_path: Path) -> None:
+    runner = CodexAgentRunner(command=_python_command(_codex_jsonl_source()), persistent=True)
+    first = runner.run("first", work_dir=tmp_path)
+    second = runner.run("second", work_dir=tmp_path)
+
+    assert first.returncode == second.returncode == 0
+    assert first.completed and second.completed
+    assert first.session_id == second.session_id == "thread-123"
+    assert first.final_text == second.final_text == "codex answer"
+    assert first.usage["input_tokens"] == 100
+    assert second.usage["input_tokens"] == 20
+    assert "exec" in first.command
+    assert "--sandbox" in first.command
+    assert first.command[first.command.index("--sandbox") + 1] == "workspace-write"
+    assert "resume" not in first.command
+    assert "resume" in second.command
+    assert "--config" in first.command
+    assert 'approval_policy="never"' in first.command
+    assert "sandbox_workspace_write.network_access=true" in first.command
+    assert second.command[second.command.index("resume") + 1] == "--config"
+
+
+def test_codex_runner_one_shot_is_ephemeral(tmp_path: Path) -> None:
+    runner = CodexAgentRunner(command=_python_command(_codex_jsonl_source()), persistent=False)
+    result = runner.run("prompt", work_dir=tmp_path)
+    assert result.returncode == 0
+    assert "--ephemeral" in result.command
+    assert "--sandbox" in result.command
+
+
+def test_codex_runner_rejects_unsandboxed_mode_and_uncapped_missing_pricing() -> None:
+    with pytest.raises(ValueError, match="workspace-write"):
+        CodexAgentRunner(sandbox=False)
+    runner = CodexAgentRunner(command=["does-not-exist"])
+    with pytest.raises(ValueError, match="requires both"):
+        runner.run("prompt", work_dir=Path.cwd(), max_budget_usd=1.0)
+    with pytest.raises(ValueError, match="both input_cost_per_million"):
+        CodexAgentRunner(command=["does-not-exist"], input_cost_per_million=1.0)
+
+
+def test_codex_runner_rejects_malformed_output_and_missing_thread_id(tmp_path: Path) -> None:
+    malformed = CodexAgentRunner(command=_python_command("print('{not-json')"))
+    malformed_result = malformed.run("prompt", work_dir=tmp_path)
+    assert malformed_result.returncode != 0
+    assert "CODEX_MALFORMED_OUTPUT" in malformed_result.stderr
+
+    no_thread_source = (
+        "import json; print(json.dumps({'type':'turn.completed','usage':{'input_tokens':1,'output_tokens':1}}))"
+    )
+    no_thread = CodexAgentRunner(command=_python_command(no_thread_source))
+    no_thread_result = no_thread.run("prompt", work_dir=tmp_path)
+    assert no_thread_result.returncode != 0
+    assert "CODEX_MISSING_SESSION_ID" in no_thread_result.stderr
+
+
+def test_codex_runner_detects_budget_overrun_after_process_exit(tmp_path: Path) -> None:
+    source = (
+        "import json; "
+        "print(json.dumps({'type':'thread.started','thread_id':'thread-123'})); "
+        "print(json.dumps({'type':'turn.completed','usage':{'input_tokens':1000,'output_tokens':1000}}))"
+    )
+    runner = CodexAgentRunner(
+        command=_python_command(source),
+        input_cost_per_million=1000.0,
+        output_cost_per_million=1000.0,
+    )
+    result = runner.run("prompt", work_dir=tmp_path, max_budget_usd=0.001)
+    assert result.returncode != 0
+    assert "CODEX_TOKEN_BUDGET" in result.stderr
+
+
+def test_codex_runner_terminates_timed_out_process_group(tmp_path: Path) -> None:
+    runner = CodexAgentRunner(command=_python_command("import time; time.sleep(30)"))
+    result = runner.run("prompt", work_dir=tmp_path, timeout_seconds=0.05)
+    assert result.timed_out
+    assert result.returncode != 0
+    assert "CODEX_TIMEOUT" in result.stderr

--- a/tests/test_pi_engines.py
+++ b/tests/test_pi_engines.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import ClassVar
+
+import pytest
+
+from gepa.oa.agent_runner import AgentRunResult
+from gepa.oa.budget import BudgetTracker
+from gepa.oa.config import OptimizeAnythingConfig
+from gepa.oa.engines.autoresearch import AutoResearchEngine
+from gepa.oa.engines.meta_harness import _run_codex_proposer, _run_pi_proposer, _run_proposer
+from gepa.oa.task import Task
+
+
+class _FakePiRunner:
+    instances: ClassVar[list[_FakePiRunner]] = []
+
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self.calls: list[str] = []
+        self.closed = False
+        self.session_id = f"session-{len(self.instances)}"
+        self.instances.append(self)
+
+    def run(self, prompt: str, *, work_dir: Path, **_kwargs: object) -> AgentRunResult:
+        self.calls.append(prompt)
+        if self.kwargs["persistent"]:
+            (work_dir / "best_candidate.txt").write_text("pi candidate")
+        event = {
+            "type": "agent_end",
+            "usage": {"input_tokens": 3, "output_tokens": 4},
+            "cost_usd": 0.2 if len(self.calls) == 1 else 0.0005,
+        }
+        return AgentRunResult(
+            command=("pi", "--mode", "rpc" if self.kwargs["persistent"] else "json"),
+            returncode=0,
+            stdout=json.dumps(event) + "\n",
+            session_id=self.session_id,
+            usage=event["usage"],
+            cost_usd=event["cost_usd"],
+            completed=True,
+        )
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeCodexRunner:
+    instances: ClassVar[list[_FakeCodexRunner]] = []
+
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self.calls: list[str] = []
+        self.closed = False
+        self.session_id = f"codex-thread-{len(self.instances)}"
+        self.instances.append(self)
+
+    def run(self, prompt: str, *, work_dir: Path, **_kwargs: object) -> AgentRunResult:
+        self.calls.append(prompt)
+        if self.kwargs["persistent"]:
+            (work_dir / "best_candidate.txt").write_text("codex candidate")
+        input_tokens = 100_000 if len(self.calls) == 1 else 250
+        event = {
+            "type": "turn.completed",
+            "thread_id": self.session_id,
+            "usage": {"input_tokens": input_tokens, "output_tokens": 0},
+        }
+        return AgentRunResult(
+            command=("codex", "exec"),
+            returncode=0,
+            stdout=json.dumps(event) + "\n",
+            session_id=self.session_id,
+            usage=event["usage"],
+            cost_usd=0.2 if len(self.calls) == 1 else 0.0005,
+            cost_known=True,
+            completed=True,
+        )
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _UnknownCostCodexRunner:
+    instances: ClassVar[list[_UnknownCostCodexRunner]] = []
+
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self.calls: list[str] = []
+        self.closed = False
+        self.session_id = f"unknown-cost-thread-{len(self.instances)}"
+        self.instances.append(self)
+
+    def run(self, prompt: str, *, work_dir: Path, **_kwargs: object) -> AgentRunResult:
+        self.calls.append(prompt)
+        if self.kwargs["persistent"]:
+            (work_dir / "best_candidate.txt").write_text("codex candidate")
+        event = {
+            "type": "turn.completed",
+            "thread_id": self.session_id,
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+        return AgentRunResult(
+            command=("codex", "exec"),
+            returncode=0 if len(self.calls) == 1 else 1,
+            stdout=json.dumps(event) + "\n",
+            stderr="" if len(self.calls) == 1 else "simulated resume failure",
+            session_id=self.session_id,
+            usage=event["usage"],
+            cost_usd=None,
+            cost_known=False,
+            completed=True,
+        )
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FailingCodexRunner:
+    instances: ClassVar[list[_FailingCodexRunner]] = []
+
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self.closed = False
+        self.instances.append(self)
+
+    def run(self, _prompt: str, *, work_dir: Path, **_kwargs: object) -> AgentRunResult:
+        diagnostics = work_dir / ".codex-runner"
+        diagnostics.mkdir(parents=True, exist_ok=True)
+        (diagnostics / "stderr.log").write_text("retained Codex diagnostics")
+        return AgentRunResult(
+            command=("codex", "exec"),
+            returncode=1,
+            stdout="{malformed jsonl\n",
+            stderr="CODEX_TIMEOUT: simulated timeout",
+            session_id=None,
+            usage={},
+            cost_usd=None,
+            cost_known=False,
+            timed_out=True,
+            completed=False,
+        )
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_autoresearch_pi_keeps_one_runner_for_ralph(monkeypatch, tmp_path: Path) -> None:
+    _FakePiRunner.instances = []
+    monkeypatch.setattr("gepa.oa.engines.autoresearch.PiAgentRunner", _FakePiRunner)
+    monkeypatch.setattr("gepa.oa.engines.autoresearch.preflight_agent_engine", lambda *a, **k: None)
+
+    class Server:
+        budget = BudgetTracker(max_evals=10)
+        url = "http://127.0.0.1:9"
+        best_score = 0.0
+        eval_log: ClassVar[list[object]] = []
+
+    engine = AutoResearchEngine(
+        OptimizeAnythingConfig(
+            engine="autoresearch",
+            sandbox=False,
+            run_dir=str(tmp_path),
+            max_token_cost=1.0,
+            engine_config={
+                "agent_backend": "pi",
+                "model": "provider/model",
+                "ralph": True,
+            },
+        )
+    )
+    result = engine.run(Task(name="smoke", seed_candidate="seed"), Server())
+
+    assert len(_FakePiRunner.instances) == 1
+    runner = _FakePiRunner.instances[0]
+    assert runner.kwargs["persistent"] is True
+    assert len(runner.calls) == 2
+    assert runner.calls[1].startswith("Continue iterating")
+    assert result.metadata["agent_backend"] == "pi"
+    assert result.metadata["ralph_iterations"] == 2
+    assert runner.closed
+
+
+def test_meta_harness_pi_starts_a_fresh_runner_per_iteration(tmp_path: Path, monkeypatch) -> None:
+    _FakePiRunner.instances = []
+    monkeypatch.setattr("gepa.oa.engines.meta_harness.PiAgentRunner", _FakePiRunner)
+    monkeypatch.setattr("gepa.oa.engines.meta_harness.pi_sandbox_prefix", lambda path: [])
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    log_dir = tmp_path / "logs"
+
+    first = _run_pi_proposer(
+        work_dir=work_dir,
+        iteration=1,
+        model="provider/model",
+        max_candidates=2,
+        max_budget_usd=1.0,
+        pending_path=work_dir / "state" / "pending_eval_iter1.json",
+        log_dir=log_dir,
+        sandbox=False,
+        pi_command="pi",
+    )
+    second = _run_pi_proposer(
+        work_dir=work_dir,
+        iteration=2,
+        model="provider/model",
+        max_candidates=2,
+        max_budget_usd=1.0,
+        pending_path=work_dir / "state" / "pending_eval_iter2.json",
+        log_dir=log_dir,
+        sandbox=False,
+        pi_command="pi",
+    )
+
+    assert first[0] == second[0] == 0
+    assert len(_FakePiRunner.instances) == 2
+    assert all(instance.kwargs["persistent"] is False for instance in _FakePiRunner.instances)
+    assert _FakePiRunner.instances[0].session_id != _FakePiRunner.instances[1].session_id
+    assert all(instance.closed for instance in _FakePiRunner.instances)
+    assert "claude" not in (log_dir / "iter1_meta.json").read_text().lower()
+
+
+def test_autoresearch_codex_reuses_one_thread_for_ralph(monkeypatch, tmp_path: Path) -> None:
+    _FakeCodexRunner.instances = []
+    monkeypatch.setattr("gepa.oa.engines.autoresearch.CodexAgentRunner", _FakeCodexRunner)
+    monkeypatch.setattr("gepa.oa.engines.autoresearch.preflight_agent_engine", lambda *a, **k: None)
+
+    class Server:
+        budget = BudgetTracker(max_evals=10)
+        url = "http://127.0.0.1:9"
+        best_score = 0.0
+        eval_log: ClassVar[list[object]] = []
+
+    engine = AutoResearchEngine(
+        OptimizeAnythingConfig(
+            engine="autoresearch",
+            sandbox=False,
+            run_dir=str(tmp_path),
+            max_token_cost=1.0,
+            engine_config={
+                "agent_backend": "codex",
+                "ralph": True,
+                "codex_input_cost_per_million": 2.0,
+                "codex_output_cost_per_million": 2.0,
+            },
+        )
+    )
+    result = engine.run(Task(name="smoke", seed_candidate="seed"), Server())
+
+    assert len(_FakeCodexRunner.instances) == 1
+    runner = _FakeCodexRunner.instances[0]
+    assert runner.kwargs["persistent"] is True
+    assert len(runner.calls) == 2
+    assert runner.calls[1].startswith("Continue iterating")
+    assert result.metadata["agent_backend"] == "codex"
+    assert result.metadata["runner_session_id"] == runner.session_id
+    assert result.metadata["adapter_cost_known"]
+    assert runner.closed
+
+
+def test_meta_harness_codex_starts_a_fresh_ephemeral_runner_per_iteration(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _FakeCodexRunner.instances = []
+    monkeypatch.setattr("gepa.oa.engines.meta_harness.CodexAgentRunner", _FakeCodexRunner)
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    log_dir = tmp_path / "logs"
+
+    first = _run_codex_proposer(
+        work_dir=work_dir,
+        iteration=1,
+        model=None,
+        max_candidates=2,
+        max_budget_usd=1.0,
+        pending_path=work_dir / "state" / "pending_eval_iter1.json",
+        log_dir=log_dir,
+        sandbox=True,
+        codex_command="codex",
+        input_cost_per_million=2.0,
+        output_cost_per_million=2.0,
+    )
+    second = _run_codex_proposer(
+        work_dir=work_dir,
+        iteration=2,
+        model=None,
+        max_candidates=2,
+        max_budget_usd=1.0,
+        pending_path=work_dir / "state" / "pending_eval_iter2.json",
+        log_dir=log_dir,
+        sandbox=True,
+        codex_command="codex",
+        input_cost_per_million=2.0,
+        output_cost_per_million=2.0,
+    )
+
+    assert first[0] == second[0] == 0
+    assert first[3] and second[3]
+    assert len(_FakeCodexRunner.instances) == 2
+    assert all(instance.kwargs["persistent"] is False for instance in _FakeCodexRunner.instances)
+    assert _FakeCodexRunner.instances[0].session_id != _FakeCodexRunner.instances[1].session_id
+    assert all(instance.closed for instance in _FakeCodexRunner.instances)
+    metadata = json.loads((log_dir / "iter1_meta.json").read_text())
+    assert metadata["agent_backend"] == "codex"
+    assert metadata["cmd"] == ["codex", "exec"]
+    assert metadata["cost_known"] is True
+
+
+def test_codex_engine_requires_complete_pricing_when_capped() -> None:
+    with pytest.raises(ValueError, match="requires both"):
+        AutoResearchEngine(
+            OptimizeAnythingConfig(
+                engine="autoresearch",
+                max_token_cost=1.0,
+                sandbox=False,
+                engine_config={"agent_backend": "codex"},
+            )
+        )
+
+
+def test_autoresearch_uncapped_codex_preserves_unknown_cost_and_continues_ralph(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _UnknownCostCodexRunner.instances = []
+    monkeypatch.setattr("gepa.oa.engines.autoresearch.CodexAgentRunner", _UnknownCostCodexRunner)
+    monkeypatch.setattr("gepa.oa.engines.autoresearch.preflight_agent_engine", lambda *a, **k: None)
+
+    class Server:
+        budget = BudgetTracker(max_evals=10)
+        url = "http://127.0.0.1:9"
+        best_score = 0.0
+        eval_log: ClassVar[list[object]] = []
+
+    engine = AutoResearchEngine(
+        OptimizeAnythingConfig(
+            engine="autoresearch",
+            sandbox=False,
+            run_dir=str(tmp_path),
+            max_token_cost=None,
+            engine_config={"agent_backend": "codex", "ralph": True},
+        )
+    )
+    result = engine.run(Task(name="smoke", seed_candidate="seed"), Server())
+
+    runner = _UnknownCostCodexRunner.instances[0]
+    assert len(runner.calls) == 2
+    assert result.metadata["adapter_cost"] is None
+    assert result.metadata["adapter_cost_known"] is False
+    assert result.metadata["adapter_cost_estimate_usd"] is None
+    assert result.metadata["invocations"][0]["cost"] is None
+    assert result.metadata["ralph_iterations"] == 1
+
+
+def test_autoresearch_persists_codex_failure_artifacts_before_raising(monkeypatch, tmp_path: Path) -> None:
+    _FailingCodexRunner.instances = []
+    monkeypatch.setattr("gepa.oa.engines.autoresearch.CodexAgentRunner", _FailingCodexRunner)
+    monkeypatch.setattr("gepa.oa.engines.autoresearch.preflight_agent_engine", lambda *a, **k: None)
+    output_dir = tmp_path / "output"
+
+    class Server:
+        budget = BudgetTracker(max_evals=10)
+        url = "http://127.0.0.1:9"
+        best_score = 0.0
+        eval_log: ClassVar[list[object]] = []
+
+    Server.output_dir = output_dir
+
+    engine = AutoResearchEngine(
+        OptimizeAnythingConfig(
+            engine="autoresearch",
+            sandbox=True,
+            run_dir=str(tmp_path / "run"),
+            max_token_cost=None,
+            engine_config={"agent_backend": "codex", "ralph": False},
+        )
+    )
+    with pytest.raises(RuntimeError, match="diagnostics="):
+        engine.run(Task(name="smoke", seed_candidate="seed"), Server())
+
+    retained = output_dir / "work" / ".codex-runner" / "stderr.log"
+    assert retained.read_text() == "retained Codex diagnostics"
+    assert _FailingCodexRunner.instances[0].closed
+
+
+def test_meta_harness_uncapped_codex_logs_unknown_cost(tmp_path: Path, monkeypatch) -> None:
+    _UnknownCostCodexRunner.instances = []
+    monkeypatch.setattr("gepa.oa.engines.meta_harness.CodexAgentRunner", _UnknownCostCodexRunner)
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    log_dir = tmp_path / "logs"
+
+    exit_code, cost, session_id, cost_known = _run_codex_proposer(
+        work_dir=work_dir,
+        iteration=1,
+        model=None,
+        max_candidates=2,
+        max_budget_usd=None,
+        pending_path=work_dir / "state" / "pending_eval_iter1.json",
+        log_dir=log_dir,
+        sandbox=True,
+        codex_command="codex",
+        input_cost_per_million=None,
+        output_cost_per_million=None,
+    )
+
+    assert exit_code == 0
+    assert cost is None
+    assert session_id == _UnknownCostCodexRunner.instances[0].session_id
+    assert cost_known is False
+    metadata = json.loads((log_dir / "iter1_meta.json").read_text())
+    assert metadata["cost_usd"] is None
+    assert metadata["cost_estimate_usd"] is None
+    assert metadata["cost_known"] is False
+
+
+def test_claude_command_omits_model_when_unset(monkeypatch, tmp_path: Path) -> None:
+    captured: list[list[str]] = []
+    monkeypatch.setattr(
+        "gepa.oa.engines.autoresearch._start_claude_process",
+        lambda command, *_args, **_kwargs: captured.append(command)
+        or SimpleNamespace(proc=SimpleNamespace(poll=lambda: 0, returncode=0)),
+    )
+    monkeypatch.setattr(
+        "gepa.oa.engines.autoresearch._collect_claude_output",
+        lambda _running: ('{"total_cost_usd": 0.1}', ""),
+    )
+    engine = AutoResearchEngine(
+        OptimizeAnythingConfig(
+            engine="autoresearch",
+            sandbox=False,
+            engine_config={"model": None, "ralph": False},
+        )
+    )
+
+    engine._run_claude(
+        work_dir=tmp_path,
+        session_id="session",
+        prompt="prompt",
+        budget=BudgetTracker(max_evals=1),
+        adapter_cost=0.0,
+        resume=False,
+        env={},
+    )
+
+    assert captured
+    assert "--model" not in captured[0]
+
+
+def test_meta_harness_claude_command_omits_model_when_unset(tmp_path: Path, monkeypatch) -> None:
+    captured: list[list[str]] = []
+
+    def fake_run(command: list[str], **_kwargs: object) -> SimpleNamespace:
+        captured.append(command)
+        return SimpleNamespace(returncode=0, stdout=json.dumps({"total_cost_usd": 0.1}), stderr="")
+
+    monkeypatch.setattr("gepa.oa.engines.meta_harness.subprocess.run", fake_run)
+    _run_proposer(
+        work_dir=tmp_path,
+        iteration=1,
+        model=None,
+        effort=None,
+        max_candidates=1,
+        max_budget_usd=None,
+        pending_path=tmp_path / "state" / "pending.json",
+        log_dir=tmp_path / "logs",
+        sandbox=False,
+    )
+
+    assert captured
+    assert "--model" not in captured[0]


### PR DESCRIPTION
## Summary

- Add first-class Codex runners with workspace-write sandboxing and persistent/resumable AutoResearch sessions.
- Add fresh ephemeral Meta-Harness sessions, JSONL normalization, usage/cost metadata, and strict pricing validation for capped runs.
- Preserve Pi and Claude paths, diagnostics, unknown-cost reporting, and regression coverage.

## Validation

- `uv run pytest` — 689 passed, 4 skipped
- Ruff and Pyright clean
- `git diff --check` clean

The Omni plugin integration is in the companion Qredence/gepa-omni PR.