### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ We welcome adapters, bug fixes, and new use cases. See [src/gepa/adapters/](src/
 ```
 
 <p align="center">
-  <a href="https://www.star-history.com/#gepa-ai/gepa&Date">
-    <img src="https://api.star-history.com/svg?repos=gepa-ai/gepa&type=Date" alt="Star History Chart" width="600">
+  <a href="https://star-history.dera.page/#gepa-ai/gepa&type=Date">
+    <img src="https://star-history.dera.page/svg?repos=gepa-ai/gepa&type=Date" alt="Star History Chart" width="600">
   </a>
 </p>


### PR DESCRIPTION
The star history chart on the README is currently broken due to GitHub stargazer API restrictions. This switches the chart to the dera.page mirror, which uses a different data source that requires no API token, so the chart works again.