### PR TITLE
fix(windows): type-check platform-specific signal handling

### DIFF
--- a/src/gepa/oa/engines/autoresearch.py
+++ b/src/gepa/oa/engines/autoresearch.py
@@ -165,7 +165,9 @@ def _terminate_claude_process(running: _RunningClaudeProcess) -> tuple[str, str]
         try:
             proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
-            _signal_claude_process(proc, signal.SIGKILL)
+            # SIGKILL is not defined by Windows' signal module. Any value other
+            # than SIGTERM uses the direct `proc.kill()` fallback there.
+            _signal_claude_process(proc, getattr(signal, "SIGKILL", -9))
             proc.wait()
     return _collect_claude_output(running)
 

--- a/src/gepa/utils/code_execution.py
+++ b/src/gepa/utils/code_execution.py
@@ -301,15 +301,15 @@ def _execute_in_process(
 
     # Set up timeout using signal (Unix only)
     old_handler = None
-    has_signal = hasattr(signal, "SIGALRM")
+    alarm_signal = getattr(signal, "SIGALRM", None)
 
-    if timeout > 0 and has_signal:
-        old_handler = signal.signal(signal.SIGALRM, _alarm_handler)
+    if timeout > 0 and alarm_signal is not None:
+        old_handler = signal.signal(alarm_signal, _alarm_handler)
         # Use setitimer for sub-second precision if available
         try:
-            signal.setitimer(signal.ITIMER_REAL, timeout)
+            signal.setitimer(signal.ITIMER_REAL, timeout)  # pyright: ignore[reportAttributeAccessIssue]
         except AttributeError:
-            signal.alarm(int(timeout))
+            signal.alarm(int(timeout))  # pyright: ignore[reportAttributeAccessIssue]
 
     try:
         with redirect_stdout(stdout_capture), redirect_stderr(stderr_capture):
@@ -333,13 +333,13 @@ def _execute_in_process(
         success = False
     finally:
         # Disable timeout
-        if timeout > 0 and has_signal:
+        if timeout > 0 and alarm_signal is not None:
             try:
-                signal.setitimer(signal.ITIMER_REAL, 0)
+                signal.setitimer(signal.ITIMER_REAL, 0)  # pyright: ignore[reportAttributeAccessIssue]
             except AttributeError:
-                signal.alarm(0)
+                signal.alarm(0)  # pyright: ignore[reportAttributeAccessIssue]
             if old_handler is not None:
-                signal.signal(signal.SIGALRM, old_handler)
+                signal.signal(alarm_signal, old_handler)
 
         # Double-check: if we've exceeded timeout but no exception was raised, kill children
         elapsed = time.time() - start_time

--- a/tests/test_optimize_anything_autoresearch_engine.py
+++ b/tests/test_optimize_anything_autoresearch_engine.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import time
 from collections.abc import Callable
+from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
@@ -12,7 +13,7 @@ import pytest
 
 from gepa.oa.budget import BudgetTracker
 from gepa.oa.config import OptimizeAnythingConfig
-from gepa.oa.engines.autoresearch import AutoResearchEngine
+from gepa.oa.engines.autoresearch import AutoResearchEngine, _RunningClaudeProcess, _terminate_claude_process
 from gepa.oa.task import Task
 
 
@@ -195,6 +196,34 @@ def test_autoresearch_budget_watchdog_preserves_reason_string(tmp_path: Path, mo
         completed = _run_once(engine, tmp_path, budget)
 
     assert "BUDGET_EXHAUSTED" in completed.stderr
+
+
+def test_autoresearch_kills_unresponsive_process_without_sigkill_on_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _UnresponsiveFakePopen(_FakePopen):
+        def __init__(self) -> None:
+            super().__init__(-9, "")
+            self.terminate_calls = 0
+            self.kill_calls = 0
+
+        def terminate(self) -> None:
+            self.terminate_calls += 1
+
+        def wait(self, timeout: float | None = None) -> int:
+            if self.kill_calls == 0:
+                raise subprocess.TimeoutExpired("claude", timeout)
+            return self.returncode
+
+        def kill(self) -> None:
+            self.kill_calls += 1
+
+    fake = _UnresponsiveFakePopen()
+    monkeypatch.setattr("gepa.oa.engines.autoresearch.os.name", "nt")
+    monkeypatch.delattr("gepa.oa.engines.autoresearch.signal.SIGKILL", raising=False)
+
+    _terminate_claude_process(_RunningClaudeProcess(fake, StringIO(), StringIO()))
+
+    assert fake.terminate_calls == 1
+    assert fake.kill_calls == 1
 
 
 def test_autoresearch_uses_direct_process_fallback_on_windows(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Fix Windows compatibility in GEPA’s process-timeout handling.

GEPA uses Unix signal APIs to enforce in-process execution timeouts and to stop an unresponsive Claude Code subprocess. Windows does not provide several of these APIs:

- `SIGALRM`
- `setitimer`
- `ITIMER_REAL`
- `alarm`
- `SIGKILL`

Direct references to them caused `uv run pyright src` to fail on Windows. More importantly, when AutoResearch tried to stop an unresponsive subprocess, the cleanup path could fail before it reached the normal `proc.kill()` fallback.

## What changed

- Resolve `SIGALRM` before using the in-process signal timeout mechanism, so the Unix-only code remains guarded on Windows.
- Keep the Pyright platform-specific suppressions limited to the guarded Unix signal calls.
- Use a non-`SIGTERM` fallback value when `SIGKILL` is unavailable. This preserves the existing behavior: on Windows, `_signal_claude_process()` uses `proc.kill()` for the forced-stop step.
- Add a regression test that simulates:
  1. Windows platform behavior,
  2. an unavailable `SIGKILL`,
  3. a subprocess that ignores `terminate()`.

  The test verifies that GEPA then calls `kill()`.

## Why this matters

Windows contributors can now run GEPA’s required Pyright check successfully. AutoResearch’s watchdog also reliably terminates an unresponsive Claude Code process on Windows instead of failing while looking up a Unix-only signal constant.

## Validation

```text
uv run ruff check src/gepa/utils/code_execution.py src/gepa/oa/engines/autoresearch.py tests/test_optimize_anything_autoresearch_engine.py
uv run pyright src
uv run pytest tests/test_optimize_anything_autoresearch_engine.py -q