### PR TITLE
fix(optimize_anything): honor legacy EngineConfig parallelism in the eval server

### DIFF
--- a/src/gepa/optimize_anything.py
+++ b/src/gepa/optimize_anything.py
@@ -27,6 +27,7 @@ Example:
 from __future__ import annotations
 
 import dataclasses
+import os
 import time
 import uuid
 import warnings
@@ -227,14 +228,25 @@ def _from_legacy_config(config: Any) -> OptimizeAnythingConfig:
     The whole config rides through ``engine_config`` field-for-field (so nested
     configs and callbacks survive as objects); the launcher's eval budget
     becomes ``max_evals`` — ``None`` stays unbounded, as in the launcher.
+
+    The launcher's parallelism settings size the eval server, which gates all
+    evaluation: ``parallel=False`` maps to ``max_concurrency=1``, an explicit
+    ``max_workers`` maps to itself, and ``max_workers=None`` falls back to
+    ``os.cpu_count() or 32`` (the same fallback as ``EngineConfig.max_workers``'s
+    default factory).
     """
     from gepa.gepa_launcher import GEPAConfig
 
     if not isinstance(config, GEPAConfig):
         raise TypeError(f"config must be an OptimizeAnythingConfig or GEPAConfig, got {type(config).__name__}")
+    if not config.engine.parallel:
+        max_concurrency = 1
+    else:
+        max_concurrency = config.engine.max_workers or (os.cpu_count() or 32)
     return OptimizeAnythingConfig(
         engine="gepa",
         max_evals=config.engine.max_metric_calls,
+        max_concurrency=max_concurrency,
         engine_config={f.name: getattr(config, f.name) for f in dataclasses.fields(config)},
     )
 

--- a/tests/test_optimize_anything_gepa_config.py
+++ b/tests/test_optimize_anything_gepa_config.py
@@ -101,6 +101,34 @@ def test_legacy_gepa_config_returns_gepa_result_even_when_budget_dies_early():
     assert result.val_aggregate_scores[result.best_idx] == max(result.val_aggregate_scores)
 
 
+def test_legacy_max_workers_sizes_the_eval_server():
+    """``EngineConfig.max_workers`` becomes the eval server's
+    ``max_concurrency``; without the mapping every legacy run is silently
+    gated at the server default regardless of the requested width."""
+    from gepa.optimize_anything import EngineConfig, GEPAConfig, _from_legacy_config
+
+    converted = _from_legacy_config(GEPAConfig(engine=EngineConfig(max_workers=512)))
+    assert converted.max_concurrency == 512
+
+
+def test_legacy_parallel_false_maps_to_sequential_eval_server():
+    """``parallel=False`` meant sequential evaluation in the launcher."""
+    from gepa.optimize_anything import EngineConfig, GEPAConfig, _from_legacy_config
+
+    converted = _from_legacy_config(GEPAConfig(engine=EngineConfig(parallel=False, max_workers=512)))
+    assert converted.max_concurrency == 1
+
+
+def test_legacy_max_workers_none_falls_back_to_cpu_count():
+    """``max_workers=None`` mirrors the field's own default factory."""
+    import os
+
+    from gepa.optimize_anything import EngineConfig, GEPAConfig, _from_legacy_config
+
+    converted = _from_legacy_config(GEPAConfig(engine=EngineConfig(max_workers=None)))
+    assert converted.max_concurrency == (os.cpu_count() or 32)
+
+
 def test_legacy_gepa_config_rejects_test_set():
     """``test_set`` is a new-API feature; combining it with a legacy
     ``GEPAConfig`` fails fast instead of silently dropping the test scores."""


### PR DESCRIPTION
## Problem

`optimize_anything` with a legacy `GEPAConfig` converts it via `_from_legacy_config`, which forwards the whole config through `engine_config` and maps the eval budget — but never maps `EngineConfig.max_workers` onto `OptimizeAnythingConfig.max_concurrency`. Since all evaluation now flows through the `EvalServer`, whose width is `max_concurrency` (default 8), every legacy-config run is silently capped at 8 concurrent evaluations no matter what width was requested. `max_workers=512` still rides along inside `engine_config`, but the server's gate binds first, so it has no effect.

There is no error or warning — runs are correct, just up to an order of magnitude slower than intended. Observed symptom: a HoVer evaluation pass that takes ~65 s at width 64 takes ~5 minutes through the legacy path.

## Fix

Map the launcher's parallelism settings onto the eval server in `_from_legacy_config`:

- `parallel=False` → `max_concurrency=1` (the launcher's sequential mode)
- explicit `max_workers=N` → `max_concurrency=N`
- `max_workers=None` → `os.cpu_count() or 32`, matching the field's own default factory

This restores the legacy contract that parallel evaluation defaults to CPU-count width.

## Tests

Three new tests in `tests/test_optimize_anything_gepa_config.py` covering each mapping case. `uv run pytest tests/test_optimize_anything_gepa_config.py tests/test_optimize_anything_eval_server.py tests/test_optimize.py` passes (17 tests); ruff and pyright clean on the touched files.