### PR TITLE
fix: store the candidate a refiner actually evaluated, not the pre-re…

### DIFF
--- a/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
+++ b/src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py
@@ -154,8 +154,7 @@ class BatchEvaluatorWrapper:
                     # Mirror the evaluator path's loudness instead of silently
                     # discarding user diagnostics.
                     raise TypeError(
-                        f"batch_evaluator result {idx}: side_info must be a dict or None, "
-                        f"got {type(si_raw).__name__}"
+                        f"batch_evaluator result {idx}: side_info must be a dict or None, got {type(si_raw).__name__}"
                     )
                 # Defensive copy (mirror of EvaluatorWrapper): the user may
                 # retain and mutate their dict; the cache, best-evals history,
@@ -397,6 +396,10 @@ class OptimizeAnythingAdapter(GEPAAdapter):
         side_infos: list[SideInfo] = [info for _, _, info in eval_output]
         # outputs = list of (score, best_candidate, side_info) tuples
         outputs = [out for _, out, _ in eval_output]
+        # The refiner may have swapped in a different candidate than the one
+        # passed in; surface it so callers can store the candidate that
+        # actually produced this score, instead of assuming it's `candidate`.
+        evaluated_candidates = [best_candidate for _, best_candidate, _ in outputs]
         objective_scores = [self._extract_objective_scores(candidate, si) for si in side_infos]
 
         # Count actual evaluator invocations from the attempt history recorded
@@ -414,6 +417,7 @@ class OptimizeAnythingAdapter(GEPAAdapter):
             trajectories=side_infos if capture_traces else None,
             objective_scores=objective_scores,
             num_metric_calls=num_metric_calls,
+            evaluated_candidates=evaluated_candidates,
         )
 
     def batch_evaluate(

--- a/src/gepa/core/adapter.py
+++ b/src/gepa/core/adapter.py
@@ -26,6 +26,10 @@ class EvaluationBatch(Generic[Trajectory, RolloutOutput]):
       should be provided and align one-to-one with `outputs` and `scores`.
     - objective_scores: optional per-example maps of objective name -> score. Leave None when
       the evaluator does not expose multi-objective metrics.
+    - evaluated_candidates: optional per-example candidate actually scored, when it differs from
+      the candidate the adapter was given (e.g. a refiner replaced it). Leave None (default) when
+      the evaluated candidate matches the one passed in — this is the common case for every adapter
+      that doesn't do internal refinement.
     """
 
     outputs: list[RolloutOutput]
@@ -33,6 +37,7 @@ class EvaluationBatch(Generic[Trajectory, RolloutOutput]):
     trajectories: list[Trajectory] | None = None
     objective_scores: list[dict[str, float]] | None = None
     num_metric_calls: int | None = None
+    evaluated_candidates: list[Candidate] | None = None
 
 
 class BatchEvaluateFn(Protocol):

--- a/src/gepa/proposer/reflective_mutation/reflective_mutation.py
+++ b/src/gepa/proposer/reflective_mutation/reflective_mutation.py
@@ -685,11 +685,18 @@ class ReflectiveMutationProposer:
 
         # Stage 5: Build proposals and filter
         proposals: list[CandidateProposal] = []
-        for (_, (task, new_candidate, eval_curr, _lm_metadata)), child_eval in zip(
-            valid_children, child_evals, strict=True
+        for idx, ((_, (task, new_candidate, eval_curr, _lm_metadata)), child_eval) in enumerate(
+            zip(valid_children, child_evals, strict=True)
         ):
+            # Prefer the candidate the adapter actually evaluated (e.g. a
+            # refiner-produced replacement) over the pre-evaluation
+            # `new_candidate`, so the stored candidate and its recorded
+            # score refer to the same artifact.
+            evaluated_candidate = (
+                child_eval.evaluated_candidates[idx] if child_eval.evaluated_candidates is not None else None
+            )
             proposal = CandidateProposal(
-                candidate=new_candidate,
+                candidate=evaluated_candidate if evaluated_candidate is not None else new_candidate,
                 parent_program_ids=[task.parent_idx],
                 subsample_indices=task.minibatch_ids,
                 subsample_scores_before=eval_curr.scores,

--- a/tests/test_refiner.py
+++ b/tests/test_refiner.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import pytest
 
 from gepa.gepa_launcher import (
-    DEFAULT_REFINER_PROMPT,
     EngineConfig,
     GEPAConfig,
     RefinerConfig,
@@ -607,6 +606,45 @@ class TestRefiner:
         # Score should equal the original (no refinement improved)
         assert score == -abs(50 - GOLDEN_NUMBER)
 
+    def test_evaluated_candidates_matches_refined_score(self):
+        """Regression test for #440: when a refiner swaps in a better candidate,
+        EvaluationBatch.evaluated_candidates must report that swapped candidate,
+        not the pre-refinement one — so a caller storing (candidate, score) pairs
+        stores an artifact that actually reproduces the recorded score.
+        """
+        from gepa.adapters.optimize_anything_adapter.optimize_anything_adapter import OptimizeAnythingAdapter
+
+        refinements = iter(["FIX1", "FIX2", "FIX3"])
+
+        def fake_refiner_lm(prompt: str) -> str:
+            import json
+
+            return json.dumps({"code": next(refinements)})
+
+        def evaluator(candidate, **kwargs):
+            scores = {"BROKEN": 0.0, "FIX1": 1.0, "FIX2": 2.0, "FIX3": 3.0}
+            code = candidate["code"]
+            side_info = {"error": "cannot run"} if code == "BROKEN" else {"ran": code}
+            return scores[code], None, side_info
+
+        adapter = OptimizeAnythingAdapter(
+            evaluator=evaluator,
+            parallel=False,
+            refiner_config=RefinerConfig(refiner_lm=fake_refiner_lm, max_refinements=3),
+            cache_mode="off",
+        )
+
+        original = {"code": "BROKEN", "refiner_prompt": "repair errors"}
+        batch = adapter.evaluate([None], original)
+
+        assert batch.scores[0] == 3.0
+        assert batch.evaluated_candidates is not None
+        evaluated_candidate = batch.evaluated_candidates[0]
+        # The candidate GEPA would store must be the one that actually earned
+        # the recorded score, not the original "BROKEN" candidate.
+        assert evaluated_candidate["code"] == "FIX3"
+        assert evaluator(evaluated_candidate)[0] == batch.scores[0]
+
 
 class TestRefinerWithDataset:
     """Test refiner with a dataset (per-instance evaluation)."""
@@ -765,7 +803,7 @@ class TestRefinerFrontierTypes:
         assert len(eval_batch.objective_scores) == len(DATASET)
 
         for i, (score, side_info, obj_scores) in enumerate(
-            zip(eval_batch.scores, eval_batch.trajectories, eval_batch.objective_scores)
+            zip(eval_batch.scores, eval_batch.trajectories, eval_batch.objective_scores, strict=False)
         ):
             print(f"\n[{frontier_type}] Example {i} (golden={DATASET[i]['golden']}):")
             print(f"  Score: {score}")


### PR DESCRIPTION
Fixes #440

## Problem
When `RefinerConfig` is enabled, `OptimizeAnythingAdapter` could return a
refined candidate's score while `ReflectiveMutationProposer` still stored
the pre-refinement candidate. The candidate pool ended up holding a
candidate paired with a score it couldn't reproduce.

## Fix
Per the direction confirmed in #440 (option 1):

- Added `EvaluationBatch.evaluated_candidates` (optional, defaults to
  `None`) - adapters can populate this when the candidate they actually
  scored differs from the one they were given. Every adapter that doesn't
  do internal refinement is unaffected.
- `OptimizeAnythingAdapter.evaluate()` now populates it with the winning
  refined candidate when `refiner_config` is set.
- `ReflectiveMutationProposer` now prefers `evaluated_candidates[idx]`
  over the pre-refinement candidate when building each `CandidateProposal`,
  falling back to the original behavior when it's `None`.

## Testing
- Added `test_evaluated_candidates_matches_refined_score` in
  `tests/test_refiner.py`, adapted from the issue's minimal repro —
  asserts the stored candidate reproduces the recorded score after
  refinement.
- `uv run pytest tests/` - all tests pass except 13 pre-existing,
  unrelated Windows-only failures (mlflow URI handling, console unicode
  encoding) present before this change.
- `uv run pyright` and `uv run pre-commit run` both clean on all changed
  files.