### PR TITLE
fix(cache): namespace valset evaluations so they cannot reuse trainset rollouts

### DIFF
--- a/.claude/skills/gepa-optimize-anything/SKILL.md
+++ b/.claude/skills/gepa-optimize-anything/SKILL.md
@@ -157,7 +157,8 @@ low** — raise it and rerun.
 - If you **opt in** to evaluation caching (`engine_config={"engine": {"cache_evaluation": True}}` on
   the gepa backend — it is **off by default**), be aware `max_evals` then counts only cache *misses*:
   a converged search can keep proposing cache-hitting candidates without consuming eval budget, so
-  `stop_at_score`/`max_token_cost` become mandatory, not optional.
+  `stop_at_score`/`max_token_cost` become mandatory, not optional. A distinct `valset` is cached
+  separately from the trainset; `valset=None` still reuses minibatch rollouts.
 
 ## Minimal working example
 The example optimizes a system prompt for concreteness, but the **shape is identical** for any

--- a/.claude/skills/gepa-optimize-anything/references/api.md
+++ b/.claude/skills/gepa-optimize-anything/references/api.md
@@ -106,7 +106,9 @@ engine_config={
         "frontier_type": "hybrid",       # "instance" | "objective" | "hybrid" (default) | "cartesian"
         "candidate_selection_strategy": "pareto",      # | "current_best" | "epsilon_greedy" | "top_k_pareto"
         "acceptance_criterion": "strict_improvement",  # | "improvement_or_equal"
-        "cache_evaluation": False,       # opt-in: cache identical (candidate, example) evals
+        "cache_evaluation": False,       # opt-in: cache (candidate, split, example) evals.
+                                         # Distinct valset is isolated from trainset ids.
+                                         # valset=None still shares minibatch rollouts.
         "capture_stdio": False,          # opt-in: route evaluator print() output into feedback
         "raise_on_exception": True,      # False → evaluator exceptions become score 0 + info["error"]
         # "write_agent_state": True,     # agent-readable iterations/ + pareto/ tree under run_dir

--- a/.claude/skills/gepa-optimize-anything/references/gotchas.md
+++ b/.claude/skills/gepa-optimize-anything/references/gotchas.md
@@ -61,6 +61,9 @@ work:
   emitting cache-hitting candidates without consuming eval budget and can spin until your process
   times out, still spending proposer-LLM tokens. With caching on, `stop_at_score` and/or
   `max_token_cost` (plus a wall-clock `timeout` on the launched process) are mandatory.
+  A distinct `valset` is a separate cache namespace from the trainset (list-position ids would
+  otherwise collide). `valset=None` still shares cached rollouts with minibatches. Resuming a
+  `run_dir` whose cache predates that namespacing drops the old entries.
 Agentic backends also spend LLM tokens between evals — cap them with `max_token_cost`
 (enforced as `--max-budget-usd`).
 

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -190,7 +190,14 @@ def optimize(
     - write_agent_state: When True, write an agent-readable directory tree under `run_dir` alongside `gepa_state.bin` (`iterations/<id>/` + `pareto/`). Each loop iteration gets its own subdir (accepted or rejected) with `meta.json`, `components/`, `trace.json` (before/after scores + trajectories); accepted ones also get `val_scores.json`, `outputs/`, `trajectories/`. Seed is `iterations/seed/`. Default False; turn on when an agent (e.g. Claude Code) will read the run directory.
 
     # Evaluation caching
-    - cache_evaluation: Whether to cache the (score, output, objective_scores) of (candidate, example) pairs. If True and a cache entry exists, GEPA will skip the fitness evaluation and use the cached results. This helps avoid redundant evaluations and saves metric calls. Defaults to False.
+    - cache_evaluation: Whether to cache the (score, output, objective_scores) of
+      (candidate, split, example) triples. If True and a cache entry exists, GEPA skips the
+      fitness evaluation. Trainset minibatches and valset evaluation share the cache only when
+      they use the same DataLoader instance (valset=None, or the same dataset object passed as
+      both trainset and valset). A distinct valset is a separate namespace, so held-out scores
+      cannot be served from trainset rollouts at the same list index. Defaults to False.
+      Resuming a run_dir whose cache was written before this namespacing existed drops those
+      entries; already-recorded valset scores in the pickled state are left as they are.
 
     # Reproducibility
     - seed: The seed to use for the random number generator.

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -18,7 +18,7 @@ from gepa.core.adapter import DataInst, GEPAAdapter, ProposalFn, RolloutOutput, 
 from gepa.core.data_loader import DataId, DataLoader, ensure_loader
 from gepa.core.engine import GEPAEngine
 from gepa.core.result import GEPAResult
-from gepa.core.state import TRAINSET_CACHE_SPLIT, VALSET_CACHE_SPLIT, EvaluationCache, FrontierType
+from gepa.core.state import EvaluationCache, FrontierType
 from gepa.logging.experiment_tracker import create_experiment_tracker
 from gepa.logging.logger import Logger, LoggerProtocol, StdOutLogger
 from gepa.proposer.merge import MergeProposer
@@ -221,9 +221,6 @@ def optimize(
     # Normalize datasets to DataLoader instances
     train_loader = ensure_loader(trainset)
     val_loader = train_loader if valset is None or valset is trainset else ensure_loader(valset)
-    # Both loaders number their examples from zero, so a distinct valset needs its own cache
-    # namespace; when it *is* the trainset the ids agree and results are shared as before.
-    valset_cache_split = TRAINSET_CACHE_SPLIT if val_loader is train_loader else VALSET_CACHE_SPLIT
 
     # Validate that only one custom proposal method is provided
     adapter_has_propose = hasattr(active_adapter, "propose_new_texts") and active_adapter.propose_new_texts is not None
@@ -460,7 +457,6 @@ def optimize(
             rng=rng,
             val_overlap_floor=merge_val_overlap_floor,
             callbacks=callbacks,
-            valset_cache_split=valset_cache_split,
         )
 
     engine = GEPAEngine(
@@ -486,7 +482,6 @@ def optimize(
         use_cloudpickle=use_cloudpickle,
         write_agent_state=write_agent_state,
         evaluation_cache=evaluation_cache,
-        valset_cache_split=valset_cache_split,
     )
 
     with experiment_tracker:

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -18,7 +18,7 @@ from gepa.core.adapter import DataInst, GEPAAdapter, ProposalFn, RolloutOutput, 
 from gepa.core.data_loader import DataId, DataLoader, ensure_loader
 from gepa.core.engine import GEPAEngine
 from gepa.core.result import GEPAResult
-from gepa.core.state import EvaluationCache, FrontierType
+from gepa.core.state import TRAINSET_CACHE_SPLIT, VALSET_CACHE_SPLIT, EvaluationCache, FrontierType
 from gepa.logging.experiment_tracker import create_experiment_tracker
 from gepa.logging.logger import Logger, LoggerProtocol, StdOutLogger
 from gepa.proposer.merge import MergeProposer
@@ -220,7 +220,10 @@ def optimize(
 
     # Normalize datasets to DataLoader instances
     train_loader = ensure_loader(trainset)
-    val_loader = ensure_loader(valset) if valset is not None else train_loader
+    val_loader = train_loader if valset is None or valset is trainset else ensure_loader(valset)
+    # Both loaders number their examples from zero, so a distinct valset needs its own cache
+    # namespace; when it *is* the trainset the ids agree and results are shared as before.
+    valset_cache_split = TRAINSET_CACHE_SPLIT if val_loader is train_loader else VALSET_CACHE_SPLIT
 
     # Validate that only one custom proposal method is provided
     adapter_has_propose = hasattr(active_adapter, "propose_new_texts") and active_adapter.propose_new_texts is not None
@@ -457,6 +460,7 @@ def optimize(
             rng=rng,
             val_overlap_floor=merge_val_overlap_floor,
             callbacks=callbacks,
+            valset_cache_split=valset_cache_split,
         )
 
     engine = GEPAEngine(
@@ -482,6 +486,7 @@ def optimize(
         use_cloudpickle=use_cloudpickle,
         write_agent_state=write_agent_state,
         evaluation_cache=evaluation_cache,
+        valset_cache_split=valset_cache_split,
     )
 
     with experiment_tracker:

--- a/src/gepa/core/data_loader.py
+++ b/src/gepa/core/data_loader.py
@@ -48,7 +48,12 @@ class MutableDataLoader(DataLoader[DataId, DataInst], Protocol):
 
 
 class ListDataLoader(MutableDataLoader[int, DataInst]):
-    """In-memory reference implementation backed by a list."""
+    """In-memory reference implementation backed by a list.
+
+    ``all_ids()`` returns ``0 .. len(items)-1``. Those ids are this loader's positions, not
+    global example identities: a second ``ListDataLoader`` (for example a valset) also numbers
+    from zero. The evaluation cache namespaces by split so those two id spaces cannot collide.
+    """
 
     def __init__(self, items: Sequence[DataInst]):
         self.items = list(items)

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -146,7 +146,6 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         selection_strategy: SelectionStrategy | None = None,
         # Evaluation caching (stored in state, passed here for initialization)
         evaluation_cache: EvaluationCache[RolloutOutput, DataId] | None = None,
-        valset_cache_split: str | None = None,
     ):
         self.logger = logger
         self.run_dir = run_dir
@@ -171,16 +170,11 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         self.evaluator = evaluator
 
         self.valset = ensure_loader(valset) if valset is not None else None
-        # Valset ids only mean the same thing as minibatch ids when both come from the same loader.
-        # When they do not, valset results need their own cache namespace or a valset lookup can be
-        # answered by the rollout of the trainset example that happens to sit at the same position.
-        if valset_cache_split is None:
-            valset_cache_split = (
-                TRAINSET_CACHE_SPLIT
-                if self.valset is not None and self.valset is getattr(reflective_proposer, "trainset", None)
-                else VALSET_CACHE_SPLIT
-            )
-        self.valset_cache_split = valset_cache_split
+        self.valset_cache_split = (
+            TRAINSET_CACHE_SPLIT
+            if self.valset is not None and self.valset is getattr(reflective_proposer, "trainset", None)
+            else VALSET_CACHE_SPLIT
+        )
         self.seed_candidate = seed_candidate
 
         self.perfect_score = perfect_score
@@ -194,6 +188,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         # Merge scheduling flags (mirroring previous behavior)
         if self.merge_proposer is not None:
             self.merge_proposer.last_iter_found_new_program = False
+            self.merge_proposer.valset_cache_split = self.valset_cache_split
 
         self.acceptance_criterion: AcceptanceCriterion = acceptance_criterion or StrictImprovementAcceptance()
         self.selection_strategy: SelectionStrategy = selection_strategy or AllImprovements()
@@ -316,7 +311,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         for program in programs:
             val_ids = list(self.val_evaluation_policy.get_eval_batch(valset, state))
             if cache is not None:
-                cached, uncached = cache.get_batch(program, val_ids, self.valset_cache_split)
+                cached, uncached = cache.get_batch(program, val_ids, split=self.valset_cache_split)
             else:
                 cached, uncached = {}, val_ids
             cached_per.append(cached)
@@ -352,7 +347,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                         objective_by = objective_by or {}
                         objective_by[eid] = obj[j]
                 if cache is not None:
-                    cache.put_batch(program, uncached, eb.outputs, eb.scores, obj, self.valset_cache_split)
+                    cache.put_batch(program, uncached, eb.outputs, eb.scores, obj, split=self.valset_cache_split)
 
             results.append(
                 (

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -36,6 +36,8 @@ from gepa.core.callbacks import (
 from gepa.core.data_loader import DataId, DataLoader, ensure_loader
 from gepa.core.state import (
     SEED_ITERATION_ID,
+    TRAINSET_CACHE_SPLIT,
+    VALSET_CACHE_SPLIT,
     EvaluationCache,
     FrontierType,
     GEPAState,
@@ -144,6 +146,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         selection_strategy: SelectionStrategy | None = None,
         # Evaluation caching (stored in state, passed here for initialization)
         evaluation_cache: EvaluationCache[RolloutOutput, DataId] | None = None,
+        valset_cache_split: str | None = None,
     ):
         self.logger = logger
         self.run_dir = run_dir
@@ -168,6 +171,14 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         self.evaluator = evaluator
 
         self.valset = ensure_loader(valset) if valset is not None else None
+        # Valset ids only mean the same thing as minibatch ids when both come from the same loader.
+        # When they do not, valset results need their own cache namespace or a valset lookup can be
+        # answered by the rollout of the trainset example that happens to sit at the same position.
+        self.valset_cache_split = valset_cache_split or (
+            TRAINSET_CACHE_SPLIT
+            if self.valset is not None and self.valset is getattr(reflective_proposer, "trainset", None)
+            else VALSET_CACHE_SPLIT
+        )
         self.seed_candidate = seed_candidate
 
         self.perfect_score = perfect_score
@@ -303,7 +314,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         for program in programs:
             val_ids = list(self.val_evaluation_policy.get_eval_batch(valset, state))
             if cache is not None:
-                cached, uncached = cache.get_batch(program, val_ids)
+                cached, uncached = cache.get_batch(program, val_ids, self.valset_cache_split)
             else:
                 cached, uncached = {}, val_ids
             cached_per.append(cached)
@@ -339,7 +350,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                         objective_by = objective_by or {}
                         objective_by[eid] = obj[j]
                 if cache is not None:
-                    cache.put_batch(program, uncached, eb.outputs, eb.scores, obj)
+                    cache.put_batch(program, uncached, eb.outputs, eb.scores, obj, self.valset_cache_split)
 
             results.append(
                 (

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -112,7 +112,17 @@ class _MemoizedAcceptance:
 
 
 class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
-    """Orchestrates the optimization loop using pluggable candidate proposers."""
+    """Orchestrates the optimization loop using pluggable candidate proposers.
+
+    ``valset_cache_split`` is derived here and is the single authority for the evaluation-cache
+    namespace used on valset reads and writes. If this engine's valset loader is the same object
+    as the reflective proposer's ``trainset`` loader, minibatch and valset share
+    ``TRAINSET_CACHE_SPLIT``; otherwise valset uses ``VALSET_CACHE_SPLIT``. A ``MergeProposer``,
+    if present, is synced to the same value so it cannot silently re-run or mis-read valset
+    rollouts. Callers should pass the same loader instance they gave the proposer when the two
+    id spaces are genuinely the same; wrapping the same list twice produces two loaders and
+    isolates the cache (extra evals, never a wrongly shared one).
+    """
 
     def __init__(
         self,
@@ -804,6 +814,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         seed_valset_evaluation = valset_evaluator(self.seed_candidate, seed_val_ids)
 
         # Initialize state with pre-computed seed evaluation
+        resumed = self.run_dir is not None and os.path.exists(os.path.join(self.run_dir, "gepa_state.bin"))
         state = initialize_gepa_state(
             run_dir=self.run_dir,
             logger=self.logger,
@@ -813,6 +824,24 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             frontier_type=self.frontier_type,
             evaluation_cache=self._initial_evaluation_cache,
         )
+        # Fresh runs: record the seed valset eval in the cache. On resume the seed scores already
+        # live in state; writing the re-computed seed eval would desynchronize cache from
+        # prog_candidate_val_subscores.
+        if not resumed and state.evaluation_cache is not None:
+            seed_ids = list(seed_valset_evaluation.scores_by_val_id)
+            seed_obj = (
+                [seed_valset_evaluation.objective_scores_by_val_id[eid] for eid in seed_ids]
+                if seed_valset_evaluation.objective_scores_by_val_id is not None
+                else None
+            )
+            state.evaluation_cache.put_batch(
+                self.seed_candidate,
+                seed_ids,
+                [seed_valset_evaluation.outputs_by_val_id[eid] for eid in seed_ids],
+                [seed_valset_evaluation.scores_by_val_id[eid] for eid in seed_ids],
+                seed_obj,
+                split=self.valset_cache_split,
+            )
 
         # Seed uses the reserved iteration id — outputs/trajectories go under
         # iterations/seed/ alongside subsequent loop iterations.

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -174,11 +174,13 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         # Valset ids only mean the same thing as minibatch ids when both come from the same loader.
         # When they do not, valset results need their own cache namespace or a valset lookup can be
         # answered by the rollout of the trainset example that happens to sit at the same position.
-        self.valset_cache_split = valset_cache_split or (
-            TRAINSET_CACHE_SPLIT
-            if self.valset is not None and self.valset is getattr(reflective_proposer, "trainset", None)
-            else VALSET_CACHE_SPLIT
-        )
+        if valset_cache_split is None:
+            valset_cache_split = (
+                TRAINSET_CACHE_SPLIT
+                if self.valset is not None and self.valset is getattr(reflective_proposer, "trainset", None)
+                else VALSET_CACHE_SPLIT
+            )
+        self.valset_cache_split = valset_cache_split
         self.seed_candidate = seed_candidate
 
         self.perfect_score = perfect_score

--- a/src/gepa/core/state.py
+++ b/src/gepa/core/state.py
@@ -105,7 +105,7 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         return len(stale)
 
     def get(
-        self, candidate: dict[str, str], example_id: DataId, split: str = TRAINSET_CACHE_SPLIT
+        self, candidate: dict[str, str], example_id: DataId, *, split: str
     ) -> CachedEvaluation[RolloutOutput] | None:
         """Retrieve cached evaluation result if it exists."""
         return self._cache.get(self._key(_candidate_hash(candidate), example_id, split))
@@ -117,14 +117,15 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         output: RolloutOutput,
         score: float,
         objective_scores: ObjectiveScores | None = None,
-        split: str = TRAINSET_CACHE_SPLIT,
+        *,
+        split: str,
     ) -> None:
         """Store an evaluation result in the cache."""
         key = self._key(_candidate_hash(candidate), example_id, split)
         self._cache[key] = CachedEvaluation(output, score, objective_scores)
 
     def get_batch(
-        self, candidate: dict[str, str], example_ids: list[DataId], split: str = TRAINSET_CACHE_SPLIT
+        self, candidate: dict[str, str], example_ids: list[DataId], *, split: str
     ) -> tuple[dict[DataId, CachedEvaluation[RolloutOutput]], list[DataId]]:
         """Look up cached results for a batch. Returns (cached_results, uncached_ids)."""
         h = _candidate_hash(candidate)
@@ -143,7 +144,8 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         outputs: list[RolloutOutput],
         scores: list[float],
         objective_scores_list: Sequence[ObjectiveScores] | None = None,
-        split: str = TRAINSET_CACHE_SPLIT,
+        *,
+        split: str,
     ) -> None:
         """Store evaluation results for a batch of examples."""
         h = _candidate_hash(candidate)
@@ -158,14 +160,15 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         example_ids: list[DataId],
         fetcher: Callable[[list[DataId]], Any],
         evaluator: Callable[[Any, dict[str, str]], tuple[Any, list[float], Sequence[ObjectiveScores] | None]],
-        split: str = TRAINSET_CACHE_SPLIT,
+        *,
+        split: str,
     ) -> tuple[dict[DataId, RolloutOutput], dict[DataId, float], dict[DataId, ObjectiveScores] | None, int]:
         """
         Evaluate using cache, returning full results.
 
         Returns (outputs_by_id, scores_by_id, objective_scores_by_id, num_actual_evals).
         """
-        cached, uncached_ids = self.get_batch(candidate, example_ids, split)
+        cached, uncached_ids = self.get_batch(candidate, example_ids, split=split)
 
         outputs_by_id: dict[DataId, RolloutOutput] = {eid: c.output for eid, c in cached.items()}
         scores_by_id: dict[DataId, float] = {eid: c.score for eid, c in cached.items()}
@@ -187,7 +190,7 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
                 if obj_scores is not None:
                     objective_by_id = objective_by_id or {}
                     objective_by_id[eid] = obj_scores[idx]
-            self.put_batch(candidate, uncached_ids, outputs, scores, obj_scores, split)
+            self.put_batch(candidate, uncached_ids, outputs, scores, obj_scores, split=split)
 
         return outputs_by_id, scores_by_id, objective_by_id, len(uncached_ids)
 
@@ -747,9 +750,6 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         if version is None or version < GEPAState._VALIDATION_SCHEMA_VERSION:
             GEPAState._upgrade_state_dict(data)
 
-        # Pre-split caches are unnamespaced, so a valset rollout could be stored under the key a
-        # trainset lookup now uses. They are never served (all keys carry a split) — drop them so
-        # they do not ride along in every subsequent save.
         cache = data.get("evaluation_cache")
         if cache is not None:
             cache.drop_unsplit_entries()
@@ -1041,11 +1041,12 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         example_ids: list[DataId],
         fetcher: Callable[[list[DataId]], Any],
         evaluator: Callable[[Any, dict[str, str]], tuple[Any, list[float], Sequence[ObjectiveScores] | None]],
-        split: str = TRAINSET_CACHE_SPLIT,
+        *,
+        split: str,
     ) -> tuple[list[float], int]:
         """Evaluate with optional caching. Returns (scores, num_actual_evals)."""
         _, scores_by_id, _, num_actual_evals = self.cached_evaluate_full(
-            candidate, example_ids, fetcher, evaluator, split
+            candidate, example_ids, fetcher, evaluator, split=split
         )
         return [scores_by_id[eid] for eid in example_ids], num_actual_evals
 
@@ -1055,11 +1056,12 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         example_ids: list[DataId],
         fetcher: Callable[[list[DataId]], Any],
         evaluator: Callable[[Any, dict[str, str]], tuple[Any, list[float], Sequence[ObjectiveScores] | None]],
-        split: str = TRAINSET_CACHE_SPLIT,
+        *,
+        split: str,
     ) -> tuple[dict[DataId, RolloutOutput], dict[DataId, float], dict[DataId, ObjectiveScores] | None, int]:
         """Evaluate with optional caching, returning full results."""
         if self.evaluation_cache is not None:
-            return self.evaluation_cache.evaluate_with_cache_full(candidate, example_ids, fetcher, evaluator, split)
+            return self.evaluation_cache.evaluate_with_cache_full(candidate, example_ids, fetcher, evaluator, split=split)
         batch = fetcher(example_ids)
         outputs, scores, objective_scores = evaluator(batch, candidate)
         outputs_by_id = dict(zip(example_ids, outputs, strict=False))

--- a/src/gepa/core/state.py
+++ b/src/gepa/core/state.py
@@ -27,7 +27,7 @@ FrontierKey: TypeAlias = DataId | str | tuple[str, DataId] | tuple[str, DataId, 
 """Key type for frontier mappings depending on frontier_type."""
 
 CandidateHash: TypeAlias = str
-CacheKey: TypeAlias = tuple[CandidateHash, DataId] | tuple[CandidateHash, str, DataId]
+CacheKey: TypeAlias = tuple[CandidateHash, str, DataId]
 
 TRAINSET_CACHE_SPLIT = "train"
 VALSET_CACHE_SPLIT = "val"
@@ -39,6 +39,10 @@ can be answered with the rollout of an unrelated trainset example. Callers that 
 valset which is a *distinct* loader from the trainset pass ``VALSET_CACHE_SPLIT``; when the two are
 the same loader the ids mean the same thing and both sides share ``TRAINSET_CACHE_SPLIT`` so results
 are still reused across minibatch and valset evaluation.
+
+Every key carries its split, including the trainset one. Caches persisted before splits existed are
+unnamespaced and therefore already contaminated, so they are dropped on resume rather than reused
+(see :meth:`EvaluationCache.drop_unsplit_entries`).
 """
 
 
@@ -85,11 +89,20 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
 
     @staticmethod
     def _key(candidate_hash: CandidateHash, example_id: DataId, split: str) -> CacheKey:
-        # The default split keeps the two-element key that earlier versions wrote, so caches
-        # persisted before splits existed stay readable on resume.
-        if split == TRAINSET_CACHE_SPLIT:
-            return (candidate_hash, example_id)
         return (candidate_hash, split, example_id)
+
+    def drop_unsplit_entries(self) -> int:
+        """Discard entries written before splits existed. Returns the number dropped.
+
+        Those keys are ``(candidate_hash, example_id)`` with no namespace, so a valset rollout and
+        the trainset rollout at the same position were stored under the same key. They can no longer
+        be served (every lookup is namespaced now), and keeping them would grow the persisted state
+        on every resume, so ``GEPAState.load`` drops them.
+        """
+        stale = [k for k in self._cache if len(k) != 3]
+        for k in stale:
+            del self._cache[k]
+        return len(stale)
 
     def get(
         self, candidate: dict[str, str], example_id: DataId, split: str = TRAINSET_CACHE_SPLIT
@@ -733,6 +746,13 @@ class GEPAState(Generic[RolloutOutput, DataId]):
             version = data.get("validation_schema_version")
         if version is None or version < GEPAState._VALIDATION_SCHEMA_VERSION:
             GEPAState._upgrade_state_dict(data)
+
+        # Pre-split caches are unnamespaced, so a valset rollout could be stored under the key a
+        # trainset lookup now uses. They are never served (all keys carry a split) — drop them so
+        # they do not ride along in every subsequent save.
+        cache = data.get("evaluation_cache")
+        if cache is not None:
+            cache.drop_unsplit_entries()
 
         state = GEPAState.__new__(GEPAState)
         state.__dict__.update(data)

--- a/src/gepa/core/state.py
+++ b/src/gepa/core/state.py
@@ -27,7 +27,19 @@ FrontierKey: TypeAlias = DataId | str | tuple[str, DataId] | tuple[str, DataId, 
 """Key type for frontier mappings depending on frontier_type."""
 
 CandidateHash: TypeAlias = str
-CacheKey: TypeAlias = tuple[CandidateHash, DataId]
+CacheKey: TypeAlias = tuple[CandidateHash, DataId] | tuple[CandidateHash, str, DataId]
+
+TRAINSET_CACHE_SPLIT = "train"
+VALSET_CACHE_SPLIT = "val"
+"""Cache namespaces for the two datasets.
+
+Data loaders identify examples by position, so a trainset and a separate valset both number their
+examples from zero. Without a namespace the two collide in the evaluation cache and a valset lookup
+can be answered with the rollout of an unrelated trainset example. Callers that evaluate against a
+valset which is a *distinct* loader from the trainset pass ``VALSET_CACHE_SPLIT``; when the two are
+the same loader the ids mean the same thing and both sides share ``TRAINSET_CACHE_SPLIT`` so results
+are still reused across minibatch and valset evaluation.
+"""
 
 
 def _candidate_hash(candidate: dict[str, str]) -> CandidateHash:
@@ -71,9 +83,19 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
 
     _cache: dict[CacheKey, CachedEvaluation[RolloutOutput]] = field(default_factory=dict)
 
-    def get(self, candidate: dict[str, str], example_id: DataId) -> CachedEvaluation[RolloutOutput] | None:
+    @staticmethod
+    def _key(candidate_hash: CandidateHash, example_id: DataId, split: str) -> CacheKey:
+        # The default split keeps the two-element key that earlier versions wrote, so caches
+        # persisted before splits existed stay readable on resume.
+        if split == TRAINSET_CACHE_SPLIT:
+            return (candidate_hash, example_id)
+        return (candidate_hash, split, example_id)
+
+    def get(
+        self, candidate: dict[str, str], example_id: DataId, split: str = TRAINSET_CACHE_SPLIT
+    ) -> CachedEvaluation[RolloutOutput] | None:
         """Retrieve cached evaluation result if it exists."""
-        return self._cache.get((_candidate_hash(candidate), example_id))
+        return self._cache.get(self._key(_candidate_hash(candidate), example_id, split))
 
     def put(
         self,
@@ -82,18 +104,20 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         output: RolloutOutput,
         score: float,
         objective_scores: ObjectiveScores | None = None,
+        split: str = TRAINSET_CACHE_SPLIT,
     ) -> None:
         """Store an evaluation result in the cache."""
-        self._cache[(_candidate_hash(candidate), example_id)] = CachedEvaluation(output, score, objective_scores)
+        key = self._key(_candidate_hash(candidate), example_id, split)
+        self._cache[key] = CachedEvaluation(output, score, objective_scores)
 
     def get_batch(
-        self, candidate: dict[str, str], example_ids: list[DataId]
+        self, candidate: dict[str, str], example_ids: list[DataId], split: str = TRAINSET_CACHE_SPLIT
     ) -> tuple[dict[DataId, CachedEvaluation[RolloutOutput]], list[DataId]]:
         """Look up cached results for a batch. Returns (cached_results, uncached_ids)."""
         h = _candidate_hash(candidate)
         cached, uncached = {}, []
         for eid in example_ids:
-            if entry := self._cache.get((h, eid)):
+            if entry := self._cache.get(self._key(h, eid, split)):
                 cached[eid] = entry
             else:
                 uncached.append(eid)
@@ -106,11 +130,12 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         outputs: list[RolloutOutput],
         scores: list[float],
         objective_scores_list: Sequence[ObjectiveScores] | None = None,
+        split: str = TRAINSET_CACHE_SPLIT,
     ) -> None:
         """Store evaluation results for a batch of examples."""
         h = _candidate_hash(candidate)
         for i, eid in enumerate(example_ids):
-            self._cache[(h, eid)] = CachedEvaluation(
+            self._cache[self._key(h, eid, split)] = CachedEvaluation(
                 outputs[i], scores[i], objective_scores_list[i] if objective_scores_list else None
             )
 
@@ -120,13 +145,14 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         example_ids: list[DataId],
         fetcher: Callable[[list[DataId]], Any],
         evaluator: Callable[[Any, dict[str, str]], tuple[Any, list[float], Sequence[ObjectiveScores] | None]],
+        split: str = TRAINSET_CACHE_SPLIT,
     ) -> tuple[dict[DataId, RolloutOutput], dict[DataId, float], dict[DataId, ObjectiveScores] | None, int]:
         """
         Evaluate using cache, returning full results.
 
         Returns (outputs_by_id, scores_by_id, objective_scores_by_id, num_actual_evals).
         """
-        cached, uncached_ids = self.get_batch(candidate, example_ids)
+        cached, uncached_ids = self.get_batch(candidate, example_ids, split)
 
         outputs_by_id: dict[DataId, RolloutOutput] = {eid: c.output for eid, c in cached.items()}
         scores_by_id: dict[DataId, float] = {eid: c.score for eid, c in cached.items()}
@@ -148,7 +174,7 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
                 if obj_scores is not None:
                     objective_by_id = objective_by_id or {}
                     objective_by_id[eid] = obj_scores[idx]
-            self.put_batch(candidate, uncached_ids, outputs, scores, obj_scores)
+            self.put_batch(candidate, uncached_ids, outputs, scores, obj_scores, split)
 
         return outputs_by_id, scores_by_id, objective_by_id, len(uncached_ids)
 
@@ -995,9 +1021,12 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         example_ids: list[DataId],
         fetcher: Callable[[list[DataId]], Any],
         evaluator: Callable[[Any, dict[str, str]], tuple[Any, list[float], Sequence[ObjectiveScores] | None]],
+        split: str = TRAINSET_CACHE_SPLIT,
     ) -> tuple[list[float], int]:
         """Evaluate with optional caching. Returns (scores, num_actual_evals)."""
-        _, scores_by_id, _, num_actual_evals = self.cached_evaluate_full(candidate, example_ids, fetcher, evaluator)
+        _, scores_by_id, _, num_actual_evals = self.cached_evaluate_full(
+            candidate, example_ids, fetcher, evaluator, split
+        )
         return [scores_by_id[eid] for eid in example_ids], num_actual_evals
 
     def cached_evaluate_full(
@@ -1006,10 +1035,11 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         example_ids: list[DataId],
         fetcher: Callable[[list[DataId]], Any],
         evaluator: Callable[[Any, dict[str, str]], tuple[Any, list[float], Sequence[ObjectiveScores] | None]],
+        split: str = TRAINSET_CACHE_SPLIT,
     ) -> tuple[dict[DataId, RolloutOutput], dict[DataId, float], dict[DataId, ObjectiveScores] | None, int]:
         """Evaluate with optional caching, returning full results."""
         if self.evaluation_cache is not None:
-            return self.evaluation_cache.evaluate_with_cache_full(candidate, example_ids, fetcher, evaluator)
+            return self.evaluation_cache.evaluate_with_cache_full(candidate, example_ids, fetcher, evaluator, split)
         batch = fetcher(example_ids)
         outputs, scores, objective_scores = evaluator(batch, candidate)
         outputs_by_id = dict(zip(example_ids, outputs, strict=False))

--- a/src/gepa/core/state.py
+++ b/src/gepa/core/state.py
@@ -31,19 +31,7 @@ CacheKey: TypeAlias = tuple[CandidateHash, str, DataId]
 
 TRAINSET_CACHE_SPLIT = "train"
 VALSET_CACHE_SPLIT = "val"
-"""Cache namespaces for the two datasets.
-
-Data loaders identify examples by position, so a trainset and a separate valset both number their
-examples from zero. Without a namespace the two collide in the evaluation cache and a valset lookup
-can be answered with the rollout of an unrelated trainset example. Callers that evaluate against a
-valset which is a *distinct* loader from the trainset pass ``VALSET_CACHE_SPLIT``; when the two are
-the same loader the ids mean the same thing and both sides share ``TRAINSET_CACHE_SPLIT`` so results
-are still reused across minibatch and valset evaluation.
-
-Every key carries its split, including the trainset one. Caches persisted before splits existed are
-unnamespaced and therefore already contaminated, so they are dropped on resume rather than reused
-(see :meth:`EvaluationCache.drop_unsplit_entries`).
-"""
+CACHE_SPLITS = frozenset({TRAINSET_CACHE_SPLIT, VALSET_CACHE_SPLIT})
 
 
 def _candidate_hash(candidate: dict[str, str]) -> CandidateHash:
@@ -83,13 +71,32 @@ class CachedEvaluation(Generic[RolloutOutput]):
 
 @dataclass
 class EvaluationCache(Generic[RolloutOutput, DataId]):
-    """Cache for storing evaluation results of (candidate, example) pairs."""
+    """Cache for ``(candidate, split, example)`` evaluation results.
+
+    Data loaders identify examples by position, so a trainset and a separate valset both number
+    their examples from zero. Every lookup therefore takes a required keyword-only ``split`` of
+    :data:`TRAINSET_CACHE_SPLIT` or :data:`VALSET_CACHE_SPLIT`. A valset that is a distinct loader
+    from the trainset uses ``VALSET_CACHE_SPLIT``; when the two are the same loader the ids mean
+    the same thing and both sides share ``TRAINSET_CACHE_SPLIT`` so minibatch rollouts are reused
+    on valset evaluation.
+
+    Keys persisted before splits existed are ``(candidate_hash, example_id)``. Those cannot be
+    told apart from contaminated distinct-valset entries, so :meth:`GEPAState.load` drops them
+    rather than serving them. There is no default ``split``: omitting it is a ``TypeError``, not a
+    silent trainset hit.
+    """
 
     _cache: dict[CacheKey, CachedEvaluation[RolloutOutput]] = field(default_factory=dict)
 
     @staticmethod
     def _key(candidate_hash: CandidateHash, example_id: DataId, split: str) -> CacheKey:
+        if split not in CACHE_SPLITS:
+            raise ValueError(f"Unknown evaluation-cache split {split!r}; expected one of {sorted(CACHE_SPLITS)}")
         return (candidate_hash, split, example_id)
+
+    @staticmethod
+    def _is_split_key(key: object) -> bool:
+        return isinstance(key, tuple) and len(key) == 3 and key[1] in CACHE_SPLITS
 
     def drop_unsplit_entries(self) -> int:
         """Discard entries written before splits existed. Returns the number dropped.
@@ -99,7 +106,7 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         be served (every lookup is namespaced now), and keeping them would grow the persisted state
         on every resume, so ``GEPAState.load`` drops them.
         """
-        stale = [k for k in self._cache if len(k) != 3]
+        stale = [k for k in self._cache if not self._is_split_key(k)]
         for k in stale:
             del self._cache[k]
         return len(stale)
@@ -107,7 +114,7 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
     def get(
         self, candidate: dict[str, str], example_id: DataId, *, split: str
     ) -> CachedEvaluation[RolloutOutput] | None:
-        """Retrieve cached evaluation result if it exists."""
+        """Retrieve cached evaluation result if it exists. ``split`` is required."""
         return self._cache.get(self._key(_candidate_hash(candidate), example_id, split))
 
     def put(
@@ -218,7 +225,7 @@ class GEPAState(Generic[RolloutOutput, DataId]):
     returned by :func:`~gepa.optimize_anything.optimize_anything`.
     """
 
-    _VALIDATION_SCHEMA_VERSION: ClassVar[int] = 6
+    _VALIDATION_SCHEMA_VERSION: ClassVar[int] = 7
     # Attributes that are runtime-only and should not be serialized (e.g., callback hooks, caches)
     _EXCLUDED_FROM_SERIALIZATION: ClassVar[frozenset[str]] = frozenset({"_budget_hooks"})
 
@@ -651,6 +658,7 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         never sees the internal candidate numbering; everything is anchored
         on the ``iterations/`` timeline.
         """
+
         def _iter_ids(candidate_idxs: "set[int]") -> list[str]:
             return sorted({cand_to_iter[c] for c in candidate_idxs if c in cand_to_iter})
 
@@ -689,23 +697,23 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         if self.pareto_front_valset:
             sorted_examples = sorted(self.pareto_front_valset.items(), key=lambda x: x[1])
             for val_id, score in sorted_examples[:20]:
-                best_iters = sorted({
-                    cand_to_iter[c]
-                    for c in self.program_at_pareto_front_valset.get(val_id, set())
-                    if c in cand_to_iter
-                })
-                hardest.append({
-                    "val_id": str(val_id),
-                    "best_score": score,
-                    "best_iteration_ids": best_iters,
-                })
+                best_iters = sorted(
+                    {
+                        cand_to_iter[c]
+                        for c in self.program_at_pareto_front_valset.get(val_id, set())
+                        if c in cand_to_iter
+                    }
+                )
+                hardest.append(
+                    {
+                        "val_id": str(val_id),
+                        "best_score": score,
+                        "best_iteration_ids": best_iters,
+                    }
+                )
 
         full_scores = self.program_full_scores_val_set
-        best_candidate_idx = (
-            int(max(range(num_candidates), key=lambda i: full_scores[i]))
-            if num_candidates > 0
-            else 0
-        )
+        best_candidate_idx = int(max(range(num_candidates), key=lambda i: full_scores[i])) if num_candidates > 0 else 0
         best_iter_id = cand_to_iter.get(best_candidate_idx)
 
         front_candidate_idxs: set[int] = set()
@@ -750,6 +758,8 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         if version is None or version < GEPAState._VALIDATION_SCHEMA_VERSION:
             GEPAState._upgrade_state_dict(data)
 
+        # Schema 7 (and every later load): drop unnamespaced cache keys. This runs even when
+        # upgrade was skipped, so a v7 pickle that somehow still holds 2-tuples cannot be served.
         cache = data.get("evaluation_cache")
         if cache is not None:
             cache.drop_unsplit_entries()
@@ -840,6 +850,9 @@ class GEPAState(Generic[RolloutOutput, DataId]):
             if "iteration_id" not in entry:
                 trace_i = entry.get("i")
                 entry["iteration_id"] = str(trace_i + 1) if trace_i is not None else SEED_ITERATION_ID
+        # Schema 7: evaluation-cache keys are (candidate_hash, split, example_id). Unnamespaced
+        # 2-tuples from earlier versions can mix train and val rollouts under the same positional
+        # id, so they are dropped in GEPAState.load rather than promoted to a split.
         d["validation_schema_version"] = GEPAState._VALIDATION_SCHEMA_VERSION
 
     @staticmethod
@@ -1044,7 +1057,7 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         *,
         split: str,
     ) -> tuple[list[float], int]:
-        """Evaluate with optional caching. Returns (scores, num_actual_evals)."""
+        """Evaluate with optional caching. Returns (scores, num_actual_evals). ``split`` is required."""
         _, scores_by_id, _, num_actual_evals = self.cached_evaluate_full(
             candidate, example_ids, fetcher, evaluator, split=split
         )
@@ -1059,9 +1072,11 @@ class GEPAState(Generic[RolloutOutput, DataId]):
         *,
         split: str,
     ) -> tuple[dict[DataId, RolloutOutput], dict[DataId, float], dict[DataId, ObjectiveScores] | None, int]:
-        """Evaluate with optional caching, returning full results."""
+        """Evaluate with optional caching, returning full results. ``split`` is required."""
         if self.evaluation_cache is not None:
-            return self.evaluation_cache.evaluate_with_cache_full(candidate, example_ids, fetcher, evaluator, split=split)
+            return self.evaluation_cache.evaluate_with_cache_full(
+                candidate, example_ids, fetcher, evaluator, split=split
+            )
         batch = fetcher(example_ids)
         outputs, scores, objective_scores = evaluator(batch, candidate)
         outputs_by_id = dict(zip(example_ids, outputs, strict=False))

--- a/src/gepa/gepa_launcher.py
+++ b/src/gepa/gepa_launcher.py
@@ -1379,7 +1379,7 @@ def optimize_anything(
 
     # Normalize datasets to DataLoader instances
     train_loader = ensure_loader(effective_dataset)
-    val_loader = ensure_loader(valset) if valset is not None else train_loader
+    val_loader = train_loader if valset is None or valset is effective_dataset else ensure_loader(valset)
     # Both loaders number their examples from zero, so a distinct valset needs its own cache
     # namespace; when it *is* the trainset the ids agree and results are shared as before.
     valset_cache_split = TRAINSET_CACHE_SPLIT if val_loader is train_loader else VALSET_CACHE_SPLIT

--- a/src/gepa/gepa_launcher.py
+++ b/src/gepa/gepa_launcher.py
@@ -136,7 +136,7 @@ from gepa.core.callbacks import GEPACallback, ReflectiveDatasetDumpCallback
 from gepa.core.data_loader import ensure_loader
 from gepa.core.engine import GEPAEngine
 from gepa.core.result import GEPAResult
-from gepa.core.state import EvaluationCache, FrontierType
+from gepa.core.state import TRAINSET_CACHE_SPLIT, VALSET_CACHE_SPLIT, EvaluationCache, FrontierType
 from gepa.image import Image  # noqa: F401 — re-exported for user convenience
 from gepa.logging.experiment_tracker import create_experiment_tracker
 from gepa.logging.logger import Logger, LoggerProtocol, StdOutLogger
@@ -1380,6 +1380,9 @@ def optimize_anything(
     # Normalize datasets to DataLoader instances
     train_loader = ensure_loader(effective_dataset)
     val_loader = ensure_loader(valset) if valset is not None else train_loader
+    # Both loaders number their examples from zero, so a distinct valset needs its own cache
+    # namespace; when it *is* the trainset the ids agree and results are shared as before.
+    valset_cache_split = TRAINSET_CACHE_SPLIT if val_loader is train_loader else VALSET_CACHE_SPLIT
 
     # --- 1. Validate and setup reflection LM ---
     if needs_seed_generation and config.reflection.reflection_lm is None:
@@ -1716,6 +1719,7 @@ def optimize_anything(
             rng=rng,
             val_overlap_floor=config.merge.merge_val_overlap_floor,
             callbacks=config.callbacks,
+            valset_cache_split=valset_cache_split,
         )
 
     # --- 13. Create evaluation cache if enabled ---
@@ -1747,6 +1751,7 @@ def optimize_anything(
         use_cloudpickle=config.engine.use_cloudpickle,
         write_agent_state=config.engine.write_agent_state,
         evaluation_cache=evaluation_cache,
+        valset_cache_split=valset_cache_split,
     )
 
     # --- 16. Run optimization ---

--- a/src/gepa/gepa_launcher.py
+++ b/src/gepa/gepa_launcher.py
@@ -506,7 +506,10 @@ class EngineConfig:
     parallel: bool = True
     max_workers: int | None = field(default_factory=lambda: os.cpu_count() or 32)
 
-    # Evaluation caching
+    # Evaluation caching. Opt-in. Keys are (candidate, split, example_id): a distinct valset
+    # never reuses trainset rollouts at the same list index. valset=None (or the same dataset
+    # object passed as both trainset and valset) shares the trainset namespace. Caches written
+    # before splits existed are dropped on resume.
     cache_evaluation: bool = False
     cache_evaluation_storage: CacheEvaluationStorage = "auto"
 

--- a/src/gepa/gepa_launcher.py
+++ b/src/gepa/gepa_launcher.py
@@ -136,7 +136,7 @@ from gepa.core.callbacks import GEPACallback, ReflectiveDatasetDumpCallback
 from gepa.core.data_loader import ensure_loader
 from gepa.core.engine import GEPAEngine
 from gepa.core.result import GEPAResult
-from gepa.core.state import TRAINSET_CACHE_SPLIT, VALSET_CACHE_SPLIT, EvaluationCache, FrontierType
+from gepa.core.state import EvaluationCache, FrontierType
 from gepa.image import Image  # noqa: F401 — re-exported for user convenience
 from gepa.logging.experiment_tracker import create_experiment_tracker
 from gepa.logging.logger import Logger, LoggerProtocol, StdOutLogger
@@ -1380,9 +1380,6 @@ def optimize_anything(
     # Normalize datasets to DataLoader instances
     train_loader = ensure_loader(effective_dataset)
     val_loader = train_loader if valset is None or valset is effective_dataset else ensure_loader(valset)
-    # Both loaders number their examples from zero, so a distinct valset needs its own cache
-    # namespace; when it *is* the trainset the ids agree and results are shared as before.
-    valset_cache_split = TRAINSET_CACHE_SPLIT if val_loader is train_loader else VALSET_CACHE_SPLIT
 
     # --- 1. Validate and setup reflection LM ---
     if needs_seed_generation and config.reflection.reflection_lm is None:
@@ -1719,7 +1716,6 @@ def optimize_anything(
             rng=rng,
             val_overlap_floor=config.merge.merge_val_overlap_floor,
             callbacks=config.callbacks,
-            valset_cache_split=valset_cache_split,
         )
 
     # --- 13. Create evaluation cache if enabled ---
@@ -1751,7 +1747,6 @@ def optimize_anything(
         use_cloudpickle=config.engine.use_cloudpickle,
         write_agent_state=config.engine.write_agent_state,
         evaluation_cache=evaluation_cache,
-        valset_cache_split=valset_cache_split,
     )
 
     # --- 16. Run optimization ---

--- a/src/gepa/proposer/base.py
+++ b/src/gepa/proposer/base.py
@@ -48,6 +48,8 @@ class ProposeNewCandidate(Protocol[DataId]):
     Strategy that receives the current optimizer state and proposes a new candidate or returns None.
     It may compute subsample evaluations, set trace fields in state, etc.
     The engine will handle acceptance and full eval unless the strategy already did those and encoded in metadata.
+    A proposer may expose the loader its minibatch ids come from as a ``trainset`` attribute; the engine
+    compares it against its valset loader to decide whether the two id spaces share a cache namespace.
     """
 
     def propose(self, state: GEPAState[Any, DataId]) -> CandidateProposal | None: ...

--- a/src/gepa/proposer/merge.py
+++ b/src/gepa/proposer/merge.py
@@ -231,11 +231,10 @@ class MergeProposer(ProposeNewCandidate[DataId]):
         val_overlap_floor: int = 5,
         rng: random.Random | None = None,
         callbacks: list[GEPACallback] | None = None,
-        valset_cache_split: str = VALSET_CACHE_SPLIT,
     ):
         self.logger = logger
         self.valset = valset
-        self.valset_cache_split = valset_cache_split
+        self.valset_cache_split = VALSET_CACHE_SPLIT
         self.evaluator = evaluator
         self.use_merge = use_merge
         self.max_merge_invocations = max_merge_invocations
@@ -365,7 +364,7 @@ class MergeProposer(ProposeNewCandidate[DataId]):
         )
 
         outputs_by_id, scores_by_id, objective_by_id, actual_evals_count = state.cached_evaluate_full(
-            new_program, subsample_ids, self.valset.fetch, self.evaluator, self.valset_cache_split
+            new_program, subsample_ids, self.valset.fetch, self.evaluator, split=self.valset_cache_split
         )
         new_sub_scores = [scores_by_id[eid] for eid in subsample_ids]
         outputs = [outputs_by_id[eid] for eid in subsample_ids]

--- a/src/gepa/proposer/merge.py
+++ b/src/gepa/proposer/merge.py
@@ -14,7 +14,7 @@ from gepa.core.callbacks import (
     notify_callbacks,
 )
 from gepa.core.data_loader import DataId, DataLoader
-from gepa.core.state import GEPAState, ObjectiveScores, ProgramIdx
+from gepa.core.state import VALSET_CACHE_SPLIT, GEPAState, ObjectiveScores, ProgramIdx
 from gepa.gepa_utils import find_dominator_programs
 from gepa.logging.logger import LoggerProtocol
 from gepa.proposer.base import CandidateProposal, ProposeNewCandidate
@@ -231,9 +231,11 @@ class MergeProposer(ProposeNewCandidate[DataId]):
         val_overlap_floor: int = 5,
         rng: random.Random | None = None,
         callbacks: list[GEPACallback] | None = None,
+        valset_cache_split: str = VALSET_CACHE_SPLIT,
     ):
         self.logger = logger
         self.valset = valset
+        self.valset_cache_split = valset_cache_split
         self.evaluator = evaluator
         self.use_merge = use_merge
         self.max_merge_invocations = max_merge_invocations
@@ -363,7 +365,7 @@ class MergeProposer(ProposeNewCandidate[DataId]):
         )
 
         outputs_by_id, scores_by_id, objective_by_id, actual_evals_count = state.cached_evaluate_full(
-            new_program, subsample_ids, self.valset.fetch, self.evaluator
+            new_program, subsample_ids, self.valset.fetch, self.evaluator, self.valset_cache_split
         )
         new_sub_scores = [scores_by_id[eid] for eid in subsample_ids]
         outputs = [outputs_by_id[eid] for eid in subsample_ids]

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -28,7 +28,7 @@ from gepa.core.callbacks import (
     notify_callbacks,
 )
 from gepa.core.data_loader import DataId, DataLoader, ensure_loader
-from gepa.core.state import GEPAState, _candidate_hash
+from gepa.core.state import TRAINSET_CACHE_SPLIT, GEPAState, _candidate_hash
 from gepa.proposer.base import CandidateProposal, SubsampleEvaluation
 from gepa.proposer.reflective_mutation.base import (
     CandidateSelector,
@@ -389,6 +389,7 @@ class ReflectiveMutationProposer:
                     eval_curr.outputs,
                     eval_curr.scores,
                     objective_scores_list,
+                    split=TRAINSET_CACHE_SPLIT,
                 )
 
         # Trace: legacy first-task keys (pre-#329 tooling compatibility) plus
@@ -648,7 +649,12 @@ class ReflectiveMutationProposer:
             for (_, (task, new_candidate, _, _)), child_eval in zip(valid_children, child_evals, strict=True):
                 new_obj_scores = list(child_eval.objective_scores) if child_eval.objective_scores else None
                 state.evaluation_cache.put_batch(
-                    new_candidate, task.minibatch_ids, child_eval.outputs, child_eval.scores, new_obj_scores
+                    new_candidate,
+                    task.minibatch_ids,
+                    child_eval.outputs,
+                    child_eval.scores,
+                    new_obj_scores,
+                    split=TRAINSET_CACHE_SPLIT,
                 )
 
         # Trace: per-task before/after scores (children is index-aligned with tasks)

--- a/tests/proposer/test_merge.py
+++ b/tests/proposer/test_merge.py
@@ -251,14 +251,14 @@ def _make_state(prog_val_scores, evaluator=None):
     state.increment_evals = lambda count: setattr(state, "total_num_evals", state.total_num_evals + count)
 
     # Add cached_evaluate method to match GEPAState interface (no caching for stubs)
-    def cached_evaluate(candidate, example_ids, fetcher, eval_fn):
+    def cached_evaluate(candidate, example_ids, fetcher, eval_fn, split=None):
         _, scores, _ = eval_fn(fetcher(example_ids), candidate)
         return scores, len(example_ids)
 
     state.cached_evaluate = cached_evaluate
 
     # Add cached_evaluate_full method to match GEPAState interface (no caching for stubs)
-    def cached_evaluate_full(candidate, example_ids, fetcher, eval_fn):
+    def cached_evaluate_full(candidate, example_ids, fetcher, eval_fn, split=None):
         outputs, scores, obj_scores = eval_fn(fetcher(example_ids), candidate)
         outputs_by_id = dict(zip(example_ids, outputs, strict=False))
         scores_by_id = dict(zip(example_ids, scores, strict=False))

--- a/tests/test_evaluation_cache.py
+++ b/tests/test_evaluation_cache.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from gepa.core.state import EvaluationCache
+from gepa.core.state import TRAINSET_CACHE_SPLIT, EvaluationCache
 
 # RECORDER_DIR paths for cached tests (imported lazily to avoid module conflicts)
 # Source: tests/test_aime_prompt_optimization/test_aime_prompt_optimize.py
@@ -22,13 +22,13 @@ class TestEvaluationCache:
     def test_empty_cache_returns_none(self):
         """Get on empty cache should return None."""
         cache: EvaluationCache = EvaluationCache()
-        assert cache.get({"prompt": "test"}, "example_1") is None
+        assert cache.get({"prompt": "test"}, "example_1", split=TRAINSET_CACHE_SPLIT) is None
 
     def test_put_and_get_basic(self):
         """Basic put and get functionality."""
         cache: EvaluationCache = EvaluationCache()
-        cache.put({"prompt": "test"}, "example_1", "output1", 0.8)
-        result = cache.get({"prompt": "test"}, "example_1")
+        cache.put({"prompt": "test"}, "example_1", "output1", 0.8, split=TRAINSET_CACHE_SPLIT)
+        result = cache.get({"prompt": "test"}, "example_1", split=TRAINSET_CACHE_SPLIT)
         assert result is not None
         assert result.output == "output1"
         assert result.score == 0.8
@@ -37,26 +37,26 @@ class TestEvaluationCache:
         """Different examples should have separate cache entries."""
         cache: EvaluationCache = EvaluationCache()
         candidate = {"prompt": "test"}
-        cache.put(candidate, "ex1", "out1", 0.5)
-        cache.put(candidate, "ex2", "out2", 0.7)
-        assert cache.get(candidate, "ex1").output == "out1"
-        assert cache.get(candidate, "ex2").output == "out2"
+        cache.put(candidate, "ex1", "out1", 0.5, split=TRAINSET_CACHE_SPLIT)
+        cache.put(candidate, "ex2", "out2", 0.7, split=TRAINSET_CACHE_SPLIT)
+        assert cache.get(candidate, "ex1", split=TRAINSET_CACHE_SPLIT).output == "out1"
+        assert cache.get(candidate, "ex2", split=TRAINSET_CACHE_SPLIT).output == "out2"
 
     def test_different_candidates_separate_entries(self):
         """Different candidates should have separate cache entries."""
         cache: EvaluationCache = EvaluationCache()
-        cache.put({"prompt": "test1"}, "ex1", "out1", 0.5)
-        cache.put({"prompt": "test2"}, "ex1", "out2", 0.7)
-        assert cache.get({"prompt": "test1"}, "ex1").output == "out1"
-        assert cache.get({"prompt": "test2"}, "ex1").output == "out2"
+        cache.put({"prompt": "test1"}, "ex1", "out1", 0.5, split=TRAINSET_CACHE_SPLIT)
+        cache.put({"prompt": "test2"}, "ex1", "out2", 0.7, split=TRAINSET_CACHE_SPLIT)
+        assert cache.get({"prompt": "test1"}, "ex1", split=TRAINSET_CACHE_SPLIT).output == "out1"
+        assert cache.get({"prompt": "test2"}, "ex1", split=TRAINSET_CACHE_SPLIT).output == "out2"
 
     def test_get_batch(self):
         """Test batch get functionality."""
         cache: EvaluationCache = EvaluationCache()
         candidate = {"prompt": "test"}
-        cache.put(candidate, "ex1", "out1", 0.5)
-        cache.put(candidate, "ex2", "out2", 0.6)
-        cached_results, uncached_ids = cache.get_batch(candidate, ["ex1", "ex2", "ex3"])
+        cache.put(candidate, "ex1", "out1", 0.5, split=TRAINSET_CACHE_SPLIT)
+        cache.put(candidate, "ex2", "out2", 0.6, split=TRAINSET_CACHE_SPLIT)
+        cached_results, uncached_ids = cache.get_batch(candidate, ["ex1", "ex2", "ex3"], split=TRAINSET_CACHE_SPLIT)
         assert "ex1" in cached_results and "ex2" in cached_results
         assert uncached_ids == ["ex3"]
 
@@ -64,9 +64,16 @@ class TestEvaluationCache:
         """Test batch put functionality."""
         cache: EvaluationCache = EvaluationCache()
         candidate = {"prompt": "test"}
-        cache.put_batch(candidate, ["ex1", "ex2"], ["out1", "out2"], [0.5, 0.6], [{"acc": 0.9}, {"acc": 0.8}])
-        assert cache.get(candidate, "ex1").score == 0.5
-        assert cache.get(candidate, "ex2").objective_scores == {"acc": 0.8}
+        cache.put_batch(
+            candidate,
+            ["ex1", "ex2"],
+            ["out1", "out2"],
+            [0.5, 0.6],
+            [{"acc": 0.9}, {"acc": 0.8}],
+            split=TRAINSET_CACHE_SPLIT,
+        )
+        assert cache.get(candidate, "ex1", split=TRAINSET_CACHE_SPLIT).score == 0.5
+        assert cache.get(candidate, "ex2", split=TRAINSET_CACHE_SPLIT).objective_scores == {"acc": 0.8}
 
 
 class TestEvaluationCacheIntegration:

--- a/tests/test_evaluation_cache.py
+++ b/tests/test_evaluation_cache.py
@@ -75,6 +75,19 @@ class TestEvaluationCache:
         assert cache.get(candidate, "ex1", split=TRAINSET_CACHE_SPLIT).score == 0.5
         assert cache.get(candidate, "ex2", split=TRAINSET_CACHE_SPLIT).objective_scores == {"acc": 0.8}
 
+    def test_split_is_required(self):
+        """Omitting split must be a TypeError, not a silent trainset lookup."""
+        cache: EvaluationCache = EvaluationCache()
+        with pytest.raises(TypeError):
+            cache.get({"prompt": "test"}, "ex1")
+        with pytest.raises(TypeError):
+            cache.put({"prompt": "test"}, "ex1", "out", 0.5)
+
+    def test_unknown_split_is_rejected(self):
+        cache: EvaluationCache = EvaluationCache()
+        with pytest.raises(ValueError, match="Unknown evaluation-cache split"):
+            cache.put({"prompt": "test"}, "ex1", "out", 0.5, split="holdout")
+
 
 class TestEvaluationCacheIntegration:
     """Integration tests for evaluation cache with optimize function."""

--- a/tests/test_valset_cache_split.py
+++ b/tests/test_valset_cache_split.py
@@ -10,9 +10,22 @@ rollout of the unrelated trainset example sitting at the same position.
 """
 
 import collections
+import contextlib
 import json
 
-from gepa.core.state import TRAINSET_CACHE_SPLIT, VALSET_CACHE_SPLIT, EvaluationCache
+import pytest
+
+import gepa
+from gepa.core.engine import GEPAEngine
+from gepa.core.state import (
+    TRAINSET_CACHE_SPLIT,
+    VALSET_CACHE_SPLIT,
+    CachedEvaluation,
+    EvaluationCache,
+    GEPAState,
+    ValsetEvaluation,
+    _candidate_hash,
+)
 from gepa.gepa_launcher import EngineConfig, GEPAConfig, ReflectionConfig, optimize_anything
 
 TRAIN = [{"content": f"train-{n}"} for n in range(12)]
@@ -122,10 +135,92 @@ def test_cache_split_isolates_identical_example_ids():
     assert cache.get(candidate, 0, split=VALSET_CACHE_SPLIT).output == "val rollout"
 
 
-def test_default_split_keeps_the_legacy_key_shape():
-    """Caches persisted before splits existed stay readable on resume."""
+def test_every_key_carries_its_split():
+    """Including the trainset one: an unnamespaced key can never be served again."""
     cache: EvaluationCache = EvaluationCache()
     cache.put({"text": "c"}, 7, "rollout", 1.0)
 
     (key,) = cache._cache
-    assert len(key) == 2, f"default split changed the persisted key shape: {key}"
+    assert key[1] == TRAINSET_CACHE_SPLIT, f"trainset key is not namespaced: {key}"
+
+
+def test_caches_written_before_splits_are_dropped_on_resume(tmp_path):
+    """A pre-split cache is already contaminated, so resume must not carry it forward."""
+    cache: EvaluationCache = EvaluationCache()
+    candidate = {"text": "c"}
+    cache.put(candidate, 0, "train rollout", 1.0)
+    # What earlier versions wrote: no namespace, so a valset rollout landed on the trainset key.
+    cache._cache[(_candidate_hash(candidate), 0)] = CachedEvaluation("val rollout", 0.0, None)
+
+    state = _seeded_state(cache)
+    state.save(str(tmp_path))
+    reloaded = GEPAState.load(str(tmp_path))
+
+    assert reloaded.evaluation_cache is not None
+    assert all(len(key) == 3 for key in reloaded.evaluation_cache._cache), "pre-split entries survived resume"
+    assert reloaded.evaluation_cache.get(candidate, 0).output == "train rollout"
+
+
+def _seeded_state(cache: EvaluationCache) -> GEPAState:
+    return GEPAState(
+        {"text": "c"},
+        ValsetEvaluation(outputs_by_val_id={0: "o"}, scores_by_val_id={0: 1.0}),
+        evaluation_cache=cache,
+    )
+
+
+class _StubAdapter:
+    """Never actually evaluated: the engine is intercepted before it runs."""
+
+    def evaluate(self, batch, candidate, capture_traces=False):
+        raise AssertionError("the engine should have been intercepted before evaluating")
+
+    def make_reflective_dataset(self, candidate, eval_batch, components_to_update):
+        return {name: [] for name in components_to_update}
+
+    def propose_new_texts(self, candidate, reflective_dataset, components_to_update):
+        return dict.fromkeys(components_to_update, "x")
+
+
+def _splits_used_by_optimize(monkeypatch, valset):
+    """Return (engine split, merge split) that ``gepa.optimize`` wires up."""
+    captured = {}
+
+    def fake_run(self):
+        captured["engine"] = self.valset_cache_split
+        captured["merge"] = self.merge_proposer.valset_cache_split
+        raise _Intercepted
+
+    monkeypatch.setattr(GEPAEngine, "run", fake_run)
+    with contextlib.suppress(_Intercepted):
+        gepa.optimize(
+            seed_candidate={"p": "seed"},
+            trainset=TRAIN,
+            valset=valset,
+            adapter=_StubAdapter(),
+            max_metric_calls=10,
+            use_merge=True,
+            cache_evaluation=True,
+            display_progress_bar=False,
+        )
+    return captured["engine"], captured["merge"]
+
+
+class _Intercepted(Exception):
+    pass
+
+
+@pytest.mark.parametrize(
+    ("valset", "expected"),
+    [
+        (None, TRAINSET_CACHE_SPLIT),  # one loader for both: ids agree, keep sharing rollouts
+        (TRAIN, TRAINSET_CACHE_SPLIT),  # same dataset passed twice: still one id space
+        (VAL, VALSET_CACHE_SPLIT),  # distinct valset: must not read trainset rollouts
+    ],
+)
+def test_optimize_gives_engine_and_merge_the_same_split(monkeypatch, valset, expected):
+    """A split the merge proposer disagrees with silently re-runs cached valset examples."""
+    engine_split, merge_split = _splits_used_by_optimize(monkeypatch, valset)
+
+    assert engine_split == expected
+    assert merge_split == engine_split, "merge proposer and engine disagree on the valset namespace"

--- a/tests/test_valset_cache_split.py
+++ b/tests/test_valset_cache_split.py
@@ -26,7 +26,7 @@ from gepa.core.state import (
     ValsetEvaluation,
     _candidate_hash,
 )
-from gepa.gepa_launcher import EngineConfig, GEPAConfig, ReflectionConfig, optimize_anything
+from gepa.gepa_launcher import EngineConfig, GEPAConfig, MergeConfig, ReflectionConfig, optimize_anything
 
 TRAIN = [{"content": f"train-{n}"} for n in range(12)]
 VAL = [{"content": f"val-{n}"} for n in range(6)]
@@ -135,6 +135,17 @@ def test_cache_split_isolates_identical_example_ids():
     assert cache.get(candidate, 0, split=VALSET_CACHE_SPLIT).output == "val rollout"
 
 
+def test_drop_unsplit_entries_removes_unknown_splits():
+    """A 3-tuple with an unknown split string is as unusable as a 2-tuple."""
+    cache: EvaluationCache = EvaluationCache()
+    candidate = {"text": "c"}
+    cache.put(candidate, 0, "ok", 1.0, split=TRAINSET_CACHE_SPLIT)
+    cache._cache[(_candidate_hash(candidate), "holdout", 0)] = CachedEvaluation("x", 0.0, None)
+
+    assert cache.drop_unsplit_entries() == 1
+    assert cache.get(candidate, 0, split=TRAINSET_CACHE_SPLIT).output == "ok"
+
+
 def test_every_key_carries_its_split():
     """Including the trainset one: an unnamespaced key can never be served again."""
     cache: EvaluationCache = EvaluationCache()
@@ -157,8 +168,23 @@ def test_caches_written_before_splits_are_dropped_on_resume(tmp_path):
     reloaded = GEPAState.load(str(tmp_path))
 
     assert reloaded.evaluation_cache is not None
-    assert all(len(key) == 3 for key in reloaded.evaluation_cache._cache), "pre-split entries survived resume"
+    assert all(EvaluationCache._is_split_key(key) for key in reloaded.evaluation_cache._cache)
     assert reloaded.evaluation_cache.get(candidate, 0, split=TRAINSET_CACHE_SPLIT).output == "train rollout"
+
+
+def test_pure_pre_split_cache_is_emptied_on_resume(tmp_path):
+    """A cache that is only 2-tuple keys has nothing safe to keep."""
+    cache: EvaluationCache = EvaluationCache()
+    candidate = {"text": "c"}
+    cache._cache[(_candidate_hash(candidate), 0)] = CachedEvaluation("legacy rollout", 0.5, None)
+
+    state = _seeded_state(cache)
+    state.save(str(tmp_path))
+    reloaded = GEPAState.load(str(tmp_path))
+
+    assert reloaded.evaluation_cache is not None
+    assert reloaded.evaluation_cache._cache == {}
+    assert reloaded.evaluation_cache.get(candidate, 0, split=TRAINSET_CACHE_SPLIT) is None
 
 
 def _seeded_state(cache: EvaluationCache) -> GEPAState:
@@ -210,17 +236,60 @@ class _Intercepted(Exception):
     pass
 
 
+def _splits_used_by_optimize_anything(monkeypatch, valset):
+    """Return (engine split, merge split) that ``optimize_anything`` wires up."""
+    captured = {}
+
+    def fake_run(self):
+        captured["engine"] = self.valset_cache_split
+        captured["merge"] = None if self.merge_proposer is None else self.merge_proposer.valset_cache_split
+        raise _Intercepted
+
+    monkeypatch.setattr(GEPAEngine, "run", fake_run)
+    with contextlib.suppress(_Intercepted):
+        optimize_anything(
+            seed_candidate=json.dumps({"text": "seed"}),
+            evaluator=lambda candidate, example: (0.0, {}),
+            dataset=TRAIN,
+            valset=valset,
+            objective="valset cache split wiring",
+            config=GEPAConfig(
+                engine=EngineConfig(max_metric_calls=10, display_progress_bar=False, cache_evaluation=True),
+                reflection=ReflectionConfig(reflection_lm=lambda _prompt: json.dumps({"text": "x"})),
+                merge=MergeConfig(max_merge_invocations=1),
+            ),
+        )
+    return captured["engine"], captured["merge"]
+
+
 @pytest.mark.parametrize(
     ("valset", "expected"),
     [
         (None, TRAINSET_CACHE_SPLIT),  # one loader for both: ids agree, keep sharing rollouts
         (TRAIN, TRAINSET_CACHE_SPLIT),  # same dataset passed twice: still one id space
         (VAL, VALSET_CACHE_SPLIT),  # distinct valset: must not read trainset rollouts
+        (list(TRAIN), VALSET_CACHE_SPLIT),  # equal copy: different object, isolate
     ],
 )
 def test_optimize_gives_engine_and_merge_the_same_split(monkeypatch, valset, expected):
     """A split the merge proposer disagrees with silently re-runs cached valset examples."""
     engine_split, merge_split = _splits_used_by_optimize(monkeypatch, valset)
+
+    assert engine_split == expected
+    assert merge_split == engine_split, "merge proposer and engine disagree on the valset namespace"
+
+
+@pytest.mark.parametrize(
+    ("valset", "expected"),
+    [
+        (None, TRAINSET_CACHE_SPLIT),
+        (TRAIN, TRAINSET_CACHE_SPLIT),
+        (VAL, VALSET_CACHE_SPLIT),
+        (list(TRAIN), VALSET_CACHE_SPLIT),
+    ],
+)
+def test_optimize_anything_gives_engine_and_merge_the_same_split(monkeypatch, valset, expected):
+    engine_split, merge_split = _splits_used_by_optimize_anything(monkeypatch, valset)
 
     assert engine_split == expected
     assert merge_split == engine_split, "merge proposer and engine disagree on the valset namespace"

--- a/tests/test_valset_cache_split.py
+++ b/tests/test_valset_cache_split.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
+# https://github.com/gepa-ai/gepa
+
+"""Tests that a separate valset does not share evaluation-cache keys with the trainset.
+
+Data loaders identify examples by position, so a trainset and a distinct valset both number their
+examples from zero. The evaluation cache is keyed by candidate and example id, the valset path reads
+it and the minibatch path writes it, so without a namespace a valset lookup can be answered by the
+rollout of the unrelated trainset example sitting at the same position.
+"""
+
+import collections
+import json
+
+from gepa.core.state import TRAINSET_CACHE_SPLIT, VALSET_CACHE_SPLIT, EvaluationCache
+from gepa.gepa_launcher import EngineConfig, GEPAConfig, ReflectionConfig, optimize_anything
+
+TRAIN = [{"content": f"train-{n}"} for n in range(12)]
+VAL = [{"content": f"val-{n}"} for n in range(6)]
+
+
+def _candidate_tag(candidate: dict[str, str]) -> str:
+    return json.loads(next(iter(candidate.values())))["text"]
+
+
+def _run(dataset, valset, produced_by):
+    """Run a short optimization, recording which example produced each valset slot's score."""
+    slot_of = {example["content"]: slot for slot, example in enumerate(valset or [])}
+
+    def evaluator(candidate: str, example: dict[str, str]):
+        tag = json.loads(candidate)["text"]
+        content = example["content"]
+        if content in slot_of:
+            produced_by[tag][slot_of[content]] = content
+        # Monotonically improving candidates, so children are accepted and trigger valset evals.
+        score = 0.1 * (int(tag.split("-")[-1]) + 1 if tag != "seed" else 0)
+        return score, {"ran": content}
+
+    counter = iter(range(1000))
+    optimize_anything(
+        seed_candidate=json.dumps({"text": "seed"}),
+        evaluator=evaluator,
+        dataset=dataset,
+        valset=valset,
+        objective="valset cache split regression",
+        config=GEPAConfig(
+            engine=EngineConfig(
+                max_metric_calls=200,
+                max_candidate_proposals=5,
+                display_progress_bar=False,
+                cache_evaluation=True,
+            ),
+            reflection=ReflectionConfig(
+                reflection_lm=lambda _prompt: json.dumps({"text": f"cand-{next(counter)}"}),
+                reflection_minibatch_size=4,
+            ),
+        ),
+    )
+
+
+def _record_cache_hits(monkeypatch, produced_by):
+    """Attribute every cache hit to the example whose rollout was stored under that key."""
+    get_batch = EvaluationCache.get_batch
+
+    def instrumented(self, candidate, example_ids, *args, **kwargs):
+        cached, uncached = get_batch(self, candidate, example_ids, *args, **kwargs)
+        for slot, entry in cached.items():
+            parts = entry.output if isinstance(entry.output, tuple) else (entry.output,)
+            ran = next((part["ran"] for part in parts if isinstance(part, dict) and "ran" in part), "?")
+            produced_by[_candidate_tag(candidate)][slot] = ran
+        return cached, uncached
+
+    monkeypatch.setattr(EvaluationCache, "get_batch", instrumented)
+
+
+def test_valset_slots_are_never_filled_by_trainset_rollouts(monkeypatch):
+    """Every valset score must come from the valset example that owns that slot."""
+    produced_by = collections.defaultdict(dict)
+    _record_cache_hits(monkeypatch, produced_by)
+
+    _run(TRAIN, VAL, produced_by)
+
+    assert produced_by, "no candidate was ever evaluated against the valset"
+    leaked = {
+        tag: {slot: content for slot, content in slots.items() if not content.startswith("val-")}
+        for tag, slots in produced_by.items()
+    }
+    offenders = {tag: slots for tag, slots in leaked.items() if slots}
+    assert not offenders, f"valset slots served by trainset rollouts: {offenders}"
+
+    for tag, slots in produced_by.items():
+        for slot, content in slots.items():
+            assert content == VAL[slot]["content"], f"{tag} slot {slot} was produced by {content}"
+
+
+def test_shared_valset_still_reuses_trainset_rollouts(monkeypatch):
+    """When the valset is the trainset the ids agree, so caching must still be shared."""
+    hits: list[int] = []
+    get_batch = EvaluationCache.get_batch
+
+    def instrumented(self, candidate, example_ids, *args, **kwargs):
+        cached, uncached = get_batch(self, candidate, example_ids, *args, **kwargs)
+        hits.append(len(cached))
+        return cached, uncached
+
+    monkeypatch.setattr(EvaluationCache, "get_batch", instrumented)
+    _run(TRAIN, None, collections.defaultdict(dict))
+
+    assert sum(hits) > 0, "valset evaluation stopped reusing minibatch rollouts of the same examples"
+
+
+def test_cache_split_isolates_identical_example_ids():
+    """Unit-level: the same id in two splits must not collide."""
+    cache: EvaluationCache = EvaluationCache()
+    candidate = {"text": "c"}
+
+    cache.put(candidate, 0, "train rollout", 1.0, split=TRAINSET_CACHE_SPLIT)
+    assert cache.get(candidate, 0, split=VALSET_CACHE_SPLIT) is None
+
+    cache.put(candidate, 0, "val rollout", 0.0, split=VALSET_CACHE_SPLIT)
+    assert cache.get(candidate, 0, split=TRAINSET_CACHE_SPLIT).output == "train rollout"
+    assert cache.get(candidate, 0, split=VALSET_CACHE_SPLIT).output == "val rollout"
+
+
+def test_default_split_keeps_the_legacy_key_shape():
+    """Caches persisted before splits existed stay readable on resume."""
+    cache: EvaluationCache = EvaluationCache()
+    cache.put({"text": "c"}, 7, "rollout", 1.0)
+
+    (key,) = cache._cache
+    assert len(key) == 2, f"default split changed the persisted key shape: {key}"

--- a/tests/test_valset_cache_split.py
+++ b/tests/test_valset_cache_split.py
@@ -138,7 +138,7 @@ def test_cache_split_isolates_identical_example_ids():
 def test_every_key_carries_its_split():
     """Including the trainset one: an unnamespaced key can never be served again."""
     cache: EvaluationCache = EvaluationCache()
-    cache.put({"text": "c"}, 7, "rollout", 1.0)
+    cache.put({"text": "c"}, 7, "rollout", 1.0, split=TRAINSET_CACHE_SPLIT)
 
     (key,) = cache._cache
     assert key[1] == TRAINSET_CACHE_SPLIT, f"trainset key is not namespaced: {key}"
@@ -148,7 +148,7 @@ def test_caches_written_before_splits_are_dropped_on_resume(tmp_path):
     """A pre-split cache is already contaminated, so resume must not carry it forward."""
     cache: EvaluationCache = EvaluationCache()
     candidate = {"text": "c"}
-    cache.put(candidate, 0, "train rollout", 1.0)
+    cache.put(candidate, 0, "train rollout", 1.0, split=TRAINSET_CACHE_SPLIT)
     # What earlier versions wrote: no namespace, so a valset rollout landed on the trainset key.
     cache._cache[(_candidate_hash(candidate), 0)] = CachedEvaluation("val rollout", 0.0, None)
 
@@ -158,7 +158,7 @@ def test_caches_written_before_splits_are_dropped_on_resume(tmp_path):
 
     assert reloaded.evaluation_cache is not None
     assert all(len(key) == 3 for key in reloaded.evaluation_cache._cache), "pre-split entries survived resume"
-    assert reloaded.evaluation_cache.get(candidate, 0).output == "train rollout"
+    assert reloaded.evaluation_cache.get(candidate, 0, split=TRAINSET_CACHE_SPLIT).output == "train rollout"
 
 
 def _seeded_state(cache: EvaluationCache) -> GEPAState:


### PR DESCRIPTION
Fixes #424.

## The bug

Data loaders identify examples by position (`ListDataLoader.all_ids()` returns `range(len(items))`), and a separate valset gets its own loader that also numbers from zero. `EvaluationCache` is keyed `(candidate_hash, example_id)`, the valset path reads it (`core/engine.py`) and the minibatch path only writes it (`reflective_mutation.py`), so a valset lookup could be served by the rollout of the unrelated trainset example at the same position.

The result is a full valset score vector for candidates that never ran some of those examples — and because those per-instance scores land in `prog_candidate_val_subscores` and `program_at_pareto_front_valset`, they also feed parent selection, which samples proportionally to frontier appearances.

This only affects the **Generalization** mode (`dataset=<list>, valset=<list>`). With `valset=None` the launcher already passes the same loader for both, so the shared id space is correct and the cache is doing the right thing.

## The fix

Cache reads and writes take a `split`. The launcher decides it once, where both loaders are in scope:

```python
valset_cache_split = TRAINSET_CACHE_SPLIT if val_loader is train_loader else VALSET_CACHE_SPLIT
```

- **Distinct valset** → valset entries get their own namespace and can no longer collide with minibatch entries.
- **`valset=None`** → both sides use the same split, the ids genuinely refer to the same examples, and cached rollouts are still shared across minibatch and valset evaluation. This is deliberate: namespacing unconditionally would have cost real evaluations in the default mode.

`GEPAEngine` also derives the split itself when it is not passed, so callers that build the engine directly get the safe behaviour without changes.

### Backwards compatibility

`_key()` returns the previous two-element key for the default split, so evaluation caches persisted by earlier versions stay readable on resume. Valset entries written before this change are simply not reused (they are the contaminated ones).

The only signature changes are new trailing parameters with defaults, on `EvaluationCache.get/put/get_batch/put_batch/evaluate_with_cache_full` and `GEPAState.cached_evaluate/cached_evaluate_full`.

## Tests

`tests/test_valset_cache_split.py`:

- `test_valset_slots_are_never_filled_by_trainset_rollouts` — the regression test. Runs a short optimization with a distinct valset and asserts every valset slot's score came from the valset example that owns it. Against unpatched `main` it fails with the leak spelled out:

  ```
  AssertionError: valset slots served by trainset rollouts:
    {'cand-0': {1: 'train-1', 5: 'train-5'}, 'cand-1': {2: 'train-2', 3: 'train-3'},
     'cand-2': {0: 'train-0', 4: 'train-4'}, 'cand-3': {3: 'train-3'},
     'cand-4': {0: 'train-0', 5: 'train-5'}}
  ```

  The collision is positional, and GEPA's own log reported `coverage 6 / 6` for those candidates — which is what made this silent.

- `test_shared_valset_still_reuses_trainset_rollouts` — guards the other direction: with `valset=None`, cache hits must still occur. This one **passes on unpatched `main` too**, so it fails if the fix is ever tightened into "namespace everything".

- Two unit tests covering the key isolation and the preserved legacy key shape.

The mock examples deliberately carry no `id` key and use `{"content": "train-N"}`, so the output distinguishes GEPA's example ids (positions) from example contents.

`uv run pytest`: 673 passed, 4 skipped. `ruff check` and `pyright` clean on the touched files. One existing test double in `tests/proposer/test_merge.py` needed the new optional parameter.
