### PR TITLE
fix: skip seed valset evaluation when resuming from run_dir

### DIFF
--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -804,15 +804,20 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             ),
         )
 
-        # Evaluate seed candidate on valset (after on_optimization_start callback).
-        # Policies may narrow the seed evaluation via the optional get_seed_eval_batch
-        # hook; the state does not exist yet, so get_eval_batch cannot be used here.
-        seed_batch_fn = getattr(self.val_evaluation_policy, "get_seed_eval_batch", None)
-        seed_val_ids = list(seed_batch_fn(valset)) if seed_batch_fn is not None else list(valset.all_ids())
-        seed_valset_evaluation = valset_evaluator(self.seed_candidate, seed_val_ids)
-
-        # Initialize state with pre-computed seed evaluation
+        # A saved state already holds the seed's valset scores, so a resumed run
+        # skips the seed evaluation instead of spending metric calls on a result
+        # that initialize_gepa_state would discard.
         resumed = self.run_dir is not None and os.path.exists(os.path.join(self.run_dir, "gepa_state.bin"))
+        seed_valset_evaluation: ValsetEvaluation[RolloutOutput, DataId] | None = None
+        if not resumed:
+            # Evaluate seed candidate on valset (after on_optimization_start callback).
+            # Policies may narrow the seed evaluation via the optional get_seed_eval_batch
+            # hook; the state does not exist yet, so get_eval_batch cannot be used here.
+            seed_batch_fn = getattr(self.val_evaluation_policy, "get_seed_eval_batch", None)
+            seed_val_ids = list(seed_batch_fn(valset)) if seed_batch_fn is not None else list(valset.all_ids())
+            seed_valset_evaluation = valset_evaluator(self.seed_candidate, seed_val_ids)
+
+        # Initialize state with pre-computed seed evaluation, or load the saved state on resume
         state = initialize_gepa_state(
             run_dir=self.run_dir,
             logger=self.logger,
@@ -825,7 +830,7 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
         # Fresh runs: record the seed valset eval in the cache. On resume the seed scores already
         # live in state; writing the re-computed seed eval would desynchronize cache from
         # prog_candidate_val_subscores.
-        if not resumed and state.evaluation_cache is not None:
+        if seed_valset_evaluation is not None and state.evaluation_cache is not None:
             seed_ids = list(seed_valset_evaluation.scores_by_val_id)
             seed_obj = (
                 [seed_valset_evaluation.objective_scores_by_val_id[eid] for eid in seed_ids]
@@ -842,8 +847,10 @@ class GEPAEngine(Generic[DataId, DataInst, Trajectory, RolloutOutput]):
             )
 
         # Seed uses the reserved iteration id — outputs/trajectories go under
-        # iterations/seed/ alongside subsequent loop iterations.
-        self._write_agent_iteration_files(SEED_ITERATION_ID, seed_valset_evaluation)
+        # iterations/seed/ alongside subsequent loop iterations. A resumed run
+        # keeps the files written by the original run.
+        if seed_valset_evaluation is not None:
+            self._write_agent_iteration_files(SEED_ITERATION_ID, seed_valset_evaluation)
 
         # Restore adapter state from persisted state (only has effect on resume)
         self._sync_state_to_adapter(state)

--- a/src/gepa/core/state.py
+++ b/src/gepa/core/state.py
@@ -1113,11 +1113,16 @@ def initialize_gepa_state(
     run_dir: str | None,
     logger: LoggerProtocol,
     seed_candidate: dict[str, str],
-    seed_valset_evaluation: ValsetEvaluation[RolloutOutput, DataId],
+    seed_valset_evaluation: ValsetEvaluation[RolloutOutput, DataId] | None,
     track_best_outputs: bool = False,
     frontier_type: FrontierType = "instance",
     evaluation_cache: "EvaluationCache[RolloutOutput, DataId] | None" = None,
 ) -> GEPAState[RolloutOutput, DataId]:
+    """Load the saved state from ``run_dir`` if one exists, otherwise build a fresh state.
+
+    ``seed_valset_evaluation`` is only read on the fresh path. Callers that know the
+    state will be loaded may pass ``None`` and skip evaluating the seed candidate.
+    """
     if run_dir is not None and os.path.exists(os.path.join(run_dir, "gepa_state.bin")):
         logger.log("Loading gepa state from run dir")
         gepa_state = GEPAState.load(run_dir)
@@ -1138,6 +1143,8 @@ def initialize_gepa_state(
             gepa_state.evaluation_cache = evaluation_cache
         # else: keep the loaded cache (gepa_state.evaluation_cache is already set)
     else:
+        if seed_valset_evaluation is None:
+            raise ValueError("seed_valset_evaluation is required when no saved state exists in run_dir")
         if run_dir is not None:
             write_eval_outputs_to_directory(
                 seed_valset_evaluation.outputs_by_val_id,

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -763,3 +763,64 @@ def test_e2e_resume_run(mocked_lms, run_dir):
         run_dir=run_dir,
     )
     assert second_run.total_metric_calls == first_run.total_metric_calls
+
+
+class _CountingAdapter:
+    """Adapter that counts valset evaluations and proposes candidates without an LM."""
+
+    def __init__(self):
+        self.evaluate_calls = 0
+        self.examples_evaluated = 0
+        self.propose_new_texts = self._propose_new_texts
+
+    def evaluate(self, batch, candidate, capture_traces=False):
+        self.evaluate_calls += 1
+        self.examples_evaluated += len(batch)
+        weight = int(candidate["system_prompt"].split("=")[-1])
+        outputs = [{"id": item["id"], "weight": weight} for item in batch]
+        scores = [min(1.0, (weight + 1) / item["difficulty"]) for item in batch]
+        trajectories = [{"score": score} for score in scores] if capture_traces else None
+        return EvaluationBatch(outputs=outputs, scores=scores, trajectories=trajectories)
+
+    def make_reflective_dataset(self, candidate, eval_batch, components_to_update):
+        return {name: [{"score": score} for score in eval_batch.scores] for name in components_to_update}
+
+    def _propose_new_texts(self, candidate, reflective_dataset, components_to_update):
+        weight = int(candidate["system_prompt"].split("=")[-1])
+        return dict.fromkeys(components_to_update, f"weight={weight + 1}")
+
+
+def test_resume_skips_seed_valset_evaluation(run_dir):
+    """Resuming from a saved gepa_state.bin must not re-evaluate the seed candidate on the valset."""
+    trainset = [{"id": i, "difficulty": i + 2} for i in range(3)]
+    valset = [{"id": i, "difficulty": i + 2} for i in range(10)]
+    seed_candidate = {"system_prompt": "weight=0"}
+
+    first_run = gepa.optimize(
+        seed_candidate=seed_candidate,
+        trainset=trainset,
+        valset=valset,
+        adapter=_CountingAdapter(),
+        reflection_lm=None,
+        max_metric_calls=25,
+        run_dir=str(run_dir),
+    )
+    assert (run_dir / "gepa_state.bin").exists()
+    saved_state = state_mod.GEPAState.load(str(run_dir))
+    assert saved_state.total_num_evals == first_run.total_metric_calls
+
+    resume_adapter = _CountingAdapter()
+    second_run = gepa.optimize(
+        seed_candidate=seed_candidate,
+        trainset=trainset,
+        valset=valset,
+        adapter=resume_adapter,
+        reflection_lm=None,
+        max_metric_calls=0,
+        run_dir=str(run_dir),
+    )
+
+    assert resume_adapter.evaluate_calls == 0
+    assert resume_adapter.examples_evaluated == 0
+    assert second_run.total_metric_calls == saved_state.total_num_evals
+    assert second_run.num_full_val_evals == saved_state.num_full_ds_evals


### PR DESCRIPTION
## The bug

When a run resumes from a `run_dir` that already holds `gepa_state.bin`, `GEPAEngine.run` evaluates the seed candidate on the full validation set and then discards the result. The seed evaluation runs before the saved state is checked, and the resume branch of `initialize_gepa_state` never reads `seed_valset_evaluation`. Every resume pays for a full valset evaluation that has no effect. With a 10 example valset and an expensive metric, that is ten wasted metric calls per resume.

## How to see it

Run an optimization with a `run_dir`, then call `gepa.optimize` again with the same `run_dir`. The log shows the adapter evaluating the seed on the full valset and then prints `Loading gepa state from run dir`. An adapter that counts `evaluate` calls records one call over the whole valset during the resume.

## The fix

- `GEPAEngine.run` checks for `gepa_state.bin` before the seed evaluation and skips the evaluation when the saved state will be loaded. The `on_optimization_start` callback still fires in the same place.
- `initialize_gepa_state` accepts `None` for `seed_valset_evaluation` on the resume path. It raises a `ValueError` if `None` is passed and no saved state exists. Callers that pass an evaluation keep working unchanged.
- On resume, the engine no longer rewrites the seed's `iterations/seed/` outputs or the seed cache entry. Both were already skipped or redundant on resume.
- Fresh runs are unchanged. The callback, seed evaluation, cache write, and agent state files happen in the same order as before.

## The test

`test_resume_skips_seed_valset_evaluation` in `tests/test_state.py` runs a small optimization with a `run_dir` using an adapter that counts `evaluate` calls and needs no LM. It then resumes from that `run_dir` with a fresh counting adapter and asserts:

- the adapter's `evaluate` was never called during the resume
- the resumed result's `total_metric_calls` equals the saved state's `total_num_evals`
- the resumed result's `num_full_val_evals` equals the saved state's `num_full_ds_evals`

The test fails on `main` with one evaluate call over 10 examples and passes with this change. The full suite passes (700 passed, 4 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XBgSqxXL22qUyVsXB45XB
