### PR TITLE
feat(strategies): BatchLexicase and UnprunedPareto candidate selectors

### DIFF
--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -28,10 +28,12 @@ from gepa.proposer.reflective_mutation.reflective_mutation import ReflectiveMuta
 from gepa.strategies.acceptance import AcceptanceCriterion, ImprovementOrEqualAcceptance, StrictImprovementAcceptance
 from gepa.strategies.batch_sampler import BatchSampler, EpochShuffledBatchSampler
 from gepa.strategies.candidate_selector import (
+    BatchLexicaseCandidateSelector,
     CurrentBestCandidateSelector,
     EpsilonGreedyCandidateSelector,
     ParetoCandidateSelector,
     TopKParetoCandidateSelector,
+    UnprunedParetoCandidateSelector,
 )
 from gepa.strategies.component_selector import (
     AllReflectionComponentSelector,
@@ -54,7 +56,9 @@ def optimize(
     reflection_lm: LanguageModel | str | None = None,
     reflection_lm_kwargs: dict[str, Any] | None = None,
     candidate_selection_strategy: CandidateSelector
-    | Literal["pareto", "current_best", "epsilon_greedy", "top_k_pareto"] = "pareto",
+    | Literal[
+        "pareto", "current_best", "epsilon_greedy", "top_k_pareto", "batch_lexicase", "unpruned_pareto"
+    ] = "pareto",
     frontier_type: FrontierType = "instance",
     skip_perfect_score: bool = True,
     batch_sampler: BatchSampler | Literal["epoch_shuffled"] = "epoch_shuffled",
@@ -150,7 +154,7 @@ def optimize(
     - sampling_strategy: Controls how many (parent, minibatch) proposal tasks are sampled per iteration. One of `SingleMutationSampling` (default; 1 parent, 1 mutation — identical to classic GEPA), `SameParentSampling(n)`, `IndependentSampling(n)`, or `PxNSampling(p, n)`, or any custom `SamplingStrategy`.
     - selection_strategy: Controls which of an iteration's improving proposals enter the candidate pool. One of `AllImprovements` (default), `BestImprovement`, or `TopKImprovements(k)`, or any custom `SelectionStrategy`.
     - reflection_strategy: Advanced: a `ReflectionLM` implementation that owns how reflective mutation calls the reflection model (e.g. stateful sessions or aggregating reflectors). Defaults to the stateless single-call reflector built from `reflection_lm`. Implementations may provide `reflect_many` for batched reflection; otherwise `reflect` is called once per task.
-    - candidate_selection_strategy: The strategy to use for selecting the candidate to update. Supported strategies: 'pareto', 'current_best', 'epsilon_greedy'. Defaults to 'pareto'.
+    - candidate_selection_strategy: The strategy to use for selecting the candidate to update. Supported strategies: 'pareto', 'current_best', 'epsilon_greedy', 'top_k_pareto', 'batch_lexicase', 'unpruned_pareto'. Defaults to 'pareto'.
     - frontier_type: Strategy for tracking Pareto frontiers. 'instance' tracks per validation example, 'objective' tracks per objective metric, 'hybrid' combines both, 'cartesian' tracks per (example, objective) pair. Defaults to 'instance'.
     - skip_perfect_score: Whether to skip updating the candidate if it achieves a perfect score on the minibatch.
     - batch_sampler: Strategy for selecting training examples. Can be a [BatchSampler](src/gepa/strategies/batch_sampler.py) instance or a string for a predefined strategy from ['epoch_shuffled']. Defaults to 'epoch_shuffled', which creates an [EpochShuffledBatchSampler](src/gepa/strategies/batch_sampler.py).
@@ -329,6 +333,8 @@ def optimize(
             "current_best": lambda: CurrentBestCandidateSelector(),
             "epsilon_greedy": lambda: EpsilonGreedyCandidateSelector(epsilon=0.1, rng=rng),
             "top_k_pareto": lambda: TopKParetoCandidateSelector(k=5, rng=rng),
+            "batch_lexicase": lambda: BatchLexicaseCandidateSelector(rng=rng),
+            "unpruned_pareto": lambda: UnprunedParetoCandidateSelector(rng=rng),
         }
 
         try:
@@ -336,7 +342,7 @@ def optimize(
         except KeyError as exc:
             raise ValueError(
                 f"Unknown candidate_selector strategy: {candidate_selection_strategy}. "
-                "Supported strategies: 'pareto', 'current_best', 'epsilon_greedy', 'top_k_pareto'"
+                "Supported strategies: 'pareto', 'current_best', 'epsilon_greedy', 'top_k_pareto', 'batch_lexicase', 'unpruned_pareto'"
             ) from exc
     elif isinstance(candidate_selection_strategy, CandidateSelector):
         candidate_selector = candidate_selection_strategy

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -25,7 +25,12 @@ from gepa.proposer.merge import MergeProposer
 from gepa.proposer.reflective_mutation.base import CandidateSelector, LanguageModel, ReflectionComponentSelector
 from gepa.proposer.reflective_mutation.reflection_lm import ReflectionLM
 from gepa.proposer.reflective_mutation.reflective_mutation import ReflectiveMutationProposer
-from gepa.strategies.acceptance import AcceptanceCriterion, ImprovementOrEqualAcceptance, StrictImprovementAcceptance
+from gepa.strategies.acceptance import (
+    AcceptanceCriterion,
+    AlwaysAcceptance,
+    ImprovementOrEqualAcceptance,
+    StrictImprovementAcceptance,
+)
 from gepa.strategies.batch_sampler import BatchSampler, EpochShuffledBatchSampler
 from gepa.strategies.candidate_selector import (
     BatchLexicaseCandidateSelector,
@@ -101,7 +106,7 @@ def optimize(
     raise_on_exception: bool = True,
     val_evaluation_policy: EvaluationPolicy[DataId, DataInst] | Literal["full_eval"] | None = None,
     acceptance_criterion: AcceptanceCriterion
-    | Literal["strict_improvement", "improvement_or_equal"] = "strict_improvement",
+    | Literal["strict_improvement", "improvement_or_equal", "always"] = "strict_improvement",
     # Proposal strategies (default: 1 parent, 1 mutation per iteration)
     sampling_strategy: SamplingStrategy | None = None,
     selection_strategy: SelectionStrategy | None = None,
@@ -386,13 +391,14 @@ def optimize(
         acceptance_factories: dict[str, type[AcceptanceCriterion]] = {
             "strict_improvement": StrictImprovementAcceptance,
             "improvement_or_equal": ImprovementOrEqualAcceptance,
+            "always": AlwaysAcceptance,
         }
         try:
             acceptance_criterion_instance = acceptance_factories[acceptance_criterion]()
         except KeyError as exc:
             raise ValueError(
                 f"Unknown acceptance_criterion: {acceptance_criterion}. "
-                "Supported strategies: 'strict_improvement', 'improvement_or_equal'"
+                "Supported strategies: 'strict_improvement', 'improvement_or_equal', 'always'"
             ) from exc
     elif isinstance(acceptance_criterion, AcceptanceCriterion):
         acceptance_criterion_instance = acceptance_criterion

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -31,6 +31,7 @@ from gepa.strategies.candidate_selector import (
     BatchLexicaseCandidateSelector,
     CurrentBestCandidateSelector,
     EpsilonGreedyCandidateSelector,
+    LatestCandidateSelector,
     ParetoCandidateSelector,
     TopKParetoCandidateSelector,
     UnprunedParetoCandidateSelector,
@@ -57,7 +58,7 @@ def optimize(
     reflection_lm_kwargs: dict[str, Any] | None = None,
     candidate_selection_strategy: CandidateSelector
     | Literal[
-        "pareto", "current_best", "epsilon_greedy", "top_k_pareto", "batch_lexicase", "unpruned_pareto"
+        "pareto", "current_best", "epsilon_greedy", "top_k_pareto", "batch_lexicase", "unpruned_pareto", "latest"
     ] = "pareto",
     frontier_type: FrontierType = "instance",
     skip_perfect_score: bool = True,
@@ -154,7 +155,7 @@ def optimize(
     - sampling_strategy: Controls how many (parent, minibatch) proposal tasks are sampled per iteration. One of `SingleMutationSampling` (default; 1 parent, 1 mutation — identical to classic GEPA), `SameParentSampling(n)`, `IndependentSampling(n)`, or `PxNSampling(p, n)`, or any custom `SamplingStrategy`.
     - selection_strategy: Controls which of an iteration's improving proposals enter the candidate pool. One of `AllImprovements` (default), `BestImprovement`, or `TopKImprovements(k)`, or any custom `SelectionStrategy`.
     - reflection_strategy: Advanced: a `ReflectionLM` implementation that owns how reflective mutation calls the reflection model (e.g. stateful sessions or aggregating reflectors). Defaults to the stateless single-call reflector built from `reflection_lm`. Implementations may provide `reflect_many` for batched reflection; otherwise `reflect` is called once per task.
-    - candidate_selection_strategy: The strategy to use for selecting the candidate to update. Supported strategies: 'pareto', 'current_best', 'epsilon_greedy', 'top_k_pareto', 'batch_lexicase', 'unpruned_pareto'. Defaults to 'pareto'.
+    - candidate_selection_strategy: The strategy to use for selecting the candidate to update. Supported strategies: 'pareto', 'current_best', 'epsilon_greedy', 'top_k_pareto', 'batch_lexicase', 'unpruned_pareto', 'latest'. Defaults to 'pareto'.
     - frontier_type: Strategy for tracking Pareto frontiers. 'instance' tracks per validation example, 'objective' tracks per objective metric, 'hybrid' combines both, 'cartesian' tracks per (example, objective) pair. Defaults to 'instance'.
     - skip_perfect_score: Whether to skip updating the candidate if it achieves a perfect score on the minibatch.
     - batch_sampler: Strategy for selecting training examples. Can be a [BatchSampler](src/gepa/strategies/batch_sampler.py) instance or a string for a predefined strategy from ['epoch_shuffled']. Defaults to 'epoch_shuffled', which creates an [EpochShuffledBatchSampler](src/gepa/strategies/batch_sampler.py).
@@ -335,6 +336,7 @@ def optimize(
             "top_k_pareto": lambda: TopKParetoCandidateSelector(k=5, rng=rng),
             "batch_lexicase": lambda: BatchLexicaseCandidateSelector(rng=rng),
             "unpruned_pareto": lambda: UnprunedParetoCandidateSelector(rng=rng),
+            "latest": lambda: LatestCandidateSelector(),
         }
 
         try:
@@ -342,7 +344,7 @@ def optimize(
         except KeyError as exc:
             raise ValueError(
                 f"Unknown candidate_selector strategy: {candidate_selection_strategy}. "
-                "Supported strategies: 'pareto', 'current_best', 'epsilon_greedy', 'top_k_pareto', 'batch_lexicase', 'unpruned_pareto'"
+                "Supported strategies: 'pareto', 'current_best', 'epsilon_greedy', 'top_k_pareto', 'batch_lexicase', 'unpruned_pareto', 'latest'"
             ) from exc
     elif isinstance(candidate_selection_strategy, CandidateSelector):
         candidate_selector = candidate_selection_strategy

--- a/src/gepa/gepa_launcher.py
+++ b/src/gepa/gepa_launcher.py
@@ -144,7 +144,12 @@ from gepa.proposer.merge import MergeProposer
 from gepa.proposer.reflective_mutation.base import CandidateSelector, LanguageModel, ReflectionComponentSelector
 from gepa.proposer.reflective_mutation.reflection_lm import ReflectionLM
 from gepa.proposer.reflective_mutation.reflective_mutation import ReflectiveMutationProposer
-from gepa.strategies.acceptance import AcceptanceCriterion, ImprovementOrEqualAcceptance, StrictImprovementAcceptance
+from gepa.strategies.acceptance import (
+    AcceptanceCriterion,
+    AlwaysAcceptance,
+    ImprovementOrEqualAcceptance,
+    StrictImprovementAcceptance,
+)
 from gepa.strategies.batch_sampler import BatchSampler, EpochShuffledBatchSampler
 from gepa.strategies.candidate_selector import (
     BatchLexicaseCandidateSelector,
@@ -504,7 +509,7 @@ class EngineConfig:
     frontier_type: FrontierType = "hybrid"
 
     # Acceptance criterion for reflective mutation proposals
-    acceptance_criterion: AcceptanceCriterion | Literal["strict_improvement", "improvement_or_equal"] = (
+    acceptance_criterion: AcceptanceCriterion | Literal["strict_improvement", "improvement_or_equal", "always"] = (
         "strict_improvement"
     )
 
@@ -1568,13 +1573,14 @@ def optimize_anything(
         acceptance_factories: dict[str, type[AcceptanceCriterion]] = {
             "strict_improvement": StrictImprovementAcceptance,
             "improvement_or_equal": ImprovementOrEqualAcceptance,
+            "always": AlwaysAcceptance,
         }
         try:
             acceptance_criterion_instance = acceptance_factories[config.engine.acceptance_criterion]()
         except KeyError as exc:
             raise ValueError(
                 f"Unknown acceptance_criterion: {config.engine.acceptance_criterion}. "
-                "Supported strategies: 'strict_improvement', 'improvement_or_equal'"
+                "Supported strategies: 'strict_improvement', 'improvement_or_equal', 'always'"
             ) from exc
     elif isinstance(config.engine.acceptance_criterion, AcceptanceCriterion):
         acceptance_criterion_instance = config.engine.acceptance_criterion

--- a/src/gepa/gepa_launcher.py
+++ b/src/gepa/gepa_launcher.py
@@ -147,10 +147,12 @@ from gepa.proposer.reflective_mutation.reflective_mutation import ReflectiveMuta
 from gepa.strategies.acceptance import AcceptanceCriterion, ImprovementOrEqualAcceptance, StrictImprovementAcceptance
 from gepa.strategies.batch_sampler import BatchSampler, EpochShuffledBatchSampler
 from gepa.strategies.candidate_selector import (
+    BatchLexicaseCandidateSelector,
     CurrentBestCandidateSelector,
     EpsilonGreedyCandidateSelector,
     ParetoCandidateSelector,
     TopKParetoCandidateSelector,
+    UnprunedParetoCandidateSelector,
 )
 from gepa.strategies.component_selector import (
     AllReflectionComponentSelector,
@@ -493,7 +495,8 @@ class EngineConfig:
     # Strategy selection for the engine
     val_evaluation_policy: EvaluationPolicy | Literal["full_eval"] = "full_eval"
     candidate_selection_strategy: (
-        CandidateSelector | Literal["pareto", "current_best", "epsilon_greedy", "top_k_pareto"]
+        CandidateSelector
+        | Literal["pareto", "current_best", "epsilon_greedy", "top_k_pareto", "batch_lexicase", "unpruned_pareto"]
     ) = "pareto"
     frontier_type: FrontierType = "hybrid"
 
@@ -1529,6 +1532,8 @@ def optimize_anything(
             "current_best": lambda: CurrentBestCandidateSelector(),
             "epsilon_greedy": lambda: EpsilonGreedyCandidateSelector(epsilon=0.1, rng=rng),
             "top_k_pareto": lambda: TopKParetoCandidateSelector(k=5, rng=rng),
+            "batch_lexicase": lambda: BatchLexicaseCandidateSelector(rng=rng),
+            "unpruned_pareto": lambda: UnprunedParetoCandidateSelector(rng=rng),
         }
 
         try:
@@ -1536,7 +1541,7 @@ def optimize_anything(
         except KeyError as exc:
             raise ValueError(
                 f"Unknown candidate_selector strategy: {config.engine.candidate_selection_strategy}. "
-                "Supported strategies: 'pareto', 'current_best', 'epsilon_greedy', 'top_k_pareto'"
+                "Supported strategies: 'pareto', 'current_best', 'epsilon_greedy', 'top_k_pareto', 'batch_lexicase', 'unpruned_pareto'"
             ) from exc
     elif isinstance(config.engine.candidate_selection_strategy, CandidateSelector):
         candidate_selector = config.engine.candidate_selection_strategy

--- a/src/gepa/gepa_launcher.py
+++ b/src/gepa/gepa_launcher.py
@@ -150,6 +150,7 @@ from gepa.strategies.candidate_selector import (
     BatchLexicaseCandidateSelector,
     CurrentBestCandidateSelector,
     EpsilonGreedyCandidateSelector,
+    LatestCandidateSelector,
     ParetoCandidateSelector,
     TopKParetoCandidateSelector,
     UnprunedParetoCandidateSelector,
@@ -496,7 +497,9 @@ class EngineConfig:
     val_evaluation_policy: EvaluationPolicy | Literal["full_eval"] = "full_eval"
     candidate_selection_strategy: (
         CandidateSelector
-        | Literal["pareto", "current_best", "epsilon_greedy", "top_k_pareto", "batch_lexicase", "unpruned_pareto"]
+        | Literal[
+            "pareto", "current_best", "epsilon_greedy", "top_k_pareto", "batch_lexicase", "unpruned_pareto", "latest"
+        ]
     ) = "pareto"
     frontier_type: FrontierType = "hybrid"
 
@@ -1534,6 +1537,7 @@ def optimize_anything(
             "top_k_pareto": lambda: TopKParetoCandidateSelector(k=5, rng=rng),
             "batch_lexicase": lambda: BatchLexicaseCandidateSelector(rng=rng),
             "unpruned_pareto": lambda: UnprunedParetoCandidateSelector(rng=rng),
+            "latest": lambda: LatestCandidateSelector(),
         }
 
         try:
@@ -1541,7 +1545,7 @@ def optimize_anything(
         except KeyError as exc:
             raise ValueError(
                 f"Unknown candidate_selector strategy: {config.engine.candidate_selection_strategy}. "
-                "Supported strategies: 'pareto', 'current_best', 'epsilon_greedy', 'top_k_pareto', 'batch_lexicase', 'unpruned_pareto'"
+                "Supported strategies: 'pareto', 'current_best', 'epsilon_greedy', 'top_k_pareto', 'batch_lexicase', 'unpruned_pareto', 'latest'"
             ) from exc
     elif isinstance(config.engine.candidate_selection_strategy, CandidateSelector):
         candidate_selector = config.engine.candidate_selection_strategy

--- a/src/gepa/strategies/acceptance.py
+++ b/src/gepa/strategies/acceptance.py
@@ -64,3 +64,16 @@ class ImprovementOrEqualAcceptance:
         old_sum = sum(proposal.subsample_scores_before or [])
         new_sum = sum(proposal.subsample_scores_after or [])
         return new_sum >= old_sum
+
+
+class AlwaysAcceptance:
+    """Accept every proposal unconditionally.
+
+    Removes selection pressure at the acceptance step entirely; the search
+    becomes a walk directed only by the proposer. Useful as an ablation
+    control for measuring how much of GEPA's progress comes from the
+    acceptance gate versus the reflective proposals themselves.
+    """
+
+    def should_accept(self, proposal: CandidateProposal, state: GEPAState) -> bool:
+        return True

--- a/src/gepa/strategies/candidate_selector.py
+++ b/src/gepa/strategies/candidate_selector.py
@@ -50,6 +50,77 @@ class EpsilonGreedyCandidateSelector(CandidateSelector):
             return idxmax(state.program_full_scores_val_set)
 
 
+class BatchLexicaseCandidateSelector(CandidateSelector):
+    """Batch lexicase selection over per-instance validation scores.
+
+    Shuffles the validation instances, groups them into batches of `batch_size`, and
+    filters the candidate pool batch by batch, keeping only candidates with the maximal
+    batch score sum, until a single candidate survives (remaining ties are broken
+    uniformly). Only instances scored for every candidate participate.
+
+    Every candidate can win under some batch ordering, so no candidate is ever assigned
+    zero selection probability. This differs from Pareto-frontier sampling, whose dominance
+    pruning can exclude the highest-aggregate candidates entirely when per-instance tie sets
+    are large (e.g. binary metrics). `batch_size` tunes selection pressure: 1 recovers plain
+    lexicase selection (Helmuth, Spector & Matheson, 2015); a batch spanning the whole
+    valset recovers argmax by aggregate score. Batching follows Aenugu & Spector (2019).
+    """
+
+    def __init__(self, batch_size: int = 8, rng: random.Random | None = None):
+        assert batch_size > 0
+        self.batch_size = batch_size
+        if rng is None:
+            self.rng = random.Random(0)
+        else:
+            self.rng = rng
+
+    def select_candidate_idx(self, state: GEPAState) -> int:
+        subscores = state.prog_candidate_val_subscores
+        assert len(subscores) == len(state.program_candidates)
+        num_candidates = len(subscores)
+        if num_candidates == 1:
+            return 0
+
+        common_ids = set(subscores[0].keys())
+        for candidate_scores in subscores[1:]:
+            common_ids &= candidate_scores.keys()
+        if not common_ids:
+            return self.rng.randrange(num_candidates)
+
+        # Sort before shuffling so selection depends only on the rng seed, not set iteration order.
+        instance_ids = sorted(common_ids, key=repr)
+        self.rng.shuffle(instance_ids)
+
+        survivors = list(range(num_candidates))
+        for start in range(0, len(instance_ids), self.batch_size):
+            batch = instance_ids[start : start + self.batch_size]
+            batch_scores = [sum(subscores[idx][i] for i in batch) for idx in survivors]
+            best = max(batch_scores)
+            survivors = [idx for idx, score in zip(survivors, batch_scores, strict=False) if score >= best - 1e-9]
+            if len(survivors) == 1:
+                return survivors[0]
+        return self.rng.choice(survivors)
+
+
+class UnprunedParetoCandidateSelector(CandidateSelector):
+    """Samples proportional to per-instance Pareto-front membership, skipping the
+    dominance-pruning step of `ParetoCandidateSelector`. Serves as an ablation control
+    for isolating the effect of dominance pruning on parent selection.
+    """
+
+    def __init__(self, rng: random.Random | None = None):
+        if rng is None:
+            self.rng = random.Random(0)
+        else:
+            self.rng = rng
+
+    def select_candidate_idx(self, state: GEPAState) -> int:
+        assert len(state.program_full_scores_val_set) == len(state.program_candidates)
+        sampling_list = [prog_idx for front in state.get_pareto_front_mapping().values() for prog_idx in front]
+        assert len(sampling_list) > 0
+        return self.rng.choice(sampling_list)
+
+
 class TopKParetoCandidateSelector(CandidateSelector):
     """Pareto selection restricted to the top K programs by aggregate score."""
 

--- a/src/gepa/strategies/candidate_selector.py
+++ b/src/gepa/strategies/candidate_selector.py
@@ -102,6 +102,18 @@ class BatchLexicaseCandidateSelector(CandidateSelector):
         return self.rng.choice(survivors)
 
 
+class LatestCandidateSelector(CandidateSelector):
+    """Always selects the most recently accepted candidate, growing a single
+    sequential chain: depth equals the number of accepts. With GEPA's
+    minibatch acceptance gate this is a greedy incumbent loop; useful for
+    isolating sequential-depth effects from pool selection.
+    """
+
+    def select_candidate_idx(self, state: GEPAState) -> int:
+        assert len(state.program_full_scores_val_set) == len(state.program_candidates)
+        return len(state.program_candidates) - 1
+
+
 class UnprunedParetoCandidateSelector(CandidateSelector):
     """Samples proportional to per-instance Pareto-front membership, skipping the
     dominance-pruning step of `ParetoCandidateSelector`. Serves as an ablation control

--- a/tests/test_candidate_selector.py
+++ b/tests/test_candidate_selector.py
@@ -297,3 +297,15 @@ class TestLatestCandidateSelector:
         mock_state.num_metric_calls_by_discovery.append(0)
         mock_state.iteration_ids_by_candidate_idx.append("3")
         assert selector.select_candidate_idx(mock_state) == 3
+
+
+class TestAlwaysAcceptance:
+    def test_accepts_everything(self):
+        from gepa.strategies.acceptance import AlwaysAcceptance
+
+        class FakeProposal:
+            def __init__(self):
+                self.subsample_scores_before = [1.0, 1.0, 1.0]
+                self.subsample_scores_after = [0.0, 0.0, 0.0]
+
+        assert AlwaysAcceptance().should_accept(FakeProposal(), state=None) is True

--- a/tests/test_candidate_selector.py
+++ b/tests/test_candidate_selector.py
@@ -280,3 +280,20 @@ class TestUnprunedParetoCandidateSelector:
         results1 = [selector1.select_candidate_idx(mock_state) for _ in range(10)]
         results2 = [selector2.select_candidate_idx(mock_state) for _ in range(10)]
         assert results1 == results2
+
+
+class TestLatestCandidateSelector:
+    def test_selects_newest_candidate(self, mock_state):
+        from gepa.strategies.candidate_selector import LatestCandidateSelector
+
+        selector = LatestCandidateSelector()
+        assert selector.select_candidate_idx(mock_state) == 2
+
+        mock_state.program_candidates.append({"system_prompt": "test4"})
+        mock_state.prog_candidate_val_subscores.append({0: 0.1, 1: 0.1, 2: 0.1})
+        mock_state.prog_candidate_objective_scores.append({})
+        mock_state.parent_program_for_candidate.append([2])
+        mock_state.named_predictor_id_to_update_next_for_program_candidate.append(0)
+        mock_state.num_metric_calls_by_discovery.append(0)
+        mock_state.iteration_ids_by_candidate_idx.append("3")
+        assert selector.select_candidate_idx(mock_state) == 3

--- a/tests/test_candidate_selector.py
+++ b/tests/test_candidate_selector.py
@@ -7,9 +7,11 @@ import pytest
 
 from gepa.core.state import GEPAState, ValsetEvaluation
 from gepa.strategies.candidate_selector import (
+    BatchLexicaseCandidateSelector,
     CurrentBestCandidateSelector,
     EpsilonGreedyCandidateSelector,
     ParetoCandidateSelector,
+    UnprunedParetoCandidateSelector,
 )
 
 
@@ -178,3 +180,103 @@ class TestEpsilonGreedyCandidateSelector:
 
         # With epsilon=0.01, expect ~99% to be best
         assert best_count >= 90
+
+
+@pytest.fixture
+def dominated_champion_state():
+    """State reproducing the binary-metric pathology: candidate 3 has the best
+    aggregate score, but every instance it wins is shared with an irremovable
+    sole-solver specialist, so dominance pruning excludes it from Pareto sampling."""
+    seed_candidate = {"system_prompt": "seed"}
+    base_valset_eval_output = ValsetEvaluation(
+        outputs_by_val_id=dict.fromkeys(range(6), "o"),
+        scores_by_val_id=dict.fromkeys(range(6), 0.0),
+        objective_scores_by_val_id=None,
+    )
+    state = GEPAState(seed_candidate, base_valset_eval_output, track_best_outputs=False)
+
+    # specialist A uniquely solves instance 0, specialist B uniquely solves instance 1:
+    # both are unremovable. The champion solves the most instances (2..5), each shared
+    # with one of the specialists, so it holds no unique slot.
+    subscores = [
+        {0: 1.0, 1: 0.0, 2: 1.0, 3: 0.0, 4: 1.0, 5: 0.0},  # specialist A
+        {0: 0.0, 1: 1.0, 2: 0.0, 3: 1.0, 4: 0.0, 5: 1.0},  # specialist B
+        {0: 0.0, 1: 0.0, 2: 1.0, 3: 1.0, 4: 1.0, 5: 1.0},  # champion
+    ]
+    for i, scores in enumerate(subscores, start=1):
+        state.program_candidates.append({"system_prompt": f"cand{i}"})
+        state.prog_candidate_val_subscores.append(scores)
+        state.prog_candidate_objective_scores.append({})
+        state.parent_program_for_candidate.append([0])
+        state.named_predictor_id_to_update_next_for_program_candidate.append(0)
+        state.num_metric_calls_by_discovery.append(0)
+        state.iteration_ids_by_candidate_idx.append(str(i))
+
+    state.pareto_front_valset = dict.fromkeys(range(6), 1.0)
+    state.program_at_pareto_front_valset = {
+        0: {1},
+        1: {2},
+        2: {1, 3},
+        3: {2, 3},
+        4: {1, 3},
+        5: {2, 3},
+    }
+    assert state.is_consistent()
+    return state
+
+
+class TestBatchLexicaseCandidateSelector:
+    def test_selects_valid_indices(self, mock_state):
+        selector = BatchLexicaseCandidateSelector(batch_size=2, rng=random.Random(42))
+        for _ in range(20):
+            idx = selector.select_candidate_idx(mock_state)
+            assert 0 <= idx < len(mock_state.program_candidates)
+
+    def test_full_batch_recovers_argmax_aggregate(self, mock_state):
+        """A batch spanning the whole valset degenerates to argmax by aggregate score."""
+        selector = BatchLexicaseCandidateSelector(batch_size=3, rng=random.Random(42))
+        results = [selector.select_candidate_idx(mock_state) for _ in range(20)]
+        assert all(r == 2 for r in results)
+
+    def test_seeding_produces_deterministic_sequence(self, mock_state):
+        selector1 = BatchLexicaseCandidateSelector(batch_size=2, rng=random.Random(42))
+        selector2 = BatchLexicaseCandidateSelector(batch_size=2, rng=random.Random(42))
+        results1 = [selector1.select_candidate_idx(mock_state) for _ in range(10)]
+        results2 = [selector2.select_candidate_idx(mock_state) for _ in range(10)]
+        assert results1 == results2
+
+    def test_batch_size_one_is_plain_lexicase(self, mock_state):
+        selector = BatchLexicaseCandidateSelector(batch_size=1, rng=random.Random(42))
+        for _ in range(10):
+            assert 0 <= selector.select_candidate_idx(mock_state) < 3
+
+    def test_invalid_batch_size_raises_assertion(self):
+        with pytest.raises(AssertionError):
+            BatchLexicaseCandidateSelector(batch_size=0)
+
+    def test_dominated_champion_keeps_selection_mass(self, dominated_champion_state):
+        """The best-aggregate candidate is excluded by Pareto dominance pruning but
+        must remain selectable under batch lexicase."""
+        pareto = ParetoCandidateSelector(random.Random(42))
+        pareto_samples = {pareto.select_candidate_idx(dominated_champion_state) for _ in range(200)}
+        assert 3 not in pareto_samples  # documents the pathology being fixed
+
+        lexicase = BatchLexicaseCandidateSelector(batch_size=2, rng=random.Random(42))
+        lexicase_samples = [lexicase.select_candidate_idx(dominated_champion_state) for _ in range(200)]
+        champion_share = sum(1 for s in lexicase_samples if s == 3) / len(lexicase_samples)
+        assert champion_share > 0.5
+
+
+class TestUnprunedParetoCandidateSelector:
+    def test_samples_all_front_members(self, dominated_champion_state):
+        """Every front member, including the dominance-pruned champion, gets mass."""
+        selector = UnprunedParetoCandidateSelector(rng=random.Random(42))
+        samples = {selector.select_candidate_idx(dominated_champion_state) for _ in range(300)}
+        assert 3 in samples
+
+    def test_seeding_produces_deterministic_sequence(self, mock_state):
+        selector1 = UnprunedParetoCandidateSelector(rng=random.Random(42))
+        selector2 = UnprunedParetoCandidateSelector(rng=random.Random(42))
+        results1 = [selector1.select_candidate_idx(mock_state) for _ in range(10)]
+        results2 = [selector2.select_candidate_idx(mock_state) for _ in range(10)]
+        assert results1 == results2


### PR DESCRIPTION
## Motivation

On binary metrics with large candidate pools, `ParetoCandidateSelector`'s dominance-pruning step (`remove_dominated_programs`) can assign **zero selection probability to the highest-aggregate candidates**:

- A sole solver of any instance is unremovable, regardless of quality: its front contains no other candidate, so `is_dominated` can never return true for it. With single-rollout evaluation, sole-solver slots are frequently minted by noise.
- A broadly strong candidate typically holds no unique slot (everything it solves, someone else also solves), so it gets pruned as "redundant" and receives zero mass.

Replaying the deployed sampler on nine 15,000-metric-call LiveBench-Math optimization runs (~126-candidate pools, binary scoring): the best-val candidate received exactly zero selection mass in five of nine runs, and lineage analysis showed the resulting search trees grow as stars around a static set of early sole-solver hubs (69-75% of accepted candidates never breed) with max depth at or below what uniform random parent attachment would produce. On a continuous-metric task (deterministic simulator scores, mostly singleton fronts), the same code behaves well: champions keep 2-3x uniform mass. The pathology is specific to large tie sets, consistent with dominance resistance in many-objective optimization (Purshouse & Fleming 2007).

This does not contradict the GEPA paper's Table 3 ablation (Pareto sampling >> SelectBestCandidate): those experiments ran 1.8k-7k rollouts, where pools are small and unique slots are meaningful. The failure emerges at larger pool sizes.

## Changes

- **`BatchLexicaseCandidateSelector(batch_size=8, rng)`** — batch lexicase selection (Helmuth, Spector & Matheson 2015; Aenugu & Spector 2019, whose batched variant targets noisy binary case scores). Validation instances are shuffled and grouped into batches; the pool is filtered batch-by-batch keeping max-batch-score survivors until one remains. Every candidate wins under some ordering, so no candidate is ever excluded outright; `batch_size` tunes selection pressure continuously between plain lexicase (1) and argmax-by-aggregate (whole valset). In counterfactual replays on the nine saved runs, batch lexicase at b=8-16 raised the expected val score of the selected parent in every run while keeping 27-66 effective parents (diversity preserved).
- **`UnprunedParetoCandidateSelector(rng)`** — frontier-frequency sampling with the dominance-pruning step skipped. Ablation control to isolate the pruning step's contribution.
- Both registered as `candidate_selection_strategy` strings (`"batch_lexicase"`, `"unpruned_pareto"`) in `api.py` and `gepa_launcher.py`.
- Regression test reproducing the pathology in miniature: a best-aggregate champion whose every win is shared with an irremovable sole-solver specialist gets zero mass from `ParetoCandidateSelector` across 200 draws and majority mass under batch lexicase.

## Status
