### PR TITLE
perf(combee): run single-job map calls as one batched wave

### DIFF
--- a/docs/docs/guides/combee.md
+++ b/docs/docs/guides/combee.md
@@ -150,18 +150,21 @@ event's `metadata`) and experiment trackers (in the
 exposed by delegation to the wrapped LM, so `max_reflection_cost` works as a
 stop condition.
 
-Under multi-proposal sampling strategies
-([parallel proposals](parallel-proposals.md)), ComBEE implements
-`reflect_many`: when the LM provides `batch_complete`, all proposals' Level-1
-calls go out as **one batched wave** and all Level-2 calls as a second. This
+When the LM provides `batch_complete`, ComBEE issues the iteration's Level-1
+map calls as **one batched wave** and the Level-2 reduce calls as a second.
+That includes the default single-proposal path: one job's `k` maps go out
+together, and a singleton reduce uses a plain completion (a wave of one is
+not batched). Under [parallel proposals](parallel-proposals.md), maps from
+all proposals share the first wave and reduces share the second. This
 assumes the LM's calls are **exchangeable** (each reply depends only on its
 own prompt — the standard property of stateless completion APIs). Without
 that capability, ComBEE automatically executes complete jobs in strict #307
 order, preserving sequential results for ordinary and order-dependent
 callables. Set `batch_reflection=False` to request that strict ordering even
 for a batch-capable LM. Failed attempts restore the RNG state and memoize
-already-completed logical calls, so both direct `reflect_many` retries and the
-engine's per-job recovery path preserve results without repurchasing work.
+already-completed logical calls, so both `reflect()` / `reflect_many` retries
+and the engine's per-job recovery path preserve results without
+repurchasing work.
 
 ## Credits
 

--- a/src/gepa/proposer/reflective_mutation/combee.py
+++ b/src/gepa/proposer/reflective_mutation/combee.py
@@ -125,9 +125,9 @@ class ComBEEReflectionLM:
         logger: Optional logger with a ``log(str)`` method. When the strategy
             is passed to a GEPA front door, its configured logger is used when
             this argument is omitted.
-        batch_reflection: When True (default), multi-proposal iterations batch
-            all Level-1 calls into one wave and all Level-2 calls into a
-            second when the underlying LM provides ``batch_complete``. Without
+        batch_reflection: When True (default), iterations batch all Level-1
+            calls into one wave and all Level-2 calls into a second when the
+            underlying LM provides ``batch_complete``. Without
             that capability, it automatically preserves #307's strict
             sequential per-proposal order. Set False to enforce that order
             even for batch-capable, order-dependent callables. The strategy
@@ -459,6 +459,9 @@ class ComBEEReflectionLM:
         if self._active_job_idx is not None:
             return self._reflect(candidate, reflective_dataset, components_to_update, self._active_job_idx)
         if self._attempt is None:
+            if self._batch_reflection and callable(getattr(self.lm, "batch_complete", None)):
+                # Two-wave path: the job's map calls form one batched wave.
+                return self.reflect_many([(candidate, reflective_dataset, components_to_update)])[0]
             return self._reflect(candidate, reflective_dataset, components_to_update, None)
 
         attempt = self._attempt
@@ -542,7 +545,7 @@ class ComBEEReflectionLM:
             batch_complete = getattr(self.lm, "batch_complete", None)
             results = (
                 self._reflect_many_inner(jobs)
-                if self._batch_reflection and callable(batch_complete) and len(jobs) > 1
+                if self._batch_reflection and callable(batch_complete)
                 else self._reflect_many_sequential(jobs)
             )
         except Exception:

--- a/src/gepa/proposer/reflective_mutation/combee.py
+++ b/src/gepa/proposer/reflective_mutation/combee.py
@@ -127,7 +127,8 @@ class ComBEEReflectionLM:
             this argument is omitted.
         batch_reflection: When True (default), iterations batch all Level-1
             calls into one wave and all Level-2 calls into a second when the
-            underlying LM provides ``batch_complete``. Without
+            underlying LM provides ``batch_complete``. A wave of one (the
+            usual singleton reduce) still uses a plain completion. Without
             that capability, it automatically preserves #307's strict
             sequential per-proposal order. Set False to enforce that order
             even for batch-capable, order-dependent callables. The strategy
@@ -451,10 +452,13 @@ class ComBEEReflectionLM:
     ) -> tuple[ReflectionProposal, ComBEEReflectionLM]:
         """Reflect one job.
 
-        Outside a failed ``reflect_many`` attempt this is a plain, uncached
-        call. During the engine's per-job recovery path it replays the matching
-        logical call slots, so completed work is reused without treating equal
-        prompts from different jobs as the same completion.
+        Outside a failed batched attempt this is uncached. With
+        ``batch_reflection=True`` and a batch-capable LM it uses the two-wave
+        path (the job's maps as one wave; a singleton reduce as a plain call).
+        Otherwise it is the sequential #307 pass. During the engine's per-job
+        recovery path it replays the matching logical call slots, so completed
+        work is reused without treating equal prompts from different jobs as
+        the same completion.
         """
         if self._active_job_idx is not None:
             return self._reflect(candidate, reflective_dataset, components_to_update, self._active_job_idx)
@@ -532,10 +536,12 @@ class ComBEEReflectionLM:
     def reflect_many(self, jobs: list[ReflectionJob]) -> list[tuple[ReflectionProposal, ComBEEReflectionLM]]:
         """Reflect all jobs as one failure-atomic attempt.
 
-        With ``batch_reflection=True``, map calls form one wave and reduce calls
-        form another. With ``False``, each job's full map/reduce pass completes
-        before the next one starts, matching #307 call order. Both forms retain
-        a logical-call retry cache and restore the shuffle stream on failure.
+        With ``batch_reflection=True``, map calls form one wave (including a
+        single job's ``k`` maps) and reduce calls form another. A wave of one
+        still uses a plain completion. With ``False``, each job's full
+        map/reduce pass completes before the next one starts, matching #307
+        call order. Both forms retain a logical-call retry cache and restore
+        the shuffle stream on failure.
         """
         batch_fingerprint = self._batch_fingerprint(jobs)
         if self._attempt is None or self._attempt.batch_fingerprint != batch_fingerprint:

--- a/tests/test_combee_reflection_lm.py
+++ b/tests/test_combee_reflection_lm.py
@@ -565,9 +565,11 @@ def test_reflect_many_batches_in_two_waves():
 
 
 def test_reflect_many_one_job_matches_reflect_for_transport_sensitive_lm():
-    """The public BatchReflectionLM API must preserve #307's single-job
-    transport. A batch-capable provider can return different samples through
-    batch_complete than through direct completion."""
+    """reflect() and reflect_many([job]) stay identical for a single job.
+
+    Since single-job map waves were enabled, both route the k map calls through
+    batch_complete (one wave) and the singleton reduce through a plain call;
+    ``batch_reflection=False`` restores #307's fully sequential transport."""
 
     class TransportSensitiveLM:
         def __init__(self):
@@ -592,12 +594,18 @@ def test_reflect_many_one_job_matches_reflect_for_transport_sensitive_lm():
     many = ComBEEReflectionLM(many_lm, rng=random.Random(7))
     many_proposal, _ = many.reflect_many([job])[0]
 
-    assert many_proposal.new_texts == direct_proposal.new_texts == {"comp": "plain-4"}
+    assert many_proposal.new_texts == direct_proposal.new_texts == {"comp": "plain-1"}
+    assert direct_lm.batch_sizes == many_lm.batch_sizes == [3]
+    assert direct_lm.plain_calls == many_lm.plain_calls == 1
+
+    sequential_lm = TransportSensitiveLM()
+    sequential = ComBEEReflectionLM(sequential_lm, rng=random.Random(7), batch_reflection=False)
+    sequential_proposal, _ = sequential.reflect(*job)
+    assert sequential_proposal.new_texts == {"comp": "plain-4"}
+    assert sequential_lm.batch_sizes == []
     assert many_proposal.prompts == direct_proposal.prompts
     assert many_proposal.raw_lm_outputs == direct_proposal.raw_lm_outputs
     assert many_proposal.metadata == direct_proposal.metadata
-    assert many_lm.batch_sizes == []
-    assert many_lm.plain_calls == 4
 
 
 class ContentKeyedLM:
@@ -1457,3 +1465,22 @@ def test_ordered_pxn_retry_is_cost_and_result_transparent():
     for retry_proposal, clean_proposal in zip(retry, clean_results, strict=True):
         assert retry_proposal.new_texts == clean_proposal.new_texts
         assert retry_proposal.prompts == clean_proposal.prompts
+
+
+def test_single_job_reflect_batches_map_wave():
+    """A plain single-proposal reflect() on a batch-capable LM runs its k map
+    calls as one wave and matches sequential mode's outputs and call order."""
+    replies = [f"map{i}" for i in range(3)] + ["reduced"]
+    batched_lm = BatchScriptedLM(replies)
+    combee_batched = ComBEEReflectionLM(batched_lm, rng=random.Random(0))
+    proposal_batched, _ = combee_batched.reflect({"comp": "seed instruction"}, {"comp": RECORDS9}, ["comp"])
+
+    sequential_lm = ScriptedLM(replies)
+    combee_sequential = ComBEEReflectionLM(sequential_lm, rng=random.Random(0), batch_reflection=False)
+    proposal_sequential, _ = combee_sequential.reflect({"comp": "seed instruction"}, {"comp": RECORDS9}, ["comp"])
+
+    # k = floor(sqrt(9)) = 3 maps form exactly one wave; the singleton reduce
+    # goes through the plain-call path, not a wave of one.
+    assert batched_lm.batch_sizes == [3]
+    assert proposal_batched.new_texts == proposal_sequential.new_texts == {"comp": "reduced"}
+    assert batched_lm.prompts == sequential_lm.prompts


### PR DESCRIPTION
## Motivation

ComBEE's parallel scan (arXiv 2604.04247, section 3.1) is premised on the k Level-1 map calls executing concurrently: shard the evidence, process shards in parallel, aggregate hierarchically. The integration realizes that concurrency only **across proposals** (`reflect_many` batches all jobs' maps into one wave), so any single-proposal iteration -- plain single mutation, or chain-style candidate selectors -- issues its k map calls strictly sequentially.

Measured on a live single-lineage run (`reflection_minibatch_size=36`, k=6, claude-sonnet-5 reflector): the 7 reflection calls of one proposal chained end-to-end with zero overlap (wall-clock span exactly equal to summed latencies, 665s), ~11 minutes of reflection per proposal, ~80% of iteration wall-clock. With this change the same proposal costs one map wave (~max single-call latency) plus the reduce -- roughly a 2.5-3x iteration speedup for single-proposal engines at identical token cost.

## Change

- `reflect()`'s plain (non-recovery) path delegates to `reflect_many([job])` whenever `batch_reflection=True` and the LM exposes `batch_complete`.
- `reflect_many` drops its `len(jobs) > 1` gate, so a single job runs through the existing two-wave path. The plan phase already consumes RNG in the same order as sequential reflection, so **outputs are byte-identical**; the singleton reduce still uses the plain-call path (no wave of one).
- `batch_reflection=False` remains the escape hatch preserving #307's fully sequential transport.

## Contract note

`reflect()` / `reflect_many([job])` on a batch-capable LM previously used plain sequential completions for a single job; both now send the maps through `batch_complete`. Providers that return different samples per transport will see different (equally valid) samples. The transport-sensitivity test is updated to pin the new behavior and the escape hatch, and a new test asserts the single-job wave shape and sequential-mode parity.

## Testing

- `pytest tests/test_combee_reflection_lm.py tests/test_reflection_lm.py` (79 passed; includes the new `test_single_job_reflect_batches_map_wave` and the updated transport test)
- `ruff format` clean; `ruff check` clean except a pre-existing `RUF043` on an untouched line (newer-ruff rule)