### PR TITLE
fix(reflection): skip a truncated reflection output instead of adopting it as a candidate

### DIFF
--- a/src/gepa/proposer/reflective_mutation/reflection_lm.py
+++ b/src/gepa/proposer/reflective_mutation/reflection_lm.py
@@ -183,6 +183,18 @@ class StatelessReflectionLM:
 
         proposals = [ReflectionProposal(new_texts={}, prompts={}, raw_lm_outputs={}) for _ in jobs]
         for (job_idx, name, prompt, _messages), raw_output in zip(rendered, raw_outputs, strict=True):
+            # A reflection that ran out of generation budget mid-thought has no
+            # instruction to extract, and the extractor would hand its raw
+            # monologue back as the proposal. Leave the component out instead:
+            # the proposer already treats a missing component as "no update"
+            # and keeps the parent text, so nothing unreviewed enters the pool.
+            if InstructionProposalSignature.is_truncated_output(raw_output):
+                self._log(
+                    f"Component '{name}': the reflection output ends inside an unterminated reasoning "
+                    "block, so the generation was truncated and carries no proposal. Skipping. Raise the "
+                    "reflection LM's output budget, or shrink the reflection minibatch, to recover it."
+                )
+                continue
             new_instruction = InstructionProposalSignature.output_extractor(raw_output.strip())["new_instruction"]
             proposals[job_idx].new_texts[name] = new_instruction
             proposals[job_idx].prompts[name] = prompt

--- a/src/gepa/strategies/instruction_proposal.py
+++ b/src/gepa/strategies/instruction_proposal.py
@@ -45,21 +45,33 @@ Provide the new instructions within ``` blocks."""
     def is_truncated_output(cls, lm_out: str) -> bool:
         """Whether ``lm_out`` was cut off before the model finished reasoning.
 
-        A reflection LM that hits its generation budget mid-thought emits an
-        opening reasoning tag it never closes and never reaches the fenced
+        A reflection LM that hits its generation budget mid-thought opens a
+        reasoning block, never closes it, and never reaches the fenced
         instruction, so its monologue arrives at :meth:`output_extractor` with
-        nothing to extract and is returned verbatim. Both halves are required
-        here: an unmatched opening tag, and no fence pair. A well-formed
-        proposal is not withheld because its instruction text happens to
-        mention a reasoning tag, and an output that merely chose not to use a
-        fence is not judged at all, since that salvage path is deliberate.
+        nothing to extract and is returned verbatim. All three parts of that
+        shape are required here: the output BEGINS with an opening reasoning
+        tag, one of the tags it opened is never closed, and there is no fence
+        pair to extract from.
 
-        This cannot detect a monologue truncated so early that no tag was ever
-        opened; it reports what the output itself makes visible.
+        Each part earns its place by the false positive it prevents. Without
+        the fence-pair test, a proposal whose instruction text mentions a
+        reasoning tag would be discarded. Without the "begins with" test, so
+        would an unfenced instruction that merely talks about one, such as
+        "open a <think> block before you answer". The unfenced salvage path is
+        deliberate, so it has to keep working.
+
+        The honest limit: a monologue truncated before any tag was emitted, or
+        one whose tags the provider strips, is indistinguishable from a
+        deliberately unfenced instruction. This reports what the output itself
+        makes visible and does not guess beyond it.
         """
         if cls._has_fence_pair(lm_out):
             return False
-        return any(lm_out.count(f"<{tag}>") > lm_out.count(f"</{tag}>") for tag in cls.reasoning_tags)
+        stripped = lm_out.lstrip()
+        return any(
+            stripped.startswith(f"<{tag}>") and lm_out.count(f"<{tag}>") > lm_out.count(f"</{tag}>")
+            for tag in cls.reasoning_tags
+        )
 
     @classmethod
     def validate_prompt_template(cls, prompt_template: str | None) -> None:

--- a/src/gepa/strategies/instruction_proposal.py
+++ b/src/gepa/strategies/instruction_proposal.py
@@ -31,6 +31,36 @@ Provide the new instructions within ``` blocks."""
     input_keys: ClassVar[list[str]] = ["current_instruction_doc", "dataset_with_feedback", "prompt_template"]
     output_keys: ClassVar[list[str]] = ["new_instruction"]
 
+    #: Reasoning-block tag names whose opening tag must be matched by a closing
+    #: one. Subclass and extend this if your reflection LM wraps its chain of
+    #: thought in a different tag.
+    reasoning_tags: ClassVar[tuple[str, ...]] = ("think",)
+
+    @classmethod
+    def _has_fence_pair(cls, lm_out: str) -> bool:
+        """Whether ``lm_out`` holds an opening and a closing fence to extract between."""
+        return (lm_out.find("```") + 3) < lm_out.rfind("```")
+
+    @classmethod
+    def is_truncated_output(cls, lm_out: str) -> bool:
+        """Whether ``lm_out`` was cut off before the model finished reasoning.
+
+        A reflection LM that hits its generation budget mid-thought emits an
+        opening reasoning tag it never closes and never reaches the fenced
+        instruction, so its monologue arrives at :meth:`output_extractor` with
+        nothing to extract and is returned verbatim. Both halves are required
+        here: an unmatched opening tag, and no fence pair. A well-formed
+        proposal is not withheld because its instruction text happens to
+        mention a reasoning tag, and an output that merely chose not to use a
+        fence is not judged at all, since that salvage path is deliberate.
+
+        This cannot detect a monologue truncated so early that no tag was ever
+        opened; it reports what the output itself makes visible.
+        """
+        if cls._has_fence_pair(lm_out):
+            return False
+        return any(lm_out.count(f"<{tag}>") > lm_out.count(f"</{tag}>") for tag in cls.reasoning_tags)
+
     @classmethod
     def validate_prompt_template(cls, prompt_template: str | None) -> None:
         if prompt_template is None:
@@ -128,8 +158,11 @@ Provide the new instructions within ``` blocks."""
             start = lm_out.find("```") + 3
             end = lm_out.rfind("```")
 
-            # Handle if the first and last backticks are the same or overlap
-            if start >= end:
+            # Handle if the first and last backticks are the same or overlap.
+            # is_truncated_output asks the same question through
+            # _has_fence_pair, so the two cannot disagree about what counts as
+            # an extractable span.
+            if not cls._has_fence_pair(lm_out):
                 # Handle incomplete blocks
                 stripped = lm_out.strip()
                 if stripped.startswith("```"):

--- a/tests/test_instruction_proposal.py
+++ b/tests/test_instruction_proposal.py
@@ -137,6 +137,11 @@ class TestTruncatedOutputDetection:
             # An unclosed reasoning block that still reached a fenced
             # instruction: the extractor takes the fence, so nothing is lost.
             "<think>\nStill thinking\n```\nAn instruction\n```",
+            # An UNFENCED instruction that mentions the tag mid-text. The salvage path is meant to keep this,
+            # and a truncated monologue is not what it looks like: this output does not begin inside a
+            # reasoning block, it talks about one.
+            "Answer concisely. Open a <think> block before you answer, then give the final line.",
+            "Do not emit <think> tags in your output.",
         ],
     )
     def test_well_formed_output_is_not_truncated(self, lm_out):

--- a/tests/test_instruction_proposal.py
+++ b/tests/test_instruction_proposal.py
@@ -100,3 +100,52 @@ I hope you didn't get confused.
         """Test extraction of instructions from various code block formats."""
         result = InstructionProposalSignature.output_extractor(lm_output)
         assert result["new_instruction"] == expected_instruction
+
+
+class TestTruncatedOutputDetection:
+    """A reflection LM cut off mid-thought carries no proposal (#390)."""
+
+    @pytest.mark.parametrize(
+        "lm_out",
+        [
+            # The shape reported in #390: the budget ran out mid-monologue, so
+            # neither the reasoning block nor a fence was ever closed.
+            "<think>\nOkay, let me try to figure out how to improve the parameter",
+            # More opens than closes: one thought was left hanging.
+            "<think>done</think>\n<think>and then it stopped",
+        ],
+    )
+    def test_unterminated_reasoning_block_is_truncated(self, lm_out):
+        assert InstructionProposalSignature.is_truncated_output(lm_out)
+
+    @pytest.mark.parametrize(
+        "lm_out",
+        [
+            # A complete reasoning block followed by a fenced instruction.
+            "<think>\nI reasoned.\n</think>\n```\nThe new instruction\n```",
+            # No reasoning block at all, fenced.
+            "Here it is:\n```\nThe new instruction\n```",
+            # No fence either. The extractor salvages this deliberately, so it
+            # must not be reclassified as truncated by this predicate.
+            "Here are the instructions.",
+            # An unterminated fence is likewise left to the extractor.
+            "```text\nHere are the instructions.",
+            # The instruction may legitimately talk about the tag, in either
+            # direction: a fenced proposal is extractable whatever its text says.
+            "```\nNever emit a </think> tag.\n```",
+            "```\nAlways open a <think> block before answering.\n```",
+            # An unclosed reasoning block that still reached a fenced
+            # instruction: the extractor takes the fence, so nothing is lost.
+            "<think>\nStill thinking\n```\nAn instruction\n```",
+        ],
+    )
+    def test_well_formed_output_is_not_truncated(self, lm_out):
+        assert not InstructionProposalSignature.is_truncated_output(lm_out)
+
+    def test_reasoning_tags_are_extensible_by_subclass(self):
+        class QwenLikeSignature(InstructionProposalSignature):
+            reasoning_tags = ("think", "reasoning")
+
+        cut_off = "<reasoning>\nHalf a thought"
+        assert QwenLikeSignature.is_truncated_output(cut_off)
+        assert not InstructionProposalSignature.is_truncated_output(cut_off)

--- a/tests/test_reflection_lm.py
+++ b/tests/test_reflection_lm.py
@@ -598,3 +598,66 @@ def test_max_reflection_cost_with_costless_strategy_raises():
             max_reflection_cost=5.0,
             max_metric_calls=10,
         )
+
+
+# ---------------------------------------------------------------------------
+# A truncated reflection output must not become a candidate (#390)
+# ---------------------------------------------------------------------------
+
+
+class TruncatedLM:
+    """A fake reflection LM whose generation budget ran out mid-thought."""
+
+    def __init__(self):
+        self.calls: list = []
+
+    def __call__(self, prompt):
+        self.calls.append(prompt)
+        return "<think>\nOkay, let me try to figure out how to improve the parameter value based on"
+
+
+def test_reflect_skips_a_truncated_reflection_output():
+    fake = TruncatedLM()
+    logger = CollectingLogger()
+    lm = StatelessReflectionLM(fake, logger=logger)
+    candidate = {"a": "old_a"}
+
+    proposal, _ = lm.reflect(candidate, _reflective_dataset(["a"]), ["a"])
+
+    # The monologue is not offered as an instruction, and the component is left
+    # out entirely rather than proposed unchanged.
+    assert proposal.new_texts == {}
+    assert len(fake.calls) == 1
+    assert any("unterminated reasoning" in m for m in logger.messages)
+
+
+def test_reflect_many_skips_only_the_truncated_task():
+    class HalfTruncatedLM(TruncatedLM):
+        def __call__(self, prompt):
+            self.calls.append(prompt)
+            if "old_a" in str(prompt):
+                return "<think>\nran out of room"
+            return "```\nbrand new prompt\n```"
+
+    lm = StatelessReflectionLM(HalfTruncatedLM())
+    jobs = [
+        ({"a": "old_a"}, _reflective_dataset(["a"]), ["a"]),
+        ({"b": "old_b"}, _reflective_dataset(["b"]), ["b"]),
+    ]
+
+    results = lm.reflect_many(jobs)
+
+    assert results[0][0].new_texts == {}
+    assert results[1][0].new_texts == {"b": "brand new prompt"}
+
+
+def test_a_truncated_reflection_produces_no_child_and_burns_no_metric_calls():
+    """The end of the path #390 describes: through the real proposer, a
+    truncated monologue never reaches the candidate pool."""
+    proposer, adapter = _make_propose_harness(StatelessReflectionLM(TruncatedLM()))
+
+    proposals = proposer.propose(_make_state())
+
+    assert proposals == []
+    # Parent stage only: no minibatch evaluation was spent scoring a monologue.
+    assert adapter.batch_evaluate.call_count == 1


### PR DESCRIPTION
Resolves #390.

Handles truncated reflection outputs so unfinished reasoning is no longer passed through as the next instruction. Truncated proposals are now skipped safely, while existing extraction behavior stays unchanged.

Added coverage for truncated, well-formed, and salvage cases, including reflect, reflect_many, and the real proposer flow.

I used Claude Code to make this change: it edited the repository directly and the project's own test suite was run before I sent it. I have reviewed it and can explain it.