### PR TITLE
Fix trace-aware batch evaluation for accepted candidates

### DIFF
--- a/docs/docs/guides/parallel-proposals.md
+++ b/docs/docs/guides/parallel-proposals.md
@@ -107,14 +107,12 @@ class MyAdapter:
         ...  # e.g. fan out across threads, processes, or an eval service
 ```
 
-Reflective minibatches pass `capture_traces=True`; seed and accepted-candidate
-full-val batches pass `False`. Existing batch adapters must accept this keyword;
-adapters implementing only `evaluate()` continue using the sequential fallback.
-
-With `write_agent_state=True`, full-val evaluation intentionally remains traced
-and sequential. The reflection LM side is batched analogously: the built-in
-stateless reflector batches all per-component reflection calls via
-`litellm.batch_completion`.
+Third-party adapters that only implement `evaluate()` keep working unmodified
+(`default_batch_evaluate` is the sequential fallback). Batch adapters receive
+`capture_traces=True` for reflection and `False` for seed and accepted-candidate
+full-val evaluation, so existing implementations must accept the new keyword.
+The reflection LM side is batched analogously: the built-in stateless reflector
+batches all per-component reflection calls via `litellm.batch_completion`.
 
 ### `batch_evaluator`: one external call for the whole batch
 

--- a/docs/docs/guides/parallel-proposals.md
+++ b/docs/docs/guides/parallel-proposals.md
@@ -112,6 +112,11 @@ full-val batches pass `False`. Adapters implementing the older one-argument
 `batch_evaluate(items)` contract must add the keyword argument. Adapter
 exceptions propagate without retry.
 
+The same rule applies to direct `evaluate()` calls, whose `capture_traces`
+default is `False`: scores and outputs are always returned, while trajectories
+are returned only when explicitly requested. `OptimizeAnythingAdapter` now
+follows this contract instead of always returning its `side_info` as trajectories.
+
 With `write_agent_state=True`, full-val evaluation intentionally remains traced
 and sequential. The reflection LM side is batched analogously: the built-in
 stateless reflector batches all per-component reflection calls via

--- a/docs/docs/guides/parallel-proposals.md
+++ b/docs/docs/guides/parallel-proposals.md
@@ -108,9 +108,9 @@ class MyAdapter:
 ```
 
 Reflective parent/child minibatches pass `capture_traces=True`; accepted-candidate
-full-val batches pass `False`. Legacy one-argument `batch_evaluate` adapters keep
-reflective batching but use the ordered, sequential, trace-free fallback for
-full-val evaluation. Adapter exceptions propagate without retry.
+full-val batches pass `False`. Adapters implementing the older one-argument
+`batch_evaluate(items)` contract must add the keyword argument. Adapter
+exceptions propagate without retry.
 
 With `write_agent_state=True`, full-val evaluation intentionally remains traced
 and sequential. The reflection LM side is batched analogously: the built-in

--- a/docs/docs/guides/parallel-proposals.md
+++ b/docs/docs/guides/parallel-proposals.md
@@ -107,15 +107,9 @@ class MyAdapter:
         ...  # e.g. fan out across threads, processes, or an eval service
 ```
 
-Reflective parent/child minibatches pass `capture_traces=True`; accepted-candidate
-full-val batches pass `False`. Adapters implementing the older one-argument
-`batch_evaluate(items)` contract must add the keyword argument. Adapter
-exceptions propagate without retry.
-
-The same rule applies to direct `evaluate()` calls, whose `capture_traces`
-default is `False`: scores and outputs are always returned, while trajectories
-are returned only when explicitly requested. `OptimizeAnythingAdapter` now
-follows this contract instead of always returning its `side_info` as trajectories.
+Reflective minibatches pass `capture_traces=True`; seed and accepted-candidate
+full-val batches pass `False`. Existing batch adapters must accept this keyword;
+adapters implementing only `evaluate()` continue using the sequential fallback.
 
 With `write_agent_state=True`, full-val evaluation intentionally remains traced
 and sequential. The reflection LM side is batched analogously: the built-in

--- a/docs/docs/guides/parallel-proposals.md
+++ b/docs/docs/guides/parallel-proposals.md
@@ -103,14 +103,19 @@ class MyAdapter:
     def evaluate(self, batch, candidate, capture_traces=False): ...
 
     # Optional. When absent, GEPA calls evaluate() once per item.
-    def batch_evaluate(self, items: list[tuple[Candidate, list]]) -> list[EvaluationBatch]:
+    def batch_evaluate(self, items: list[tuple[Candidate, list]], *, capture_traces: bool = True) -> list[EvaluationBatch]:
         ...  # e.g. fan out across threads, processes, or an eval service
 ```
 
-Third-party adapters that only implement `evaluate()` keep working unmodified
-(`default_batch_evaluate` is the sequential fallback). The reflection LM side
-is batched analogously: the built-in stateless reflector batches all
-per-component reflection calls via `litellm.batch_completion`.
+Reflective parent/child minibatches pass `capture_traces=True`; accepted-candidate
+full-val batches pass `False`. Legacy one-argument `batch_evaluate` adapters keep
+reflective batching but use the ordered, sequential, trace-free fallback for
+full-val evaluation. Adapter exceptions propagate without retry.
+
+With `write_agent_state=True`, full-val evaluation intentionally remains traced
+and sequential. The reflection LM side is batched analogously: the built-in
+stateless reflector batches all per-component reflection calls via
+`litellm.batch_completion`.
 
 ### `batch_evaluator`: one external call for the whole batch
 

--- a/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
+++ b/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
@@ -382,12 +382,12 @@ class OptimizeAnythingAdapter(GEPAAdapter):
                 # batch_evaluator is the preferred transport for any multi-pair
                 # evaluation (valset evals, merge evals, seed evals) — one
                 # external call for the whole batch, cache-aware.
-                return self._batch_evaluate_via_user_fn([(candidate, batch)])[0]
+                return self._batch_evaluate_via_user_fn([(candidate, batch)], capture_traces=capture_traces)[0]
             if self.parallel and len(batch) > 1:
                 raw_results = self._evaluate_parallel(batch, candidate)
             else:
                 raw_results = [self._call_evaluator(candidate, example) for example in batch]
-            return self._assemble_no_refiner_batch(candidate, batch, raw_results)
+            return self._assemble_no_refiner_batch(candidate, batch, raw_results, capture_traces=capture_traces)
 
         # Refiner path: evaluate with refinement. eval_output is a list of
         # (score, output, side_info) where output = (score, best_candidate, side_info).
@@ -411,7 +411,7 @@ class OptimizeAnythingAdapter(GEPAAdapter):
         return EvaluationBatch(
             outputs=outputs,
             scores=scores,
-            trajectories=side_infos,
+            trajectories=side_infos if capture_traces else None,
             objective_scores=objective_scores,
             num_metric_calls=num_metric_calls,
         )
@@ -419,6 +419,8 @@ class OptimizeAnythingAdapter(GEPAAdapter):
     def batch_evaluate(
         self,
         items: list[tuple["Candidate", list]],
+        *,
+        capture_traces: bool = True,
     ) -> list[EvaluationBatch]:
         """Evaluate multiple (candidate, batch) pairs.
 
@@ -427,21 +429,23 @@ class OptimizeAnythingAdapter(GEPAAdapter):
         into a single call to the user's batch function.
 
         Falls back to sequential ``evaluate()`` calls for the refiner path or a
-        single item. Always captures traces. With ``refiner_config`` set,
+        single item. With ``refiner_config`` set,
         evaluation is per-example by construction (each example runs its own
         evaluate->refine->re-evaluate loop), so grouped calls degrade to
         singleton batches through ``_resolve_pair`` — refinement is never
         silently skipped.
         """
         if self._batch_evaluator is not None and self.refiner_config is None:
-            return self._batch_evaluate_via_user_fn(items)
+            return self._batch_evaluate_via_user_fn(items, capture_traces=capture_traces)
         if self.parallel and self.refiner_config is None and len(items) > 1:
-            return self._batch_evaluate_parallel_fallback(items)
-        return [self.evaluate(batch, candidate, capture_traces=True) for candidate, batch in items]
+            return self._batch_evaluate_parallel_fallback(items, capture_traces=capture_traces)
+        return [self.evaluate(batch, candidate, capture_traces=capture_traces) for candidate, batch in items]
 
     def _batch_evaluate_via_user_fn(
         self,
         items: list[tuple["Candidate", list]],
+        *,
+        capture_traces: bool = True,
     ) -> list[EvaluationBatch]:
         """Flatten all (candidate, example) pairs, call batch_evaluator once, repackage.
 
@@ -522,7 +526,12 @@ class OptimizeAnythingAdapter(GEPAAdapter):
             raw_by_item.setdefault(item_idx, []).append((score, None, side_info))
 
         return [
-            self._assemble_no_refiner_batch(items[item_idx][0], items[item_idx][1], raw_by_item.get(item_idx, []))
+            self._assemble_no_refiner_batch(
+                items[item_idx][0],
+                items[item_idx][1],
+                raw_by_item.get(item_idx, []),
+                capture_traces=capture_traces,
+            )
             for item_idx in range(len(items))
         ]
 
@@ -650,6 +659,8 @@ class OptimizeAnythingAdapter(GEPAAdapter):
     def _batch_evaluate_parallel_fallback(
         self,
         items: list[tuple["Candidate", list]],
+        *,
+        capture_traces: bool = True,
     ) -> list[EvaluationBatch]:
         """Fan all ``(candidate, example)`` pairs out across one thread pool, regroup per item.
 
@@ -671,7 +682,7 @@ class OptimizeAnythingAdapter(GEPAAdapter):
             raw_per_item[pair_to_item_idx[pair_idx]].append(raw)
 
         return [
-            self._assemble_no_refiner_batch(candidate, batch, raw_per_item[item_idx])
+            self._assemble_no_refiner_batch(candidate, batch, raw_per_item[item_idx], capture_traces=capture_traces)
             for item_idx, (candidate, batch) in enumerate(items)
         ]
 
@@ -691,6 +702,8 @@ class OptimizeAnythingAdapter(GEPAAdapter):
         candidate: "Candidate",
         batch: list[DataInst],
         raw_results: list[tuple[float, Any, "SideInfo"]],
+        *,
+        capture_traces: bool = True,
     ) -> EvaluationBatch:
         """Package raw ``(score, _, side_info)`` evaluator results into an EvaluationBatch.
 
@@ -718,7 +731,7 @@ class OptimizeAnythingAdapter(GEPAAdapter):
         return EvaluationBatch(
             outputs=outputs,
             scores=scores,
-            trajectories=side_infos,
+            trajectories=side_infos if capture_traces else None,
             objective_scores=objective_scores,
             num_metric_calls=len(batch),
         )

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -195,7 +195,8 @@ def optimize(
     # Reproducibility
     - seed: The seed to use for the random number generator.
     - val_evaluation_policy: Strategy controlling which validation ids to score each iteration and which candidate is currently best. Supported strings: "full_eval" (evaluate every id each time) Passing None defaults to "full_eval".
-    - raise_on_exception: Whether to propagate proposer/evaluator exceptions instead of stopping gracefully.
+    - raise_on_exception: Whether to propagate proposer/evaluator exceptions immediately. When False, GEPA can
+      continue after failures that consumed metric budget, but re-raises zero-progress failures to prevent infinite retries.
     """
     # Validate seed_candidate is not None or empty
     if seed_candidate is None or not seed_candidate:

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -195,8 +195,8 @@ def optimize(
     # Reproducibility
     - seed: The seed to use for the random number generator.
     - val_evaluation_policy: Strategy controlling which validation ids to score each iteration and which candidate is currently best. Supported strings: "full_eval" (evaluate every id each time) Passing None defaults to "full_eval".
-    - raise_on_exception: Whether to propagate proposer/evaluator exceptions immediately. When False, GEPA can
-      continue after failures that consumed metric budget, but re-raises zero-progress failures to prevent infinite retries.
+    - raise_on_exception: Whether to propagate proposer/evaluator exceptions. False suppresses failures only after
+      an iteration consumes metric budget; zero-progress failures still propagate.
     """
     # Validate seed_candidate is not None or empty
     if seed_candidate is None or not seed_candidate:

--- a/src/gepa/core/adapter.py
+++ b/src/gepa/core/adapter.py
@@ -139,9 +139,6 @@ class GEPAAdapter(Protocol[DataInst, Trajectory, RolloutOutput]):
         with the failed example, including the error message, identifying the reason for the failure.
       - Reserve exceptions for unrecoverable, systemic failures (e.g., missing model,
         misconfigured program, schema mismatch).
-      - If an exception is raised with `raise_on_exception=False`, the engine continues only
-        when that iteration consumed metric budget. Zero-progress failures are re-raised to
-        prevent an infinite retry loop.
     """
 
     def evaluate(

--- a/src/gepa/core/adapter.py
+++ b/src/gepa/core/adapter.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
 # https://github.com/gepa-ai/gepa
 
+import inspect
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Generic, Protocol, TypeVar
@@ -41,6 +42,8 @@ class BatchEvaluateFn(Protocol):
     def __call__(
         self,
         items: list[tuple[Candidate, list]],
+        *,
+        capture_traces: bool = True,
     ) -> list["EvaluationBatch"]: ...
 
 
@@ -217,24 +220,50 @@ class GEPAAdapter(Protocol[DataInst, Trajectory, RolloutOutput]):
     propose_new_texts: ProposalFn | None = None
 
     # Optional: adapters can implement batch_evaluate to evaluate multiple
-    # (candidate, batch) pairs in a single call.  When not present, the
-    # proposer falls back to default_batch_evaluate() which calls evaluate()
-    # sequentially.  Unlike evaluate(), batch_evaluate always returns full
-    # results including trajectories.
+    # (candidate, batch) pairs in a single call. When not present, GEPA falls
+    # back to default_batch_evaluate() which calls evaluate() sequentially.
+    # ``capture_traces`` has the same meaning as on evaluate().
     #
     # def batch_evaluate(
     #     self, items: list[tuple[Candidate, list[DataInst]]],
+    #     *, capture_traces: bool = True,
     # ) -> list[EvaluationBatch[Trajectory, RolloutOutput]]: ...
 
 
 def default_batch_evaluate(
     adapter: GEPAAdapter,
     items: list[tuple[Candidate, list]],
+    *,
+    capture_traces: bool = True,
 ) -> list[EvaluationBatch]:
     """Default sequential batch_evaluate fallback.
 
-    Calls ``adapter.evaluate()`` once per (candidate, batch) pair with
-    ``capture_traces=True``.  Adapters can implement ``batch_evaluate``
-    directly for true batching or parallelism.
+    Calls ``adapter.evaluate()`` once per (candidate, batch) pair. Adapters can
+    implement ``batch_evaluate`` directly for true batching or parallelism.
     """
-    return [adapter.evaluate(batch, candidate, capture_traces=True) for candidate, batch in items]
+    return [adapter.evaluate(batch, candidate, capture_traces=capture_traces) for candidate, batch in items]
+
+
+def invoke_batch_evaluate(
+    adapter: GEPAAdapter,
+    items: list[tuple[Candidate, list]],
+    *,
+    capture_traces: bool = True,
+) -> list[EvaluationBatch]:
+    """Use an adapter's optional batch evaluator without breaking legacy implementations."""
+    batch_fn = getattr(adapter, "batch_evaluate", None)
+    if batch_fn is not None:
+        try:
+            parameters = inspect.signature(batch_fn).parameters.values()
+        except (TypeError, ValueError):
+            parameters = ()
+        supports_trace_mode = any(
+            parameter.kind == inspect.Parameter.VAR_KEYWORD
+            or (parameter.name == "capture_traces" and parameter.kind != inspect.Parameter.POSITIONAL_ONLY)
+            for parameter in parameters
+        )
+        if supports_trace_mode:
+            return batch_fn(items, capture_traces=capture_traces)
+        if capture_traces:
+            return batch_fn(items)
+    return default_batch_evaluate(adapter, items, capture_traces=capture_traces)

--- a/src/gepa/core/adapter.py
+++ b/src/gepa/core/adapter.py
@@ -139,7 +139,9 @@ class GEPAAdapter(Protocol[DataInst, Trajectory, RolloutOutput]):
         with the failed example, including the error message, identifying the reason for the failure.
       - Reserve exceptions for unrecoverable, systemic failures (e.g., missing model,
         misconfigured program, schema mismatch).
-      - If an exception is raised, the engine will log the error and proceed to the next iteration.
+      - If an exception is raised with `raise_on_exception=False`, the engine continues only
+        when that iteration consumed metric budget. Zero-progress failures are re-raised to
+        prevent an infinite retry loop.
     """
 
     def evaluate(

--- a/src/gepa/core/adapter.py
+++ b/src/gepa/core/adapter.py
@@ -139,6 +139,7 @@ class GEPAAdapter(Protocol[DataInst, Trajectory, RolloutOutput]):
         with the failed example, including the error message, identifying the reason for the failure.
       - Reserve exceptions for unrecoverable, systemic failures (e.g., missing model,
         misconfigured program, schema mismatch).
+      - Systemic exceptions follow the `raise_on_exception` policy passed to `optimize()`.
     """
 
     def evaluate(

--- a/src/gepa/core/adapter.py
+++ b/src/gepa/core/adapter.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
 # https://github.com/gepa-ai/gepa
 
-import inspect
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Generic, Protocol, TypeVar
@@ -250,20 +249,8 @@ def invoke_batch_evaluate(
     *,
     capture_traces: bool = True,
 ) -> list[EvaluationBatch]:
-    """Use an adapter's optional batch evaluator without breaking legacy implementations."""
+    """Use an adapter's optional trace-aware batch evaluator."""
     batch_fn = getattr(adapter, "batch_evaluate", None)
     if batch_fn is not None:
-        try:
-            parameters = inspect.signature(batch_fn).parameters.values()
-        except (TypeError, ValueError):
-            parameters = ()
-        supports_trace_mode = any(
-            parameter.kind == inspect.Parameter.VAR_KEYWORD
-            or (parameter.name == "capture_traces" and parameter.kind != inspect.Parameter.POSITIONAL_ONLY)
-            for parameter in parameters
-        )
-        if supports_trace_mode:
-            return batch_fn(items, capture_traces=capture_traces)
-        if capture_traces:
-            return batch_fn(items)
+        return batch_fn(items, capture_traces=capture_traces)
     return default_batch_evaluate(adapter, items, capture_traces=capture_traces)

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -752,11 +752,17 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                     ),
                 )
 
-            outputs, scores, objective_scores = self.evaluator(valset.fetch(val_ids), program)
-            outputs_dict = dict(zip(val_ids, outputs, strict=False))
-            scores_dict = dict(zip(val_ids, scores, strict=False))
+            (eval_result,) = invoke_batch_evaluate(
+                self.adapter,
+                [(program, valset.fetch(val_ids))],
+                capture_traces=False,
+            )
+            outputs_dict = dict(zip(val_ids, eval_result.outputs, strict=False))
+            scores_dict = dict(zip(val_ids, eval_result.scores, strict=False))
             objective_scores_dict = (
-                dict(zip(val_ids, objective_scores, strict=False)) if objective_scores is not None else None
+                dict(zip(val_ids, eval_result.objective_scores, strict=False))
+                if eval_result.objective_scores is not None
+                else None
             )
             return ValsetEvaluation(
                 outputs_by_val_id=outputs_dict,
@@ -899,6 +905,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             assert state.is_consistent()
             proposal_accepted = False
             iteration_started = False
+            evals_before_iteration = state.total_num_evals
             try:
                 self._sync_adapter_state_to_state(state)
                 state.save(
@@ -1029,6 +1036,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             except Exception as e:
                 self.logger.log(f"Iteration {state.i + 1}: Exception during optimization: {e}")
                 self.logger.log(traceback.format_exc())
+                made_progress = state.total_num_evals > evals_before_iteration
                 # Notify error callback
                 notify_callbacks(
                     self.callbacks,
@@ -1036,10 +1044,10 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                     ErrorEvent(
                         iteration=state.i + 1,
                         exception=e,
-                        will_continue=not self.raise_on_exception,
+                        will_continue=not self.raise_on_exception and made_progress,
                     ),
                 )
-                if self.raise_on_exception:
+                if self.raise_on_exception or not made_progress:
                     raise e
                 else:
                     continue

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -9,11 +9,10 @@ from typing import Any, Generic
 
 from gepa.core.adapter import (
     DataInst,
-    EvaluationBatch,
     GEPAAdapter,
     RolloutOutput,
     Trajectory,
-    default_batch_evaluate,
+    invoke_batch_evaluate,
 )
 from gepa.core.callbacks import (
     BudgetUpdatedEvent,
@@ -312,7 +311,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         # 2) One adapter call over every (program, cache-miss examples) pair.
         eval_idxs = [i for i, todo in enumerate(todo_per) if todo]
         items = [(programs[i], valset.fetch(todo_per[i])) for i in eval_idxs]
-        fresh = self._batch_evaluate(items) if items else []
+        fresh = invoke_batch_evaluate(self.adapter, items, capture_traces=False) if items else []
         fresh_by_idx = dict(zip(eval_idxs, fresh, strict=True))
 
         # 3) Merge cached + fresh per program, repopulating the cache.
@@ -352,13 +351,6 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
                 )
             )
         return results
-
-    def _batch_evaluate(self, items: list[tuple[dict[str, str], list]]) -> list[EvaluationBatch]:
-        """Evaluate (candidate, batch) pairs via the adapter's batch_evaluate or fallback."""
-        batch_fn = getattr(self.adapter, "batch_evaluate", None)
-        if batch_fn is not None:
-            return batch_fn(items)
-        return default_batch_evaluate(self.adapter, items)
 
     def _run_full_eval_and_add(
         self,

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -13,7 +13,7 @@ from gepa.core.adapter import (
     ProposalFn,
     RolloutOutput,
     Trajectory,
-    default_batch_evaluate,
+    invoke_batch_evaluate,
 )
 from gepa.core.callbacks import (
     CandidateSelectedEvent,
@@ -277,10 +277,7 @@ class ReflectiveMutationProposer:
 
     def _batch_evaluate(self, items: list[tuple[dict[str, str], list]]) -> list[EvaluationBatch]:
         """Evaluate (candidate, batch) pairs via the adapter's batch_evaluate or fallback."""
-        batch_fn = getattr(self.adapter, "batch_evaluate", None)
-        if batch_fn is not None:
-            return batch_fn(items)
-        return default_batch_evaluate(self.adapter, items)
+        return invoke_batch_evaluate(self.adapter, items, capture_traces=True)
 
     # ------------------------------------------------------------------
     # Main proposal method

--- a/tests/test_batch_evaluator_user_fn.py
+++ b/tests/test_batch_evaluator_user_fn.py
@@ -194,9 +194,23 @@ def test_batch_only_adapter_evaluate_routes_whole_batch():
     adapter = OptimizeAnythingAdapter(evaluator=None, parallel=False, cache_mode="off", batch_evaluator=fn)
     result = adapter.evaluate([1, 2, 3], {"bias": "0"})
     assert result.scores == [1.0, 2.0, 3.0]
+    assert result.trajectories is None
     assert len(fn.calls) == 1 and len(fn.calls[0]) == 3  # one grouped call
     # Packaging parity: outputs are (score, candidate, side_info) triples.
     assert all(out[1] == {"bias": "0"} for out in result.outputs)
+
+
+def test_direct_evaluate_returns_trajectories_when_requested():
+    adapter = OptimizeAnythingAdapter(
+        evaluator=None,
+        parallel=False,
+        cache_mode="off",
+        batch_evaluator=_CountingBatchFn(),
+    )
+
+    result = adapter.evaluate([1, 2], {"bias": "0"}, capture_traces=True)
+
+    assert result.trajectories == [{"example": 1}, {"example": 2}]
 
 
 def test_batch_only_singleton_resolution_for_refiner_seam():

--- a/tests/test_batch_evaluator_user_fn.py
+++ b/tests/test_batch_evaluator_user_fn.py
@@ -144,6 +144,11 @@ def test_batch_path_packaging_matches_sequential_path():
     assert batched[1].outputs[0][1] == {"bias": "100"}
 
 
+def test_batch_path_honors_capture_traces_false():
+    results = _make_adapter(batch_evaluator=_user_batch_fn).batch_evaluate(ITEMS, capture_traces=False)
+    assert all(result.trajectories is None for result in results)
+
+
 def test_batch_path_updates_best_evals_for_warm_start():
     """B1: the top-K best-eval buffer must be populated on the batch path."""
     adapter = _make_adapter(batch_evaluator=_user_batch_fn)

--- a/tests/test_multi_proposal_invariants.py
+++ b/tests/test_multi_proposal_invariants.py
@@ -72,9 +72,9 @@ class SyntheticAdapter:
 
 
 class BatchedSyntheticAdapter(SyntheticAdapter):
-    def batch_evaluate(self, items):
+    def batch_evaluate(self, items, *, capture_traces=True):
         self.grouped_calls.append(len(items))
-        return [self.evaluate(batch, candidate, capture_traces=True) for candidate, batch in items]
+        return [self.evaluate(batch, candidate, capture_traces=capture_traces) for candidate, batch in items]
 
 
 class SyntheticReflectionLM:

--- a/tests/test_parallel_valset_eval.py
+++ b/tests/test_parallel_valset_eval.py
@@ -87,6 +87,7 @@ def test_trace_aware_adapter_batches_accepted_candidates_without_traces(tmp_path
     adapter = TraceAwareBatchImprovingAdapter()
     result = _run(adapter, IndependentSampling(3), tmp_path)
     assert len(result.candidates) > 2
+    assert adapter.batch_calls[0] == ("val", 1, False)
     assert any(split == "val" and n > 1 and capture_traces is False for split, n, capture_traces in adapter.batch_calls)
     assert any(split == "train" and capture_traces is True for split, _, capture_traces in adapter.batch_calls)
 
@@ -102,6 +103,39 @@ def test_legacy_batch_adapter_gets_clear_contract_error():
             [({"system_prompt": "s"}, [{"split": "train"}])],
             capture_traces=True,
         )
+
+
+def test_batch_error_without_budget_progress_does_not_loop_when_exceptions_are_suppressed(tmp_path):
+    class BrokenAdapter(ImprovingAdapter):
+        def __init__(self):
+            super().__init__()
+            self.batch_calls = 0
+
+        def batch_evaluate(self, items, *, capture_traces=True):
+            self.batch_calls += 1
+            if capture_traces:
+                raise TypeError("adapter bug")
+            return [
+                self.evaluate(batch, candidate, capture_traces=False)
+                for candidate, batch in items
+            ]
+
+    adapter = BrokenAdapter()
+    with pytest.raises(TypeError, match="adapter bug"):
+        import gepa
+
+        gepa.optimize(
+            seed_candidate={"system_prompt": "s"},
+            trainset=[{"id": 0, "split": "train"}],
+            valset=[{"id": 0, "split": "val"}],
+            adapter=adapter,
+            max_metric_calls=20,
+            reflection_lm=None,
+            raise_on_exception=False,
+            run_dir=str(tmp_path),
+        )
+
+    assert adapter.batch_calls == 2  # One seed evaluation, then one failed reflective evaluation.
 
 
 def test_runtime_batch_type_error_is_not_retried_sequentially():

--- a/tests/test_parallel_valset_eval.py
+++ b/tests/test_parallel_valset_eval.py
@@ -44,18 +44,6 @@ class ImprovingAdapter:
         return out
 
 
-class BatchImprovingAdapter(ImprovingAdapter):
-    """Adds a real ``batch_evaluate`` and records the items of each call."""
-
-    def __init__(self):
-        super().__init__()
-        self.batch_calls: list[tuple[str, int]] = []
-
-    def batch_evaluate(self, items):
-        self.batch_calls.append((items[0][1][0]["split"], len(items)))
-        return [self.evaluate(batch, candidate, capture_traces=True) for candidate, batch in items]
-
-
 class TraceAwareBatchImprovingAdapter(ImprovingAdapter):
     def __init__(self):
         super().__init__()
@@ -103,16 +91,17 @@ def test_trace_aware_adapter_batches_accepted_candidates_without_traces(tmp_path
     assert any(split == "train" and capture_traces is True for split, _, capture_traces in adapter.batch_calls)
 
 
-def test_legacy_adapter_batches_reflection_and_falls_back_for_full_val(tmp_path):
-    adapter = BatchImprovingAdapter()
-    result = _run(adapter, IndependentSampling(3), tmp_path)
-    assert len(result.candidates) > 2
-    assert adapter.batch_calls
-    assert all(split == "train" for split, _ in adapter.batch_calls)
-    assert all(capture_traces is True for split, _, capture_traces in adapter.evaluate_calls if split == "train")
-    accepted_val_calls = [call for call in adapter.evaluate_calls if call[0] == "val" and call[1] != "s"]
-    assert accepted_val_calls
-    assert all(capture_traces is False for _, _, capture_traces in accepted_val_calls)
+def test_legacy_batch_adapter_gets_clear_contract_error():
+    class LegacyAdapter(ImprovingAdapter):
+        def batch_evaluate(self, items):
+            return []
+
+    with pytest.raises(TypeError, match="unexpected keyword argument 'capture_traces'"):
+        invoke_batch_evaluate(
+            LegacyAdapter(),
+            [({"system_prompt": "s"}, [{"split": "train"}])],
+            capture_traces=True,
+        )
 
 
 def test_runtime_batch_type_error_is_not_retried_sequentially():

--- a/tests/test_parallel_valset_eval.py
+++ b/tests/test_parallel_valset_eval.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
 # https://github.com/gepa-ai/gepa
 
-"""End-to-end test for batched full-valset eval of multiple accepted candidates.
+"""End-to-end tests for trace-aware batched evaluation.
 
 A multi-proposal sampler (``IndependentSampling``) can accept several candidates
 in one iteration. Their full-valset evaluations are batched into a single
@@ -9,7 +9,9 @@ in one iteration. Their full-valset evaluations are batched into a single
 stays single-threaded and pool/Pareto mutation stays sequential.
 """
 
-from gepa.core.adapter import EvaluationBatch
+import pytest
+
+from gepa.core.adapter import EvaluationBatch, invoke_batch_evaluate
 from gepa.strategies.proposal_sampling import IndependentSampling, SingleMutationSampling
 from gepa.strategies.proposal_selection import AllImprovements
 
@@ -21,8 +23,10 @@ class ImprovingAdapter:
     def __init__(self):
         self.propose_new_texts = self._propose_new_texts
         self._suffix = 0
+        self.evaluate_calls: list[tuple[str, str, bool]] = []
 
     def evaluate(self, batch, candidate, capture_traces=False):
+        self.evaluate_calls.append((batch[0]["split"], candidate["system_prompt"], capture_traces))
         score = min(1.0, len(candidate["system_prompt"]) / 80.0)
         outputs = [score for _ in batch]
         scores = [score for _ in batch]
@@ -45,11 +49,23 @@ class BatchImprovingAdapter(ImprovingAdapter):
 
     def __init__(self):
         super().__init__()
-        self.batch_calls: list[int] = []
+        self.batch_calls: list[tuple[str, int]] = []
 
     def batch_evaluate(self, items):
-        self.batch_calls.append(len(items))
+        self.batch_calls.append((items[0][1][0]["split"], len(items)))
         return [self.evaluate(batch, candidate, capture_traces=True) for candidate, batch in items]
+
+
+class TraceAwareBatchImprovingAdapter(ImprovingAdapter):
+    def __init__(self):
+        super().__init__()
+        self.batch_calls: list[tuple[str, int, bool]] = []
+
+    def batch_evaluate(self, items, *, capture_traces=True):
+        self.batch_calls.append((items[0][1][0]["split"], len(items), capture_traces))
+        return [
+            self.evaluate(batch, candidate, capture_traces=capture_traces) for candidate, batch in items
+        ]
 
 
 def _run(adapter, sampling_strategy, tmp_path):
@@ -57,8 +73,8 @@ def _run(adapter, sampling_strategy, tmp_path):
 
     return gepa.optimize(
         seed_candidate={"system_prompt": "s"},
-        trainset=[{"id": i} for i in range(4)],
-        valset=[{"id": i} for i in range(4)],
+        trainset=[{"id": i, "split": "train"} for i in range(4)],
+        valset=[{"id": i, "split": "val"} for i in range(4)],
         adapter=adapter,
         max_metric_calls=300,
         reflection_lm=None,
@@ -79,14 +95,87 @@ def test_multiple_candidates_accepted_and_evaluated_in_one_iteration(tmp_path):
     assert max(result.val_aggregate_scores) >= result.val_aggregate_scores[0]
 
 
-def test_accepted_candidates_share_one_batch_evaluate_call(tmp_path):
-    """When the adapter implements batch_evaluate, the valset evals of all
-    candidates accepted in one iteration go out as a single batched call."""
+def test_trace_aware_adapter_batches_accepted_candidates_without_traces(tmp_path):
+    adapter = TraceAwareBatchImprovingAdapter()
+    result = _run(adapter, IndependentSampling(3), tmp_path)
+    assert len(result.candidates) > 2
+    assert any(split == "val" and n > 1 and capture_traces is False for split, n, capture_traces in adapter.batch_calls)
+    assert any(split == "train" and capture_traces is True for split, _, capture_traces in adapter.batch_calls)
+
+
+def test_legacy_adapter_batches_reflection_and_falls_back_for_full_val(tmp_path):
     adapter = BatchImprovingAdapter()
     result = _run(adapter, IndependentSampling(3), tmp_path)
     assert len(result.candidates) > 2
-    # At least one iteration batched several candidates into one batch_evaluate call.
-    assert any(n > 1 for n in adapter.batch_calls)
+    assert adapter.batch_calls
+    assert all(split == "train" for split, _ in adapter.batch_calls)
+    assert all(capture_traces is True for split, _, capture_traces in adapter.evaluate_calls if split == "train")
+    accepted_val_calls = [call for call in adapter.evaluate_calls if call[0] == "val" and call[1] != "s"]
+    assert accepted_val_calls
+    assert all(capture_traces is False for _, _, capture_traces in accepted_val_calls)
+
+
+def test_runtime_batch_type_error_is_not_retried_sequentially():
+    class BrokenAdapter:
+        def __init__(self):
+            self.batch_calls = 0
+            self.evaluate_calls = 0
+
+        def batch_evaluate(self, items, *, capture_traces=True):
+            self.batch_calls += 1
+            raise TypeError("adapter bug")
+
+        def evaluate(self, batch, candidate, capture_traces=False):
+            self.evaluate_calls += 1
+            return EvaluationBatch(outputs=["unexpected"], scores=[0.0])
+
+    adapter = BrokenAdapter()
+    with pytest.raises(TypeError, match="adapter bug"):
+        invoke_batch_evaluate(adapter, [({"system_prompt": "s"}, [{"split": "val"}])], capture_traces=False)
+    assert adapter.batch_calls == 1
+    assert adapter.evaluate_calls == 0
+
+
+def test_issue_428_call_sequence_ends_with_untraced_accepted_val(tmp_path):
+    class ReproAdapter:
+        def __init__(self):
+            self.calls = []
+            self.propose_new_texts = self.propose
+
+        def evaluate(self, batch, candidate, capture_traces=False):
+            self.calls.append((batch[0]["split"], candidate["prompt"], capture_traces))
+            score = 0.1 * len(candidate["prompt"])
+            return EvaluationBatch(
+                outputs=["ok"] * len(batch),
+                scores=[score] * len(batch),
+                trajectories=[{}] * len(batch) if capture_traces else None,
+            )
+
+        def make_reflective_dataset(self, candidate, evaluation, components):
+            return {component: [{}] for component in components}
+
+        def propose(self, candidate, dataset, components):
+            return {"prompt": candidate["prompt"] + "x"}
+
+    import gepa
+
+    adapter = ReproAdapter()
+    gepa.optimize(
+        seed_candidate={"prompt": "a"},
+        trainset=[{"split": "train"}],
+        valset=[{"split": "val"}],
+        adapter=adapter,
+        max_metric_calls=4,
+        reflection_lm=None,
+        run_dir=str(tmp_path),
+    )
+
+    assert adapter.calls == [
+        ("val", "a", False),
+        ("train", "a", True),
+        ("train", "ax", True),
+        ("val", "ax", False),
+    ]
 
 
 def test_single_mutation_still_works(tmp_path):

--- a/tests/test_refiner.py
+++ b/tests/test_refiner.py
@@ -759,7 +759,7 @@ class TestRefinerFrontierTypes:
         }
 
         # Evaluate across dataset
-        eval_batch = adapter.evaluate(DATASET, candidate)
+        eval_batch = adapter.evaluate(DATASET, candidate, capture_traces=True)
 
         assert len(eval_batch.scores) == len(DATASET)
         assert len(eval_batch.objective_scores) == len(DATASET)

--- a/tests/test_reflection_lm.py
+++ b/tests/test_reflection_lm.py
@@ -439,7 +439,7 @@ def test_trace_records_every_task_not_just_the_first():
     adapter = MagicMock()
     adapter.propose_new_texts = None
     adapter.batch_evaluate = MagicMock(
-        side_effect=lambda items: [
+        side_effect=lambda items, **kwargs: [
             EvaluationBatch(
                 outputs=["o"], scores=[0.4], trajectories=[{"step": 1}], objective_scores=None, num_metric_calls=1
             )
@@ -460,6 +460,7 @@ def test_trace_records_every_task_not_just_the_first():
     )
     state = _make_state()
     proposals = proposer.propose(state)
+    assert all(call.kwargs == {"capture_traces": True} for call in adapter.batch_evaluate.call_args_list)
     assert len(proposals) == 2
 
     entry = state.full_program_trace[-1]


### PR DESCRIPTION
## Summary

- make batch evaluation trace-aware by forwarding `capture_traces` through the adapter contract and Optimize Anything adapter
- preserve batching for seed and accepted-candidate full-validation evaluation while passing `capture_traces=False`
- require the explicit `batch_evaluate(items, *, capture_traces=True)` contract and remove runtime signature inspection
- stop suppressed-exception retries when an iteration makes no metric-budget progress, with `ErrorEvent.will_continue` matching the actual outcome
- document the zero-progress `raise_on_exception=False` behavior in the public API
- document and test that direct `OptimizeAnythingAdapter.evaluate()` calls return trajectories only when trace capture is requested
- add regression coverage for issue #428, trace-aware routing, contract errors, error propagation, and stalled retries

## Batch adapter contract

The batch contract is `batch_evaluate(items, *, capture_traces: bool = True)`: seed and accepted-candidate full-val evaluation pass `False`, while reflection passes `True`.

Adapters implementing the older one-argument `batch_evaluate(items)` contract must add the keyword parameter; otherwise Python raises a clear `unexpected keyword argument 'capture_traces'` error. Wrappers and mocks must expose and forward the same contract. Adapters implementing only `evaluate()` remain supported because the sequential fallback controls trace capture. Built-in adapters are updated in this PR. Adapter exceptions propagate without retry.

Direct `evaluate()` calls also default `capture_traces` to `False`: scores and outputs are returned normally, while trajectories require explicit trace capture. With `write_agent_state=True`, full-val evaluation intentionally remains traced and sequential.

When `raise_on_exception=False`, GEPA continues only if the failed iteration consumed additional metric budget. A zero-progress failure is re-raised instead of looping indefinitely, and `ErrorEvent.will_continue` reports that decision accurately. This caveat is documented on the public `optimize()` API.

This supersedes the closed rollback PR #429.

Fixes #428

## Local verification

- Lakshya's delegating-wrapper reproduction immediately raises the expected contract `TypeError`
- focused trace/batch/engine/callback tests: 150 passed
- final docs simplification checks: 40 passed
- `uv run --frozen pytest` (675 passed, 4 skipped)
- `uv run --frozen ruff check src tests`
- `uv run --frozen pyright src` (0 errors, 0 warnings)
- `uv run --with-requirements requirements.txt mkdocs build` from `docs/`
- `git diff --check`

