### PR TITLE
Fix trace capture for accepted-candidate full-val evaluation

### DIFF
--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -9,11 +9,9 @@ from typing import Any, Generic
 
 from gepa.core.adapter import (
     DataInst,
-    EvaluationBatch,
     GEPAAdapter,
     RolloutOutput,
     Trajectory,
-    default_batch_evaluate,
 )
 from gepa.core.callbacks import (
     BudgetUpdatedEvent,
@@ -253,13 +251,11 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         programs: list[dict[str, str]],
         state: GEPAState[RolloutOutput, DataId],
     ) -> list[tuple[ValsetEvaluation[RolloutOutput, DataId], int]]:
-        """Evaluate candidates on the valset, read-only, via ``adapter.batch_evaluate``.
+        """Evaluate candidates on the valset, read-only, without capturing traces.
 
-        Cache-miss examples across all candidates go out in one batched call, so
-        parallelism (if any) is the adapter's. Honors the eval cache and
-        ``val_evaluation_policy``. Returns each evaluation with its metric-call
-        count (cache misses); the budget is incremented later in
-        :meth:`_add_evaluated_program`, not here.
+        Honors the eval cache and ``val_evaluation_policy``. Returns each
+        evaluation with its metric-call count (cache misses); the budget is
+        incremented later in :meth:`_add_evaluated_program`, not here.
         """
         valset = self.valset
         assert valset is not None
@@ -309,10 +305,10 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             cached_per.append(cached)
             todo_per.append(uncached)
 
-        # 2) One adapter call over every (program, cache-miss examples) pair.
+        # 2) Evaluate each program's cache-miss examples without capturing traces.
         eval_idxs = [i for i, todo in enumerate(todo_per) if todo]
         items = [(programs[i], valset.fetch(todo_per[i])) for i in eval_idxs]
-        fresh = self._batch_evaluate(items) if items else []
+        fresh = [self.adapter.evaluate(batch, program, capture_traces=False) for program, batch in items]
         fresh_by_idx = dict(zip(eval_idxs, fresh, strict=True))
 
         # 3) Merge cached + fresh per program, repopulating the cache.
@@ -352,13 +348,6 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                 )
             )
         return results
-
-    def _batch_evaluate(self, items: list[tuple[dict[str, str], list]]) -> list[EvaluationBatch]:
-        """Evaluate (candidate, batch) pairs via the adapter's batch_evaluate or fallback."""
-        batch_fn = getattr(self.adapter, "batch_evaluate", None)
-        if batch_fn is not None:
-            return batch_fn(items)
-        return default_batch_evaluate(self.adapter, items)
 
     def _run_full_eval_and_add(
         self,
@@ -648,7 +637,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                 trace_entry["proposal_accepted"] = False
             return False
 
-        # 3) Full-valset eval of the selected candidates (one batched, read-only call).
+        # 3) Full-valset eval of the selected candidates (read-only, without traces).
         valset_evals = self._evaluate_programs_on_valset([p.candidate for p in selected], state)
 
         # 4) Add each selected candidate to the pool, in order.

--- a/tests/test_parallel_valset_eval.py
+++ b/tests/test_parallel_valset_eval.py
@@ -1,12 +1,10 @@
 # Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
 # https://github.com/gepa-ai/gepa
 
-"""End-to-end test for batched full-valset eval of multiple accepted candidates.
+"""End-to-end tests for evaluating multiple accepted candidates.
 
 A multi-proposal sampler (``IndependentSampling``) can accept several candidates
-in one iteration. Their full-valset evaluations are batched into a single
-``adapter.batch_evaluate`` call (where any parallelism lives), while the engine
-stays single-threaded and pool/Pareto mutation stays sequential.
+in one iteration while the engine keeps pool/Pareto mutation sequential.
 """
 
 from gepa.core.adapter import EvaluationBatch
@@ -41,11 +39,16 @@ class ImprovingAdapter:
 
 
 class BatchImprovingAdapter(ImprovingAdapter):
-    """Adds a real ``batch_evaluate`` and records the items of each call."""
+    """Records trace behavior across direct and batched evaluations."""
 
     def __init__(self):
         super().__init__()
         self.batch_calls: list[int] = []
+        self.evaluate_calls: list[tuple[str, str, bool]] = []
+
+    def evaluate(self, batch, candidate, capture_traces=False):
+        self.evaluate_calls.append((batch[0]["split"], candidate["system_prompt"], capture_traces))
+        return super().evaluate(batch, candidate, capture_traces)
 
     def batch_evaluate(self, items):
         self.batch_calls.append(len(items))
@@ -57,8 +60,8 @@ def _run(adapter, sampling_strategy, tmp_path):
 
     return gepa.optimize(
         seed_candidate={"system_prompt": "s"},
-        trainset=[{"id": i} for i in range(4)],
-        valset=[{"id": i} for i in range(4)],
+        trainset=[{"id": i, "split": "train"} for i in range(4)],
+        valset=[{"id": i, "split": "val"} for i in range(4)],
         adapter=adapter,
         max_metric_calls=300,
         reflection_lm=None,
@@ -79,14 +82,16 @@ def test_multiple_candidates_accepted_and_evaluated_in_one_iteration(tmp_path):
     assert max(result.val_aggregate_scores) >= result.val_aggregate_scores[0]
 
 
-def test_accepted_candidates_share_one_batch_evaluate_call(tmp_path):
-    """When the adapter implements batch_evaluate, the valset evals of all
-    candidates accepted in one iteration go out as a single batched call."""
+def test_val_evaluations_are_trace_free_while_reflective_evaluations_are_traced(tmp_path):
     adapter = BatchImprovingAdapter()
-    result = _run(adapter, IndependentSampling(3), tmp_path)
-    assert len(result.candidates) > 2
-    # At least one iteration batched several candidates into one batch_evaluate call.
-    assert any(n > 1 for n in adapter.batch_calls)
+    _run(adapter, SingleMutationSampling(), tmp_path)
+
+    seed_prompt = "s"
+    accepted_prompts = {candidate for split, candidate, _ in adapter.evaluate_calls if split == "val"} - {seed_prompt}
+    assert accepted_prompts
+    assert all(not capture_traces for split, _, capture_traces in adapter.evaluate_calls if split == "val")
+    assert all(capture_traces for split, _, capture_traces in adapter.evaluate_calls if split == "train")
+    assert adapter.batch_calls
 
 
 def test_single_mutation_still_works(tmp_path):


### PR DESCRIPTION
## Summary

- evaluate accepted candidates' full validation sets with `capture_traces=False`
- keep reflective minibatch evaluation traced and batched
- add regression coverage for trace behavior across validation and reflection

Fixes #428.

## Test

- `uv run --frozen pytest tests/test_parallel_valset_eval.py` (3 passed)
